### PR TITLE
fix(web_ui): RAG retrieval grounding & citation accuracy (Issue #22)

### DIFF
--- a/RAG_PIPELINE_FIXES_PLAN.md
+++ b/RAG_PIPELINE_FIXES_PLAN.md
@@ -8,6 +8,15 @@
 
 **Tech Stack:** Python 3.10+, FastAPI, ChromaDB, sentence-transformers, pytest
 
+> **Engine scope note:** This document describes the **Python desktop** RAG
+> engine (`vector_store.py`, `rag_engine.py`), whose keyword retriever is
+> **BM25**. The separate **browser web_ui** RAG pipeline
+> (`web_ui/src/lib/search/keyword-index.ts`) is a *different* engine: it uses
+> **FlexSearch resolution-rank scoring** with `suggest:true` fuzzy matching, not
+> BM25. The two share a hybrid (vector + keyword) shape but have different
+> scoring/tuning characteristics — do not transfer BM25 tuning conclusions to
+> the browser engine (and vice versa).
+
 ---
 
 ## File Structure

--- a/web_ui/src/components/ChatMessageBubble.tsx
+++ b/web_ui/src/components/ChatMessageBubble.tsx
@@ -198,26 +198,71 @@ export const ChatMessageBubble: React.FC<ChatMessageBubbleProps> = React.memo(({
       onMouseLeave={() => setShowCopy(false)}
     >
       <div style={{ width: '100%', padding: 'var(--spacing-md) 0' }}>
-        <div style={{ fontFamily: 'var(--font-family)', lineHeight: 'var(--line-height-body)' }}>
-          <MarkdownRenderer content={message.content} />
-          {message.isStreaming && <span style={cursorStyle} aria-hidden="true" />}
-        </div>
-        <div style={{ ...timeStyle, textAlign: 'left' }}>{formatRelativeTime(message.timestamp)}</div>
-        <div style={{ display: 'flex', gap: 'var(--spacing-sm)', marginTop: 'var(--spacing-sm)' }}>
-          {showCopiedFeedback ? (
-            <span style={copiedFeedbackInlineStyle}>Copied!</span>
-          ) : (
-            <button style={copyButtonInlineStyle} onClick={handleCopy} aria-label="Copy message" type="button">
-              Copy
-            </button>
-          )}
-          {onRegenerate && (
-            <button type="button" onClick={onRegenerate} aria-label="Regenerate response" style={regenerateStyle}>
-              ↻ Regenerate
-            </button>
-          )}
-        </div>
-        {message.sources && message.sources.length > 0 && <SourceCitation sources={message.sources} />}
+        {message.abstain ? (
+          // F2: distinct abstention state. The pipeline deliberately did NOT
+          // answer because it found no usable evidence, so we never show the
+          // model's content or copy/citation actions.
+          <div
+            role="status"
+            aria-live="polite"
+            style={{
+              padding: 'var(--spacing-sm) var(--spacing-md)',
+              borderRadius: '8px',
+              backgroundColor: 'var(--color-bubble-system)',
+              color: 'var(--color-text-muted)',
+              fontStyle: 'italic',
+              fontFamily: 'var(--font-family)',
+            }}
+          >
+            {message.abstainReason === 'retrieval_degraded'
+              ? 'Retrieval is degraded (semantic search unavailable) and no relevant passages were found.'
+              : 'Insufficient evidence in the knowledge base to answer this question.'}
+          </div>
+        ) : (
+          <>
+            <div style={{ fontFamily: 'var(--font-family)', lineHeight: 'var(--line-height-body)' }}>
+              <MarkdownRenderer content={message.content} />
+              {message.isStreaming && <span style={cursorStyle} aria-hidden="true" />}
+            </div>
+            {/* F4: non-blocking indicator when only keyword search was available. */}
+            {message.retrievalDegraded && (
+              <div
+                role="status"
+                aria-live="polite"
+                style={{
+                  marginTop: 'var(--spacing-xs)',
+                  fontSize: 'var(--font-size-caption)',
+                  color: 'var(--color-text-muted)',
+                  fontStyle: 'italic',
+                }}
+              >
+                Retrieval is degraded — semantic search unavailable (showing keyword-only results).
+              </div>
+            )}
+            <div style={{ ...timeStyle, textAlign: 'left' }}>{formatRelativeTime(message.timestamp)}</div>
+            <div style={{ display: 'flex', gap: 'var(--spacing-sm)', marginTop: 'var(--spacing-sm)' }}>
+              {showCopiedFeedback ? (
+                <span style={copiedFeedbackInlineStyle}>Copied!</span>
+              ) : (
+                <button style={copyButtonInlineStyle} onClick={handleCopy} aria-label="Copy message" type="button">
+                  Copy
+                </button>
+              )}
+              {onRegenerate && (
+                <button type="button" onClick={onRegenerate} aria-label="Regenerate response" style={regenerateStyle}>
+                  ↻ Regenerate
+                </button>
+              )}
+            </div>
+            {/* F7: prefer structured numbered citations; fall back to legacy
+                sources string array for older persisted messages. */}
+            {message.citations && message.citations.length > 0 ? (
+              <SourceCitation citations={message.citations} />
+            ) : (
+              message.sources && message.sources.length > 0 && <SourceCitation sources={message.sources} />
+            )}
+          </>
+        )}
       </div>
     </div>
   );

--- a/web_ui/src/components/SourceCitation.test.tsx
+++ b/web_ui/src/components/SourceCitation.test.tsx
@@ -262,4 +262,93 @@ describe('SourceCitation', () => {
       expect(pill).toBeInTheDocument();
     });
   });
+
+  // -------------------------------------------------------------------------
+  // Structured citations (F7): numbered [1] pills with filename/page/click-
+  // through to chunk text. Numbers align with the model's context order.
+  // -------------------------------------------------------------------------
+  describe('structured citations (F7)', () => {
+    it('renders numbered pills [1] [2] aligned to citations array order', () => {
+      render(
+        <SourceCitation
+          citations={[
+            { docId: 'd1', chunkIndex: 0, source: 'alpha.pdf', page: 3, text: 'first chunk' },
+            { docId: 'd2', chunkIndex: 0, source: 'beta.md', page: 7, text: 'second chunk' },
+          ]}
+        />
+      );
+
+      // Numbering matches array index (model's [1] -> citations[0]).
+      expect(screen.getByText('[1]')).toBeInTheDocument();
+      expect(screen.getByText('[2]')).toBeInTheDocument();
+      // Filename (basename) + page suffix render.
+      expect(screen.getByText('alpha.pdf (p. 3)')).toBeInTheDocument();
+      expect(screen.getByText('beta.md (p. 7)')).toBeInTheDocument();
+    });
+
+    it('omits the page suffix when page is not provided', () => {
+      render(
+        <SourceCitation
+          citations={[{ docId: 'd1', chunkIndex: 0, source: 'no-page.txt', text: 't' }]}
+        />
+      );
+      expect(screen.getByText('no-page.txt')).toBeInTheDocument();
+      // No "(p. N)" suffix anywhere.
+      expect(screen.queryByText(/p\./)).toBeNull();
+    });
+
+    it('falls back to docId when source filename is absent', () => {
+      render(
+        <SourceCitation
+          citations={[{ docId: '1700000000-abc', chunkIndex: 0, text: 't' }]}
+        />
+      );
+      expect(screen.getByText('1700000000-abc')).toBeInTheDocument();
+    });
+
+    it('shows a Copy button only when chunk text is present', () => {
+      const { rerender } = render(
+        <SourceCitation
+          citations={[{ docId: 'd1', chunkIndex: 0, source: 'has-text.pdf', text: 'real text' }]}
+        />
+      );
+      expect(screen.getByRole('button', { name: 'Copy source text' })).toBeInTheDocument();
+
+      // No text → no Copy button.
+      rerender(
+        <SourceCitation
+          citations={[{ docId: 'd2', chunkIndex: 0, source: 'no-text.pdf' }]}
+        />
+      );
+      expect(screen.queryByRole('button', { name: 'Copy source text' })).toBeNull();
+    });
+
+    it('expands to show chunk text on click', () => {
+      render(
+        <SourceCitation
+          citations={[{ docId: 'd1', chunkIndex: 0, source: 'x.pdf', page: 1, text: 'the full chunk body' }]}
+        />
+      );
+      // Popover hidden initially.
+      expect(screen.queryByText('the full chunk body')).toBeNull();
+
+      // Click the pill (role=button) to expand.
+      const pill = screen.getByText('[1]').closest('[role="button"]')!;
+      fireEvent.click(pill);
+
+      expect(screen.getByText('the full chunk body')).toBeInTheDocument();
+    });
+
+    it('prefers structured citations over legacy sources when both are provided', () => {
+      render(
+        <SourceCitation
+          sources={['legacy.pdf']}
+          citations={[{ docId: 'd1', chunkIndex: 0, source: 'structured.pdf', text: 't' }]}
+        />
+      );
+      // Structured mode wins: the [1] label appears, legacy filename does not.
+      expect(screen.getByText('[1]')).toBeInTheDocument();
+      expect(screen.queryByText('legacy.pdf')).toBeNull();
+    });
+  });
 });

--- a/web_ui/src/components/SourceCitation.tsx
+++ b/web_ui/src/components/SourceCitation.tsx
@@ -1,12 +1,23 @@
 /**
  * Source citation pills component.
- * Displays source file paths as compact pills with expand and copy functionality.
+ *
+ * Two render modes:
+ *  - Structured (F7): `citations` carries per-chunk metadata (filename, page,
+ *    text). Pills are numbered [1], [2], ... in the SAME order the model was
+ *    shown the context, so a model-emitted "[2]" resolves to citations[1].
+ *    Clicking a pill opens a popover with the chunk's source text.
+ *  - Legacy: `sources` is a string array of paths/IDs (older persisted
+ *    messages). Pills show the basename with copy/expand, as before.
  */
 
 import React, { useState, useCallback, useRef, useEffect } from 'react';
+import type { CitationRef } from '../types/chat';
 
 interface SourceCitationProps {
-  sources: string[];
+  /** Legacy: bare source path/id strings. */
+  sources?: string[];
+  /** Structured per-chunk citations aligned with the model's [1],[2] order. */
+  citations?: CitationRef[];
   onCopySource?: (source: string) => void;
 }
 
@@ -16,9 +27,9 @@ function getBasename(fullPath: string): string {
   return lastSlash >= 0 ? normalized.slice(lastSlash + 1) : fullPath;
 }
 
-export const SourceCitation: React.FC<SourceCitationProps> = React.memo(({ sources, onCopySource }) => {
-  const [expandedSource, setExpandedSource] = useState<string | null>(null);
-  const [copiedSource, setCopiedSource] = useState<string | null>(null);
+export const SourceCitation: React.FC<SourceCitationProps> = React.memo(({ sources, citations, onCopySource }) => {
+  const [expandedKey, setExpandedKey] = useState<string | null>(null);
+  const [copiedKey, setCopiedKey] = useState<string | null>(null);
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
@@ -30,17 +41,17 @@ export const SourceCitation: React.FC<SourceCitationProps> = React.memo(({ sourc
   }, []);
 
   const handleCopy = useCallback(
-    async (source: string, e: React.MouseEvent) => {
+    async (key: string, text: string, e: React.MouseEvent) => {
       e.stopPropagation();
       try {
-        await navigator.clipboard.writeText(source);
-        setCopiedSource(source);
-        onCopySource?.(source);
+        await navigator.clipboard.writeText(text);
+        setCopiedKey(key);
+        onCopySource?.(text);
         if (copyTimerRef.current !== null) {
           clearTimeout(copyTimerRef.current);
         }
         copyTimerRef.current = setTimeout(() => {
-          setCopiedSource((prev) => (prev === source ? null : prev));
+          setCopiedKey((prev) => (prev === key ? null : prev));
           copyTimerRef.current = null;
         }, 1500);
       } catch {
@@ -50,27 +61,134 @@ export const SourceCitation: React.FC<SourceCitationProps> = React.memo(({ sourc
     [onCopySource]
   );
 
-  const handleToggleExpand = useCallback((source: string) => {
-    setExpandedSource((prev) => (prev === source ? null : source));
+  const handleToggleExpand = useCallback((key: string) => {
+    setExpandedKey((prev) => (prev === key ? null : key));
   }, []);
 
+  // ---- Structured citation mode (F7) ----
+  if (citations && citations.length > 0) {
+    return (
+      <div
+        style={{
+          marginTop: 'var(--spacing-sm)',
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: 'var(--spacing-xs)',
+        }}
+      >
+        {citations.map((cite, index) => {
+          const key = `cite-${index}-${cite.docId}-${cite.chunkIndex}`;
+          const label = cite.source ? getBasename(cite.source) : cite.docId;
+          const pageSuffix = typeof cite.page === 'number' ? ` (p. ${cite.page})` : '';
+          const isExpanded = expandedKey === key;
+          const isCopied = copiedKey === key;
+
+          const pillStyle: React.CSSProperties = {
+            backgroundColor: 'var(--color-source-pill-bg)',
+            padding: '2px 6px',
+            borderRadius: '4px',
+            fontSize: 'var(--font-size-small)',
+            color: 'var(--color-text-muted)',
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: '4px',
+            maxWidth: '240px',
+            cursor: 'pointer',
+            position: 'relative',
+          };
+
+          return (
+            <div
+              key={key}
+              role="button"
+              tabIndex={0}
+              aria-label={`Source ${index + 1}: ${label}${pageSuffix}`}
+              style={pillStyle}
+              onClick={() => handleToggleExpand(key)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  handleToggleExpand(key);
+                }
+              }}
+            >
+              <span style={{ fontWeight: 600 }}>[{index + 1}]</span>
+              <span
+                style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                title={`${label}${pageSuffix}`}
+              >
+                {label}
+                {pageSuffix}
+              </span>
+              {cite.text && (
+                <button
+                  style={{
+                    background: 'transparent',
+                    border: 'none',
+                    cursor: 'pointer',
+                    padding: '0',
+                    fontSize: 'var(--font-size-caption)',
+                    color: 'var(--color-text-muted)',
+                    opacity: isCopied ? 0.7 : 0.5,
+                    transition: 'opacity 0.15s ease',
+                    flexShrink: 0,
+                  }}
+                  onClick={(e) => handleCopy(key, cite.text ?? '', e)}
+                  aria-label={isCopied ? 'Copied' : 'Copy source text'}
+                  type="button"
+                >
+                  {isCopied ? '✓' : 'Copy'}
+                </button>
+              )}
+              {isExpanded && cite.text && (
+                <div
+                  style={{
+                    position: 'absolute',
+                    top: '100%',
+                    left: 0,
+                    marginTop: '4px',
+                    backgroundColor: 'var(--color-bubble-assistant)',
+                    color: 'var(--color-text-on-bubble-assistant)',
+                    padding: 'var(--spacing-sm)',
+                    borderRadius: '4px',
+                    fontSize: 'var(--font-size-caption)',
+                    zIndex: 10,
+                    maxWidth: '360px',
+                    whiteSpace: 'normal',
+                    boxShadow: '0 2px 8px rgba(0,0,0,0.2)',
+                    lineHeight: 'var(--line-height-body)',
+                  }}
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {cite.text}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
+  // ---- Legacy mode (string sources) ----
   if (!sources || sources.length === 0) {
     return null;
   }
 
-  const containerStyle: React.CSSProperties = {
-    marginTop: 'var(--spacing-sm)',
-    display: 'flex',
-    flexWrap: 'wrap',
-    gap: 'var(--spacing-xs)',
-  };
-
   return (
-    <div style={containerStyle}>
+    <div
+      style={{
+        marginTop: 'var(--spacing-sm)',
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: 'var(--spacing-xs)',
+      }}
+    >
       {sources.map((source, index) => {
         const filename = getBasename(source);
-        const isExpanded = expandedSource === source;
-        const isCopied = copiedSource === source;
+        const key = `source-${index}-${source}`;
+        const isExpanded = expandedKey === key;
+        const isCopied = copiedKey === key;
 
         const pillStyle: React.CSSProperties = {
           backgroundColor: 'var(--color-source-pill-bg)',
@@ -86,44 +204,36 @@ export const SourceCitation: React.FC<SourceCitationProps> = React.memo(({ sourc
           position: 'relative',
         };
 
-        const filenameStyle: React.CSSProperties = {
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          whiteSpace: 'nowrap',
-        };
-
-        const copyButtonStyle: React.CSSProperties = {
-          background: 'transparent',
-          border: 'none',
-          cursor: 'pointer',
-          padding: '0',
-          fontSize: 'var(--font-size-caption)',
-          color: isCopied ? 'var(--color-text-muted)' : 'var(--color-text-muted)',
-          opacity: isCopied ? 0.7 : 0.5,
-          transition: 'opacity 0.15s ease',
-          flexShrink: 0,
-        };
-
         return (
           <div
-            key={`source-${index}-${source}`}
+            key={key}
             role="button"
             tabIndex={0}
             style={pillStyle}
-            onClick={() => handleToggleExpand(source)}
+            onClick={() => handleToggleExpand(key)}
             onKeyDown={(e) => {
               if (e.key === 'Enter' || e.key === ' ') {
                 e.preventDefault();
-                handleToggleExpand(source);
+                handleToggleExpand(key);
               }
             }}
           >
-            <span style={filenameStyle} title={source}>
+            <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={source}>
               {filename}
             </span>
             <button
-              style={copyButtonStyle}
-              onClick={(e) => handleCopy(source, e)}
+              style={{
+                background: 'transparent',
+                border: 'none',
+                cursor: 'pointer',
+                padding: '0',
+                fontSize: 'var(--font-size-caption)',
+                color: 'var(--color-text-muted)',
+                opacity: isCopied ? 0.7 : 0.5,
+                transition: 'opacity 0.15s ease',
+                flexShrink: 0,
+              }}
+              onClick={(e) => handleCopy(key, source, e)}
               aria-label={isCopied ? 'Copied' : 'Copy source path'}
               type="button"
             >

--- a/web_ui/src/lib/embeddings/embedding-service.test.ts
+++ b/web_ui/src/lib/embeddings/embedding-service.test.ts
@@ -302,6 +302,23 @@ describe('EmbeddingService', () => {
       expect(result.length).toBe(384);
     });
 
+    it('uses CLS pooling (F9 — bge-small-en-v1.5 requires cls, not mean)', async () => {
+      const embedding = createMockEmbedding();
+      setupPipelineMock(embedding);
+      const instance = EmbeddingService.getInstance();
+      await instance.initialize();
+      mockPipelineCallable.mockClear();
+
+      await instance.encode('hello world');
+
+      // The model's 1_Pooling/config.json declares pooling_mode_cls_token:true;
+      // mean pooling silently degrades retrieval accuracy.
+      expect(mockPipelineCallable).toHaveBeenCalledWith(
+        'hello world',
+        expect.objectContaining({ pooling: 'cls', normalize: true })
+      );
+    });
+
     it('throws error for empty text', async () => {
       setupPipelineMock();
       const instance = EmbeddingService.getInstance();

--- a/web_ui/src/lib/embeddings/embedding-service.ts
+++ b/web_ui/src/lib/embeddings/embedding-service.ts
@@ -124,8 +124,10 @@ export class EmbeddingService {
 
       // Verify model is cached by attempting a test encoding
       // Bypass isReady() check since we know featureExtractor is just created
+      // CLS pooling: the packaged bge-small-en-v1.5 declares
+      // pooling_mode_cls_token:true in its 1_Pooling/config.json (F9).
       const testResult = await this.featureExtractor!('init', {
-        pooling: 'mean',
+        pooling: 'cls',
         normalize: true,
       }) as { data: Float32Array; dims: number[] };
       if (testResult.data.length !== EMBEDDING_DIMENSIONS) {
@@ -186,7 +188,7 @@ export class EmbeddingService {
 
     try {
       const result = await this.featureExtractor!(text, {
-        pooling: 'mean',
+        pooling: 'cls',
         normalize: true,
       }) as {
         data: Float32Array;
@@ -252,7 +254,7 @@ export class EmbeddingService {
 
         // Use native batch inference via featureExtractor directly
         const batchResults = await this.featureExtractor!(batch, {
-          pooling: 'mean',
+          pooling: 'cls',
           normalize: true,
         }) as { data: Float32Array; dims: number[] };
 

--- a/web_ui/src/lib/llm/wllama-service.ts
+++ b/web_ui/src/lib/llm/wllama-service.ts
@@ -35,7 +35,7 @@ import {
 import { probeAsset } from '../models/probe';
 
 /** Context window. LFM2-VL handles long context; 4096 is a safe default for RAM. */
-const DEFAULT_N_CTX = 4096;
+export const DEFAULT_N_CTX = 4096;
 
 function threadCount(): number {
   return navigator.hardwareConcurrency ? Math.min(navigator.hardwareConcurrency, 4) : 2;

--- a/web_ui/src/lib/rag/rag-orchestrator.test.ts
+++ b/web_ui/src/lib/rag/rag-orchestrator.test.ts
@@ -19,6 +19,7 @@ import type { LLMMessage } from '../../types/llm';
 
 const createMockEmbeddingService = () => ({
   encodeWithMetadata: vi.fn(),
+  encodeBatch: vi.fn(),
   isReady: vi.fn().mockReturnValue(true),
 });
 
@@ -79,6 +80,23 @@ vi.mock('../llm/web-llm-service', () => ({
   },
 }));
 
+// F10: the orchestrator now defaults to the offline-first engine via
+// getLLMService() instead of WebLLMService.getInstance() directly. Mock the
+// factory so the no-arg constructor used in these tests resolves to the test
+// LLM service. The mock factory returns whatever LLM service is currently
+// registered below.
+vi.mock('../llm/llm-factory', () => ({
+  getLLMService: vi.fn(),
+}));
+
+// F4: readiness helpers are now consulted (their boolean result drives whether
+// semantic search runs). Mock them so tests can control semantic availability;
+// default to ready (true) so the full pipeline exercises the embedding path.
+vi.mock('../../hooks/useServiceInitialization', () => ({
+  ensureEmbeddingServiceReady: vi.fn().mockResolvedValue(true),
+  ensureReadinessGateChecked: vi.fn().mockResolvedValue({ ready: true }),
+}));
+
 // Import types and class AFTER mocks are set up
 import { RAGOrchestrator } from './rag-orchestrator';
 
@@ -91,7 +109,8 @@ import { getVectorIndex } from '../search/vector-index';
 import { getKeywordIndex } from '../search/keyword-index';
 import { getRerankerService } from '../search/reranker';
 import { rrfFuse } from '../search/rrf-fusion';
-import { WebLLMService } from '../llm/web-llm-service';
+import { getLLMService } from '../llm/llm-factory';
+import { ensureEmbeddingServiceReady, ensureReadinessGateChecked } from '../../hooks/useServiceInitialization';
 
 // --- Test Data ---
 
@@ -130,7 +149,12 @@ describe('RAGOrchestrator', () => {
     (getVectorIndex as ReturnType<typeof vi.fn>).mockReturnValue(mockVectorIndex);
     (getKeywordIndex as ReturnType<typeof vi.fn>).mockReturnValue(mockKeywordIndex);
     (getRerankerService as ReturnType<typeof vi.fn>).mockReturnValue(mockRerankerService);
-    (WebLLMService.getInstance as ReturnType<typeof vi.fn>).mockReturnValue(mockWebLLMService);
+    (getLLMService as ReturnType<typeof vi.fn>).mockReturnValue(mockWebLLMService);
+
+    // Default: semantic search available. Tests that exercise the degraded
+    // path override this (F4).
+    (ensureEmbeddingServiceReady as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+    (ensureReadinessGateChecked as ReturnType<typeof vi.fn>).mockResolvedValue({ ready: true });
     (rrfFuse as ReturnType<typeof vi.fn>).mockImplementation((lists: SearchResult[][]) => {
       const combined: SearchResult[] = [];
       for (const list of lists) {
@@ -255,8 +279,11 @@ describe('RAGOrchestrator', () => {
       events.push(event);
     }
 
-    // Verify embedding was called
-    expect(mockEmbeddingService.encodeWithMetadata).toHaveBeenCalledWith(question);
+    // Verify embedding was called with the BGE retrieval-instruction prefix
+    // prepended to the query (F8 — query side only; passages stay un-prefixed).
+    expect(mockEmbeddingService.encodeWithMetadata).toHaveBeenCalledWith(
+      'Represent this sentence for searching relevant passages: ' + question
+    );
 
     // Verify vector search was called with embedding
     expect(mockVectorIndex.search).toHaveBeenCalledWith(mockEmbedding, { k: 10 });
@@ -453,7 +480,6 @@ describe('RAGOrchestrator', () => {
   // TEST: Context assembly formats numbered sources correctly
   // ========================================================================
   test('Context assembly formats numbered sources correctly', async () => {
-    const question = 'What is AI?';
     const chunks = [
       { docId: 'doc-X', chunkIndex: 0, score: 0.9, text: 'AI is artificial intelligence.' },
       { docId: 'doc-Y', chunkIndex: 1, score: 0.8, text: 'ML is machine learning.' },
@@ -462,27 +488,29 @@ describe('RAGOrchestrator', () => {
 
     const orchestrator = new RAGOrchestrator();
 
-    // Access the private buildContext method via any
-    const context = (orchestrator as unknown as { buildContext: (q: string, c: SearchResult[]) => string }).buildContext(question, chunks);
+    // buildContext no longer takes a question param and no longer emits a
+    // "Context:" header or per-line "Source:" — buildMessages owns the single
+    // header (F6). It numbers chunks [1],[2],... in array order.
+    const context = (orchestrator as unknown as { buildContext: (c: SearchResult[]) => string }).buildContext(chunks);
 
-    // Verify numbered format [1], [2], etc.
+    // Verify numbered format [1], [2], etc. — order matches the input array,
+    // which is what the model's [1],[2] citations resolve against (F7).
     expect(context).toContain('[1] AI is artificial intelligence.');
     expect(context).toContain('[2] ML is machine learning.');
     expect(context).toContain('[3] DL is deep learning.');
 
-    // Verify source metadata is included
-    expect(context).toContain('Source: doc-X');
-    expect(context).toContain('Source: doc-Y');
-
-    expect(context).toContain('Context:');
+    // F6: the duplicate "Context:" header is gone from buildContext.
+    expect(context).not.toContain('Context:');
   });
 
   test('Context handles empty chunks gracefully', async () => {
     const orchestrator = new RAGOrchestrator();
 
-    const context = (orchestrator as unknown as { buildContext: (q: string, c: SearchResult[]) => string }).buildContext('test', []);
+    // buildContext returns an empty string for an empty chunk list (the
+    // abstention path short-circuits before generation, so this is defensive).
+    const context = (orchestrator as unknown as { buildContext: (c: SearchResult[]) => string }).buildContext([]);
 
-    expect(context).toBe('No relevant context found.');
+    expect(context).toBe('');
   });
 
   // ========================================================================
@@ -685,10 +713,16 @@ describe('RAGOrchestrator', () => {
     expect(eventTypes).toContain('complete');
   });
 
-  test('Error during embedding yields error event', async () => {
+  // F4 changed this behavior: an embedding failure no longer hard-fails the
+  // whole query. The pipeline degrades to keyword-only retrieval and, if that
+  // also yields nothing, abstains with a retrieval_degraded reason. It must NOT
+  // emit a fatal embedding error event or invoke the LLM.
+  test('Embedding failure degrades to keyword-only retrieval (F4)', async () => {
     const question = 'embedding error test';
 
     mockEmbeddingService.encodeWithMetadata.mockRejectedValue(new Error('Embedding failed'));
+    // Keyword index has nothing either → the pipeline should abstain.
+    mockKeywordIndex.search.mockReturnValue([]);
 
     const orchestrator = new RAGOrchestrator();
     const events: Array<{ type: string; data?: unknown }> = [];
@@ -697,13 +731,29 @@ describe('RAGOrchestrator', () => {
       events.push(event);
     }
 
-    // Should yield retrieving event first, then error event
-    expect(events).toHaveLength(2);
-    expect(events[0].type).toBe('retrieving');
-    expect(events[1].type).toBe('error');
-    const errorEvent = events[1] as { type: 'error'; data: { stage: string; message: string } };
-    expect(errorEvent.data.stage).toBe('embedding');
-    expect(errorEvent.data.message).toBe('Embedding failed');
+    // No fatal embedding error event — degradation, not failure.
+    const errorEvents = events.filter((e) => e.type === 'error');
+    expect(errorEvents.filter((e) => (e.data as { stage: string }).stage === 'embedding')).toHaveLength(0);
+
+    // Vector search must be skipped (no query embedding available).
+    expect(mockVectorIndex.search).not.toHaveBeenCalled();
+
+    // Keyword search still ran.
+    expect(mockKeywordIndex.search).toHaveBeenCalled();
+
+    // Pipeline abstained with the degraded reason.
+    const complete = events.find((e) => e.type === 'complete') as {
+      type: 'complete';
+      data: { abstain?: boolean; abstainReason?: string; retrievalDegraded?: boolean };
+    };
+    expect(complete).toBeDefined();
+    expect(complete.data.abstain).toBe(true);
+    expect(complete.data.retrievalDegraded).toBe(true);
+    expect(complete.data.abstainReason).toBe('retrieval_degraded');
+
+    // The LLM must never be invoked when there is no evidence.
+    expect(mockWebLLMService.generate).not.toHaveBeenCalled();
+    expect(mockWebLLMService.generateComplete).not.toHaveBeenCalled();
   });
 
   // ========================================================================
@@ -983,6 +1033,262 @@ describe('RAGOrchestrator', () => {
         events.push(ev);
       }
       expect(events.some((e: any) => e.type === 'complete')).toBe(true);
+    });
+  });
+
+  // ==========================================================================
+  // Regression tests for issue #22 (RAG grounding & citations)
+  // ==========================================================================
+  describe('issue #22: grounding, abstention, budget, citations', () => {
+    test('F2: zero-chunk retrieval abstains instead of calling the LLM', async () => {
+      const mockEmbedding = createMockEmbedding();
+      mockEmbeddingService.encodeWithMetadata.mockResolvedValue({
+        vector: mockEmbedding,
+        text: 'q',
+        dimensions: 384,
+      });
+      mockVectorIndex.search.mockResolvedValue([]);
+      mockKeywordIndex.search.mockReturnValue([]);
+      (rrfFuse as ReturnType<typeof vi.fn>).mockReturnValue([]);
+
+      const orchestrator = new RAGOrchestrator();
+      const events: any[] = [];
+      for await (const ev of orchestrator.query('unanswerable', { streamTokens: false })) {
+        events.push(ev);
+      }
+
+      const complete = events.find((e) => e.type === 'complete');
+      expect(complete).toBeDefined();
+      expect(complete.data.abstain).toBe(true);
+      expect(complete.data.chunks).toEqual([]);
+      // The LLM must NEVER be invoked when abstaining.
+      expect(mockWebLLMService.generate).not.toHaveBeenCalled();
+      expect(mockWebLLMService.generateComplete).not.toHaveBeenCalled();
+    });
+
+    test('F3: relevance floor drops sub-threshold RRF chunks and abstains', async () => {
+      const mockEmbedding = createMockEmbedding();
+      // RRF scores well below MIN_RRF_SCORE (0.005): a hit only in one list at
+      // rank 0 scores 1/(60+0+1) ≈ 0.0164; rank 40 → 1/81 ≈ 0.0123 — still above
+      // 0.005. So push a single weak hit and override rrfFuse to return a chunk
+      // with an explicitly tiny score.
+      mockEmbeddingService.encodeWithMetadata.mockResolvedValue({
+        vector: mockEmbedding,
+        text: 'q',
+        dimensions: 384,
+      });
+      const weak = [{ docId: 'd', chunkIndex: 0, score: 0.0001, text: 't' }];
+      mockVectorIndex.search.mockResolvedValue(weak);
+      mockKeywordIndex.search.mockReturnValue([]);
+      (rrfFuse as ReturnType<typeof vi.fn>).mockReturnValue(weak);
+
+      const orchestrator = new RAGOrchestrator();
+      const events: any[] = [];
+      for await (const ev of orchestrator.query('out of corpus', { streamTokens: false, rerank: false })) {
+        events.push(ev);
+      }
+
+      const complete = events.find((e) => e.type === 'complete');
+      expect(complete.data.abstain).toBe(true);
+      expect(mockWebLLMService.generateComplete).not.toHaveBeenCalled();
+    });
+
+    test('F7: complete.chunks order matches the buildContext numbering order', async () => {
+      const mockEmbedding = createMockEmbedding();
+      // Distinct texts so we can verify [1]→chunks[0], [2]→chunks[1] mapping.
+      const fused = [
+        { docId: 'd1', chunkIndex: 0, score: 0.9, text: 'AAA first chunk' },
+        { docId: 'd2', chunkIndex: 0, score: 0.8, text: 'BBB second chunk' },
+      ];
+      mockEmbeddingService.encodeWithMetadata.mockResolvedValue({
+        vector: mockEmbedding,
+        text: 'q',
+        dimensions: 384,
+      });
+      mockVectorIndex.search.mockResolvedValue(fused);
+      mockKeywordIndex.search.mockReturnValue([]);
+      (rrfFuse as ReturnType<typeof vi.fn>).mockReturnValue(fused);
+      mockWebLLMService.generateComplete.mockResolvedValue('answer [1] and [2]');
+
+      const orchestrator = new RAGOrchestrator();
+      const events: any[] = [];
+      for await (const ev of orchestrator.query('q', { streamTokens: false, rerank: false })) {
+        events.push(ev);
+      }
+      const complete = events.find((e) => e.type === 'complete');
+      // chunks[i] is the chunk the model numbered [i+1].
+      expect(complete.data.chunks[0].text).toBe('AAA first chunk');
+      expect(complete.data.chunks[1].text).toBe('BBB second chunk');
+    });
+
+    test('F8: query embedding receives the BGE instruction prefix', async () => {
+      const mockEmbedding = createMockEmbedding();
+      mockEmbeddingService.encodeWithMetadata.mockResolvedValue({
+        vector: mockEmbedding,
+        text: 'q',
+        dimensions: 384,
+      });
+      mockVectorIndex.search.mockResolvedValue([]);
+      mockKeywordIndex.search.mockReturnValue([]);
+
+      const orchestrator = new RAGOrchestrator();
+      for await (const _ of orchestrator.query('clinical question', { streamTokens: false })) {
+        void _;
+      }
+      expect(mockEmbeddingService.encodeWithMetadata).toHaveBeenCalledWith(
+        'Represent this sentence for searching relevant passages: clinical question'
+      );
+    });
+
+    test('F8: the BGE prefix lives ONLY in the query path (passages un-prefixed, PRR-007)', async () => {
+      // The prefix is orchestrator-local: it is prepended at the query
+      // encodeWithMetadata call site and NOWHERE else. The passage-ingestion
+      // path (DocumentsPage -> EmbeddingService.encodeBatch) must receive raw
+      // text. We verify two things: (1) the orchestrator only ever calls the
+      // prefixed query embedding, and (2) the prefix string is not referenced
+      // by encodeBatch/encode at all.
+      const mockEmbedding = createMockEmbedding();
+      mockEmbeddingService.encodeWithMetadata.mockResolvedValue({
+        vector: mockEmbedding,
+        text: 'q',
+        dimensions: 384,
+      });
+      mockVectorIndex.search.mockResolvedValue([]);
+      mockKeywordIndex.search.mockReturnValue([]);
+
+      const orchestrator = new RAGOrchestrator();
+      for await (const _ of orchestrator.query('a question', { streamTokens: false })) {
+        void _;
+      }
+
+      // Only the query embedding is invoked by the orchestrator, and it is
+      // prefixed. encodeBatch (the passage path) is NEVER called by the
+      // orchestrator, so passages cannot be accidentally prefixed here.
+      expect(mockEmbeddingService.encodeWithMetadata).toHaveBeenCalledTimes(1);
+      expect(mockEmbeddingService.encodeWithMetadata).toHaveBeenCalledWith(
+        'Represent this sentence for searching relevant passages: a question'
+      );
+      expect(mockEmbeddingService.encodeBatch).not.toHaveBeenCalled();
+    });
+
+    test('F10: no-arg constructor uses getLLMService (offline-first, not WebLLM)', () => {
+      // getLLMService is mocked in beforeEach to return mockWebLLMService.
+      // Constructing without an explicit llmService must route through the
+      // factory (wllama default), not WebLLMService.getInstance() directly.
+      (getLLMService as ReturnType<typeof vi.fn>).mockClear();
+      new RAGOrchestrator();
+      expect(getLLMService).toHaveBeenCalled();
+    });
+
+    test('F11: token budget drops overflowing chunks and reports contextTrimmed', async () => {
+      const mockEmbedding = createMockEmbedding();
+      // A single chunk far larger than the entire context window (n_ctx=4096 →
+      // ~16k chars total budget). It cannot fit and is dropped, leaving zero
+      // chunks → abstention. The LLM is never fed a truncated prompt.
+      const huge = 'x'.repeat(1_000_000);
+      const fused = [
+        { docId: 'd1', chunkIndex: 0, score: 0.9, text: huge },
+        { docId: 'd2', chunkIndex: 0, score: 0.8, text: huge },
+      ];
+      mockEmbeddingService.encodeWithMetadata.mockResolvedValue({
+        vector: mockEmbedding,
+        text: 'q',
+        dimensions: 384,
+      });
+      mockVectorIndex.search.mockResolvedValue(fused);
+      mockKeywordIndex.search.mockReturnValue([]);
+      (rrfFuse as ReturnType<typeof vi.fn>).mockReturnValue(fused);
+
+      const orchestrator = new RAGOrchestrator();
+      const events: any[] = [];
+      for await (const ev of orchestrator.query('my question', { streamTokens: false, rerank: false, maxTokens: 512 })) {
+        events.push(ev);
+      }
+      const complete = events.find((e) => e.type === 'complete');
+      // Both oversized chunks are dropped to fit the budget, leaving zero
+      // chunks → abstention.
+      expect(complete.data.abstain).toBe(true);
+      expect(complete.data.contextTrimmed).toBe(2);
+      expect(mockWebLLMService.generateComplete).not.toHaveBeenCalled();
+    });
+
+    test('F11: question text survives in the prompt when chunks fit the budget', async () => {
+      const mockEmbedding = createMockEmbedding();
+      const small = [{ docId: 'd1', chunkIndex: 0, score: 0.9, text: 'small context' }];
+      mockEmbeddingService.encodeWithMetadata.mockResolvedValue({
+        vector: mockEmbedding,
+        text: 'q',
+        dimensions: 384,
+      });
+      mockVectorIndex.search.mockResolvedValue(small);
+      mockKeywordIndex.search.mockReturnValue([]);
+      (rrfFuse as ReturnType<typeof vi.fn>).mockReturnValue(small);
+      const captured: string[] = [];
+      mockWebLLMService.generateComplete.mockImplementation(async (msgs: any) => {
+        captured.push(msgs.find((m: any) => m.role === 'user')?.content ?? '');
+        return 'answer';
+      });
+
+      const orchestrator = new RAGOrchestrator();
+      const question = 'the all-important user question';
+      for await (const _ of orchestrator.query(question, { streamTokens: false, rerank: false })) {
+        void _;
+      }
+      // The question must appear verbatim in the final prompt (not truncated).
+      expect(captured[0]).toContain(question);
+    });
+
+    test('F11: partial fit — higher-ranked chunks kept, lower-ranked dropped (PRR-006)', async () => {
+      const mockEmbedding = createMockEmbedding();
+      // Two chunks: the first (higher score) fits the budget, the second (lower
+      // score, same size) overflows it. This exercises the budget accumulation
+      // + drop branch, which the all-or-nothing tests do not.
+      const big = 'y'.repeat(10000);
+      const fused = [
+        { docId: 'd-keep', chunkIndex: 0, score: 0.9, text: big },
+        { docId: 'd-drop', chunkIndex: 0, score: 0.8, text: big },
+      ];
+      mockEmbeddingService.encodeWithMetadata.mockResolvedValue({
+        vector: mockEmbedding,
+        text: 'q',
+        dimensions: 384,
+      });
+      mockVectorIndex.search.mockResolvedValue(fused);
+      mockKeywordIndex.search.mockReturnValue([]);
+      (rrfFuse as ReturnType<typeof vi.fn>).mockReturnValue(fused);
+      mockWebLLMService.generateComplete.mockResolvedValue('answer');
+
+      const orchestrator = new RAGOrchestrator();
+      const events: any[] = [];
+      for await (const ev of orchestrator.query('q', { streamTokens: false, rerank: false, maxTokens: 512 })) {
+        events.push(ev);
+      }
+      const complete = events.find((e) => e.type === 'complete');
+      // Exactly one chunk fit; the other was dropped for budget.
+      expect(complete.data.chunks).toHaveLength(1);
+      expect(complete.data.chunks[0].docId).toBe('d-keep');
+      expect(complete.data.contextTrimmed).toBe(1);
+    });
+
+    test('F4: semantic-available gate returning false skips vector search and embedding', async () => {
+      // Embedding service never came up.
+      (ensureEmbeddingServiceReady as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+      const keywordHits = [{ docId: 'd1', chunkIndex: 0, score: 0.5, text: 'keyword hit' }];
+      mockKeywordIndex.search.mockReturnValue(keywordHits);
+      (rrfFuse as ReturnType<typeof vi.fn>).mockReturnValue(keywordHits);
+      mockWebLLMService.generateComplete.mockResolvedValue('degraded answer');
+
+      const orchestrator = new RAGOrchestrator();
+      const events: any[] = [];
+      for await (const ev of orchestrator.query('q', { streamTokens: false, rerank: false })) {
+        events.push(ev);
+      }
+      // Embedding must not be invoked at all.
+      expect(mockEmbeddingService.encodeWithMetadata).not.toHaveBeenCalled();
+      expect(mockVectorIndex.search).not.toHaveBeenCalled();
+      const complete = events.find((e) => e.type === 'complete');
+      expect(complete.data.retrievalDegraded).toBe(true);
+      expect(complete.data.abstain).not.toBe(true);
     });
   });
 });

--- a/web_ui/src/lib/rag/rag-orchestrator.ts
+++ b/web_ui/src/lib/rag/rag-orchestrator.ts
@@ -26,7 +26,8 @@ import { getVectorIndex, type VectorIndex } from '../search/vector-index';
 import { getKeywordIndex, type KeywordIndex } from '../search/keyword-index';
 import { rrfFuse } from '../search/rrf-fusion';
 import { getRerankerService, type RerankerService } from '../search/reranker';
-import { WebLLMService } from '../llm/web-llm-service';
+import { getLLMService } from '../llm/llm-factory';
+import { DEFAULT_N_CTX } from '../llm/wllama-service';
 import { ensureEmbeddingServiceReady, ensureReadinessGateChecked } from '../../hooks/useServiceInitialization';
 
 /**
@@ -69,7 +70,24 @@ export type RAGEvent =
   | { type: 'reranked'; data: { results: SearchResult[] } }
   | { type: 'generating'; data: { contextLength: number; sourceCount: number } }
   | { type: 'token'; data: string }
-  | { type: 'complete'; data: { answer: string; sources: string[]; chunks: SearchResult[] } }
+  | {
+      type: 'complete';
+      data: {
+        answer: string;
+        /** Filenames (deduped from chunk.source, falling back to docId). */
+        sources: string[];
+        /** The exact contextChunks array passed to buildContext, in order. The
+         *  model's [1],[2] citations map onto this array by index. */
+        chunks: SearchResult[];
+        /** True when the pipeline abstained instead of answering (F2). */
+        abstain?: boolean;
+        abstainReason?: 'insufficient_evidence' | 'retrieval_degraded';
+        /** True when retrieval ran keyword-only (semantic search unavailable) (F4). */
+        retrievalDegraded?: boolean;
+        /** Number of context chunks dropped to fit the token budget (F11). */
+        contextTrimmed?: number;
+      };
+    }
   | { type: 'error'; data: { stage: RAGStage; message: string } };
 
 /**
@@ -81,6 +99,34 @@ type RAGStage = 'embedding' | 'vector_search' | 'keyword_search' | 'rrf_fusion' 
  * Default system prompt instructing the LLM to cite sources.
  */
 const DEFAULT_SYSTEM_PROMPT = 'Answer the question based on the provided context. Cite sources using [1], [2] notation. If the context doesn\'t contain enough information, say so.';
+
+/**
+ * BGE retrieval query instruction. BAAI's bge-small-en-v1.5 model card requires
+ * this prefix on the QUERY embedding for short-query→long-passage retrieval
+ * (F8). Passages are intentionally left UN-prefixed (only the query side).
+ */
+const BGE_QUERY_INSTRUCTION = 'Represent this sentence for searching relevant passages: ';
+
+/**
+ * Relevance floors applied AFTER the rerank/slice branch resolves, so the floor
+ * must match the score scale contextChunks actually carries (F3).
+ *  - When the cross-encoder reran: scores are cosine-ish relevance in ~[0,1],
+ *    meaningful hits are well above 0.1.
+ *  - When only RRF ran: scores are sums of 1/(60+rank+1); meaningful hits sit
+ *    far above 0.005 (a hit at rank 0 in both lists scores ~0.033).
+ */
+const MIN_CROSS_SCORE = 0.1;
+const MIN_RRF_SCORE = 0.005;
+
+/**
+ * Token-budget estimate for keeping the user's question in-prompt under the
+ * model context window (F11). No tokenizer is exposed by the LLM service, so a
+ * conservative chars-per-token approximation is used with an explicit safety
+ * margin. DEFAULT_N_CTX (4096) is sourced from wllama-service — the binding
+ * constraint for the default offline engine.
+ */
+const CHARS_PER_TOKEN = 4;
+const TOKEN_SAFETY_MARGIN = 96;
 
 /**
  * RAG Orchestrator - Coordinates embedding search, keyword search, RRF fusion,
@@ -96,15 +142,16 @@ export class RAGOrchestrator {
   /**
    * Create a new RAGOrchestrator with service references.
    * Retrieval services are singletons; the LLM engine can be injected so callers
-   * (e.g. ChatPage) can select wllama vs WebLLM. Defaults to WebLLM when omitted
-   * for backward compatibility with direct construction.
+   * (e.g. ChatPage) can select wllama vs WebLLM. Defaults to the offline-first
+   * engine (wllama) via getLLMService() — WebLLM resolves weights from a CDN and
+   * breaks the air-gap guarantee, so it must never be the implicit default (F10).
    */
   constructor(opts?: { llmService?: LLMService }) {
     this.embeddingService = getEmbeddingService();
     this.vectorIndex = getVectorIndex();
     this.keywordIndex = getKeywordIndex();
     this.rerankerService = getRerankerService();
-    this.llmService = opts?.llmService ?? WebLLMService.getInstance();
+    this.llmService = opts?.llmService ?? getLLMService();
   }
 
   /**
@@ -132,20 +179,28 @@ export class RAGOrchestrator {
       throw new DOMException('The operation was aborted.', 'AbortError');
     }
 
-    await Promise.all([
+    // F4: capture the readiness result instead of discarding it. The two
+    // ensure*() helpers swallow errors (return false / null), so Promise.all
+    // always resolves even when the embedding model failed to load. We must
+    // inspect the boolean ourselves to know whether semantic search is
+    // available — if not, we degrade to keyword-only retrieval instead of
+    // throwing fatally later.
+    const [embeddingReady] = await Promise.all([
       ensureEmbeddingServiceReady(),
       ensureReadinessGateChecked(),
     ]);
+    const semanticAvailable = embeddingReady === true;
 
     if (signal?.aborted) {
       throw new DOMException('The operation was aborted.', 'AbortError');
     }
 
     let fusedResults: SearchResult[] = [];
-    let rerankedResults: SearchResult[] = [];
     let contextChunks: SearchResult[] = [];
-    let sources: string[] = [];
     let fullAnswer = '';
+    // True when semantic/vector search was unavailable for any reason; surfaces
+    // as a non-blocking "retrieval degraded" indicator in the UI (F4).
+    let retrievalDegraded = false;
 
     // Stage 1: Embed the query
     yield { type: 'retrieving', data: { query: question } };
@@ -154,42 +209,57 @@ export class RAGOrchestrator {
       throw new DOMException('The operation was aborted.', 'AbortError');
     }
 
-    let queryEmbedding: EmbeddingVector;
-    try {
-      const embeddingResult = await this.embeddingService.encodeWithMetadata(question);
-      queryEmbedding = embeddingResult.vector;
-    } catch (err) {
-      yield {
-        type: 'error',
-        data: {
-          stage: 'embedding',
-          message: err instanceof Error ? err.message : 'Failed to embed query',
-        },
-      };
-      return;
-    }
-
-    // Stage 2 & 3: Search both indexes in parallel
-    let vectorResults: SearchResult[] = [];
-    let keywordResults: SearchResult[] = [];
-
-    try {
-      if (this.vectorIndex.isReady()) {
-        vectorResults = await this.vectorIndex.search(queryEmbedding, { k: topK });
-      } else {
-        console.warn('[RAGOrchestrator] VectorIndex not ready, skipping vector search');
+    // F4 + F8: embed the query ONLY when semantic search is available, and
+    // prepend the BGE retrieval instruction to the query text (passages stay
+    // un-prefixed — only the query side changes, F8).
+    let queryEmbedding: EmbeddingVector | null = null;
+    if (semanticAvailable) {
+      try {
+        const embeddingResult = await this.embeddingService.encodeWithMetadata(
+          BGE_QUERY_INSTRUCTION + question
+        );
+        queryEmbedding = embeddingResult.vector;
+      } catch (err) {
+        // Embedding failed at runtime even though the gate passed. Degrade
+        // rather than abort the whole query (F4).
+        console.error('[RAGOrchestrator] Query embedding failed, degrading to keyword-only:', err);
+        queryEmbedding = null;
+        retrievalDegraded = true;
       }
-    } catch (err) {
-      console.error('[RAGOrchestrator] Vector search failed:', err);
-      yield {
-        type: 'error',
-        data: {
-          stage: 'vector_search',
-          message: err instanceof Error ? err.message : 'Vector search failed',
-        },
-      };
+    } else {
+      // Embedding service never came up. Keyword search can still serve a
+      // useful (if lower-recall) answer.
+      console.warn('[RAGOrchestrator] Embedding service unavailable; using keyword-only retrieval');
+      retrievalDegraded = true;
     }
 
+    // Stage 2 & 3: Search both indexes. Vector search is gated on having a
+    // query embedding (F4); keyword search runs unconditionally — it is
+    // independent of the embedding model and healthy on its own.
+    let vectorResults: SearchResult[] = [];
+
+    if (queryEmbedding !== null) {
+      try {
+        if (this.vectorIndex.isReady()) {
+          vectorResults = await this.vectorIndex.search(queryEmbedding, { k: topK });
+        } else {
+          console.warn('[RAGOrchestrator] VectorIndex not ready, skipping vector search');
+          retrievalDegraded = true;
+        }
+      } catch (err) {
+        console.error('[RAGOrchestrator] Vector search failed:', err);
+        yield {
+          type: 'error',
+          data: {
+            stage: 'vector_search',
+            message: err instanceof Error ? err.message : 'Vector search failed',
+          },
+        };
+        retrievalDegraded = true;
+      }
+    }
+
+    let keywordResults: SearchResult[] = [];
     try {
       if (this.keywordIndex.isReady()) {
         keywordResults = this.keywordIndex.search(question, { limit: topK });
@@ -207,7 +277,7 @@ export class RAGOrchestrator {
       };
     }
 
-    // Stage 4: RRF fusion
+    // Stage 4: RRF fusion (harmless with a single non-empty list; no special-case).
     try {
       if (vectorResults.length > 0 || keywordResults.length > 0) {
         fusedResults = rrfFuse([vectorResults, keywordResults], 60);
@@ -230,16 +300,19 @@ export class RAGOrchestrator {
       data: { vectorResults, keywordResults, fusedResults },
     };
 
-    // Stage 5: Optional reranking
+    // Stage 5: Optional reranking. Track whether the cross-encoder actually ran
+    // so the relevance floor is applied on the correct score scale (F3).
+    let didRerank = false;
     if (doRerank && fusedResults.length > 0) {
       try {
         if (this.rerankerService.isReady() && this.rerankerService.canRerank(fusedResults.length)) {
           yield { type: 'reranking', data: { count: fusedResults.length } };
 
-          rerankedResults = await this.rerankerService.rerank(question, fusedResults, topK);
+          const rerankedResults = await this.rerankerService.rerank(question, fusedResults, topK);
 
           yield { type: 'reranked', data: { results: rerankedResults } };
           contextChunks = rerankedResults;
+          didRerank = true;
         } else {
           contextChunks = fusedResults.slice(0, topK);
         }
@@ -258,17 +331,83 @@ export class RAGOrchestrator {
       contextChunks = fusedResults.slice(0, topK);
     }
 
-    // Collect unique sources from chunks
-    const sourceSet = new Set<string>();
-    for (const chunk of contextChunks) {
-      if (chunk.docId) {
-        sourceSet.add(chunk.docId);
+    // F3: relevance floor. Pick the floor by the score scale contextChunks
+    // actually carries — cross-encoder scores (after rerank) vs RRF scores.
+    if (contextChunks.length > 0) {
+      const floor = didRerank ? MIN_CROSS_SCORE : MIN_RRF_SCORE;
+      const before = contextChunks.length;
+      contextChunks = contextChunks.filter((c) => c.score >= floor);
+      if (contextChunks.length < before) {
+        // Structured content-gap log for future governance consumers (PR-7 #26
+        // wires a real store; the format is stable from now). bestScore is the
+        // strongest surviving chunk after the floor (null if all were dropped).
+        console.info('[RAG] content-gap', {
+          query: question,
+          bestScore: contextChunks.length > 0 ? contextChunks[0].score : null,
+          droppedByFloor: before - contextChunks.length,
+          scale: didRerank ? 'cross-encoder' : 'rrf',
+        });
       }
     }
-    sources = Array.from(sourceSet);
+
+    // F11: token budget. Keep the user's question in-prompt by reserving space
+    // for the system prompt, the question, and generation, then fitting only as
+    // many ranked chunks (highest first) as the remaining budget allows. Drop
+    // whole chunks that overflow — never truncate mid-chunk. Applied BEFORE the
+    // abstention check so that budget-induced emptiness also abstains.
+    const reservedTokens =
+      estimateTokens(systemPrompt, CHARS_PER_TOKEN) +
+      estimateTokens(question, CHARS_PER_TOKEN) +
+      (maxTokens ?? 512) +
+      TOKEN_SAFETY_MARGIN;
+    const contextBudgetChars = Math.max(0, (DEFAULT_N_CTX - reservedTokens) * CHARS_PER_TOKEN);
+    let usedChars = 0;
+    let droppedForBudget = 0;
+    const budgeted: SearchResult[] = [];
+    for (const chunk of contextChunks) {
+      const len = (chunk.text ?? '').length;
+      if (usedChars + len <= contextBudgetChars) {
+        budgeted.push(chunk);
+        usedChars += len;
+      } else {
+        droppedForBudget++;
+      }
+    }
+    contextChunks = budgeted;
+
+    // F2: abstention. If no chunks survive the floor AND budget, short-circuit
+    // BEFORE generation so the model never answers from pretrained knowledge
+    // with no source. The UI renders a visually distinct abstention state.
+    if (contextChunks.length === 0) {
+      yield {
+        type: 'complete',
+        data: {
+          answer: '',
+          sources: [],
+          chunks: [],
+          abstain: true,
+          abstainReason:
+            retrievalDegraded && keywordResults.length === 0
+              ? 'retrieval_degraded'
+              : 'insufficient_evidence',
+          retrievalDegraded,
+          contextTrimmed: droppedForBudget > 0 ? droppedForBudget : undefined,
+        },
+      };
+      return;
+    }
+
+    // Collect unique source filenames for the legacy sources field (fall back to
+    // docId when a chunk has no filename). The structured citations live in the
+    // chunks array (F7).
+    const sourceSet = new Set<string>();
+    for (const chunk of contextChunks) {
+      sourceSet.add(chunk.source ?? chunk.docId);
+    }
+    const sources = Array.from(sourceSet);
 
     // Stage 6: Build context from chunks
-    const contextText = this.buildContext(question, contextChunks);
+    const contextText = this.buildContext(contextChunks);
     const contextMessages = this.buildMessages(systemPrompt, question, contextText, options.images);
 
     yield {
@@ -302,35 +441,52 @@ export class RAGOrchestrator {
       return;
     }
 
-    // Stage 9: Yield final complete event
+    // Stage 9: Yield final complete event. `chunks` is the exact contextChunks
+    // array passed to buildContext, in order — the model's [1],[2] citations map
+    // onto it by index (F7 numbering invariant).
     yield {
       type: 'complete',
       data: {
         answer: fullAnswer,
         sources,
         chunks: contextChunks,
+        retrievalDegraded,
+        contextTrimmed: droppedForBudget > 0 ? droppedForBudget : undefined,
       },
     };
   }
 
   /**
-   * Build a formatted context string from search results.
-   * Each chunk is numbered and includes its text and source metadata.
+   * Build a formatted context string from search results. Each chunk is
+   * numbered `[i+1]`; the model is instructed to cite using those numbers, and
+   * the UI renders citations in the SAME order (F7 numbering invariant).
+   *
+   * NOTE: this no longer emits a `"Context:\n"` header — `buildMessages` owns
+   * the single header (F6 removed the duplicate). It also no longer takes the
+   * (unused) `question` parameter.
    */
-  private buildContext(_question: string, chunks: SearchResult[]): string {
+  private buildContext(chunks: SearchResult[]): string {
     if (chunks.length === 0) {
-      return 'No relevant context found.';
+      return '';
     }
 
     const contextParts: string[] = [];
-    contextParts.push('Context:\n');
-
     for (let i = 0; i < chunks.length; i++) {
       const chunk = chunks[i];
-      const chunkText = chunk.text ?? `Document chunk from ${chunk.docId}`;
-      contextParts.push(`[${i + 1}] ${chunkText}`);
-      if (chunk.docId) {
-        contextParts.push(`    Source: ${chunk.docId}`);
+      const chunkText = chunk.text;
+      // F1 tripwire: after the fix, every chunk reaching here MUST carry real
+      // text. A missing/empty text is a regression — emit a clearly-fake
+      // sentinel (never the old `Document chunk from <id>` placeholder, which
+      // looked like real content) and log loudly. Do not throw, so the user
+      // still gets a degraded answer instead of a hard error.
+      if (chunkText === undefined || chunkText.length === 0) {
+        console.error('[RAGOrchestrator] chunk reached buildContext with no text (F1 regression)', {
+          docId: chunk.docId,
+          chunkIndex: chunk.chunkIndex,
+        });
+        contextParts.push(`[${i + 1}] [MISSING CHUNK TEXT — docId ${chunk.docId}]`);
+      } else {
+        contextParts.push(`[${i + 1}] ${chunkText}`);
       }
       contextParts.push('');
     }
@@ -377,8 +533,19 @@ export class RAGOrchestrator {
 }
 
 /**
- * Convenience function to create a new RAGOrchestrator instance.
+ * Conservative token estimate from character count (F11). The LLM service
+ * exposes no tokenizer, so ~chars/4 is used as a lower-bound approximation with
+ * an explicit safety margin applied by the caller.
+ */
+function estimateTokens(text: string, charsPerToken: number): number {
+  return Math.ceil((text?.length ?? 0) / charsPerToken);
+}
+
+/**
+ * Convenience function to create a new RAGOrchestrator instance. Uses the
+ * offline-first default engine (wllama) via getLLMService() — never WebLLM,
+ * which would fetch weights from a CDN and break the air gap (F10).
  */
 export function getRAGOrchestrator(): RAGOrchestrator {
-  return new RAGOrchestrator();
+  return new RAGOrchestrator({ llmService: getLLMService() });
 }

--- a/web_ui/src/lib/search/keyword-index.ts
+++ b/web_ui/src/lib/search/keyword-index.ts
@@ -40,6 +40,8 @@ interface IndexEntry {
   docId: string;
   chunkIndex: number;
   text: string;
+  source?: string;
+  page?: number;
 }
 
 interface StoredData {
@@ -61,7 +63,7 @@ export class KeywordIndex {
   private disposed: boolean = false;
 
   // In-memory mapping from FlexSearch document ID to chunk metadata
-  private idMapping: Map<string, { docId: string; chunkIndex: number; text: string }> = new Map();
+  private idMapping: Map<string, { docId: string; chunkIndex: number; text: string; source?: string; page?: number }> = new Map();
   // Reverse mapping: docId -> Set of chunk indices
   private docIdToChunks: Map<string, Set<string>> = new Map();
 
@@ -146,8 +148,14 @@ export class KeywordIndex {
    * @param docId - Document ID this chunk belongs to
    * @param chunkIndex - Chunk index within the document
    * @param text - Text content to index
+   * @param meta - Optional filename/page for citation rendering (F7)
    */
-  addDocument(docId: string, chunkIndex: number, text: string): void {
+  addDocument(
+    docId: string,
+    chunkIndex: number,
+    text: string,
+    meta?: { source?: string; page?: number }
+  ): void {
     if (!this.isReady()) {
       throw new Error('KeywordIndex not initialized. Call initialize() first.');
     }
@@ -159,7 +167,7 @@ export class KeywordIndex {
     const id = this.makeChunkId(docId, chunkIndex);
 
     // Store metadata for retrieval
-    this.idMapping.set(id, { docId, chunkIndex, text });
+    this.idMapping.set(id, { docId, chunkIndex, text, source: meta?.source, page: meta?.page });
 
     // Update reverse mapping
     if (!this.docIdToChunks.has(docId)) {
@@ -189,7 +197,10 @@ export class KeywordIndex {
       if (!chunk.docId) {
         throw new Error(`Document chunk missing docId at index ${chunk.chunkIndex}`);
       }
-      this.addDocument(chunk.docId, chunk.chunkIndex, chunk.text);
+      this.addDocument(chunk.docId, chunk.chunkIndex, chunk.text, {
+        source: chunk.source,
+        page: chunk.page,
+      });
     }
 
     console.info(`[KeywordIndex] Batch indexed ${chunks.length} chunks`);
@@ -227,6 +238,8 @@ export class KeywordIndex {
           chunkIndex: meta?.chunkIndex ?? 0,
           score: 1 / (rank + 1), // Position-based scoring: higher rank = higher score
           text: meta?.text,
+          source: meta?.source, // F7: filename for citations
+          page: meta?.page,     // F7: page number for citations
         };
       });
     } catch (error) {
@@ -279,6 +292,8 @@ export class KeywordIndex {
           docId: meta.docId,
           chunkIndex: meta.chunkIndex,
           text: meta.text,
+          source: meta.source,
+          page: meta.page,
         });
       }
 
@@ -366,6 +381,8 @@ export class KeywordIndex {
           docId: entry.docId,
           chunkIndex: entry.chunkIndex,
           text: entry.text,
+          source: entry.source,
+          page: entry.page,
         });
       }
 

--- a/web_ui/src/lib/search/reranker.test.ts
+++ b/web_ui/src/lib/search/reranker.test.ts
@@ -394,12 +394,12 @@ describe('RerankerService', () => {
       });
     });
 
-    test('handles empty text in results', async () => {
+    test('handles empty text in results (F5: empty-text passes through UNSCORED)', async () => {
       const pipeline = pipelineMock as ReturnType<typeof vi.fn> & { dispose: ReturnType<typeof vi.fn> };
+      // Only ONE score is returned because only the non-empty chunk is scored.
       const mockFn = Object.assign(
         vi.fn().mockResolvedValue([
-          { label: 'positive', score: 0.5 }, // empty text
-          { label: 'positive', score: 0.9 }, // non-empty text
+          { label: 'positive', score: 0.9 }, // non-empty text only
         ]),
         { dispose: vi.fn() }
       );
@@ -414,7 +414,20 @@ describe('RerankerService', () => {
       ];
 
       const reranked = asTestResults(await service.rerank('query', asSearchResults(results)));
+
+      // Both results survive.
       expect(reranked).toHaveLength(2);
+      // F5 contract: the cross-encoder must NOT be called with [query, ''] for
+      // the empty-text chunk — only the single non-empty pair is scored.
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockFn).toHaveBeenCalledWith([['query', 'doc 2']]);
+      // The empty-text result passes through UNSCORED (retains its original
+      // score 0.1, not a cross-encoder score), and is appended after the
+      // scored result (score 0.9).
+      expect(reranked[0].score).toBe(0.9);
+      expect(reranked[0].id).toBe('2');
+      expect(reranked[1].score).toBe(0.1);
+      expect(reranked[1].id).toBe('1');
     });
   });
 

--- a/web_ui/src/lib/search/reranker.ts
+++ b/web_ui/src/lib/search/reranker.ts
@@ -182,21 +182,29 @@ export class RerankerService {
     }
 
     try {
-      // Build batch of [query, text] pairs for cross-encoder
+      // Build batch of [query, text] pairs for the cross-encoder. Chunks with no
+      // text are NOT scored (scoring [query, ''] would demote exactly the chunks
+      // we want to keep); they pass through with their input rank preserved so
+      // upstream ordering still applies. After F1 lands this branch is
+      // unreachable — it exists as defense in depth.
       const pairs: [string, string][] = [];
       const resultMap: SearchResult[] = [];
+      const unscored: Array<{ index: number; result: SearchResult }> = [];
 
-      for (const result of results) {
+      for (let i = 0; i < results.length; i++) {
+        const result = results[i];
         const text = result.text || '';
         if (text.trim().length === 0) {
-          // Skip empty texts but preserve them in output
-          pairs.push([query, '']);
-          resultMap.push(result);
+          unscored.push({ index: i, result });
           continue;
         }
-
         pairs.push([query, text]);
         resultMap.push(result);
+      }
+
+      // No scorable pairs: return inputs unchanged.
+      if (pairs.length === 0) {
+        return results;
       }
 
       // Batch inference: call pipeline once with all pairs. Cross-encoder
@@ -204,25 +212,30 @@ export class RerankerService {
       // signature only models string|string[], so cast through unknown.
       const scoreResults = (await (this.crossEncoder as unknown as (input: unknown) => Promise<Array<{ label: string; score: number }>>)(pairs)) as Array<{ label: string; score: number }>;
 
-      // Map scores back to results
-      const scoredResults: Array<{ result: SearchResult; crossScore: number }> = scoreResults.map((scoreResult, i) => ({
-        result: resultMap[i],
-        crossScore: scoreResult.score,
+      // Map scores back to the scored results. Iterate over resultMap (one entry
+      // per scored pair) and read the matching score defensively, in case a
+      // pipeline returns more/fewer scores than pairs.
+      const scoredResults: Array<{ result: SearchResult; crossScore: number }> = resultMap.map((result, i) => ({
+        result,
+        crossScore: scoreResults[i]?.score ?? 0,
       }));
 
       // Sort by cross-encoder score descending
       scoredResults.sort((a, b) => b.crossScore - a.crossScore);
 
-      // Extract reranked results, optionally limiting to topK
-      const reranked = scoredResults
-        .slice(0, topK)
-        .map((sr) => ({
-          ...sr.result,
-          // Vector score replaced by cross-encoder relevance score
-          score: sr.crossScore,
-        }));
+      // Scored results first (cross-encoder score replaces the vector score);
+      // unscored (empty-text) results are appended afterwards in their input
+      // order so they are not lost, but never promoted above scored hits.
+      const rerankedAll = scoredResults.map((sr) => ({
+        ...sr.result,
+        score: sr.crossScore,
+      }));
+      for (const { result } of unscored) {
+        rerankedAll.push(result);
+      }
 
-      return reranked;
+      // Optionally limit to topK
+      return topK !== undefined ? rerankedAll.slice(0, topK) : rerankedAll;
     } catch (error) {
       // Graceful degradation: return original results if reranking fails
       console.warn(

--- a/web_ui/src/lib/search/rrf-fusion.test.ts
+++ b/web_ui/src/lib/search/rrf-fusion.test.ts
@@ -155,8 +155,8 @@ describe('rrfFuse', () => {
     });
   });
 
-  describe('text field preserved from first occurrence', () => {
-    it('uses text from highest-ranked occurrence', () => {
+  describe('metadata merged order-agnostically (F1)', () => {
+    it('uses text from the first occurrence that has it', () => {
       const list1: SearchResult[] = [
         { docId: 'doc-a', chunkIndex: 0, score: 0.9, text: 'text from list1 rank0' },
         { docId: 'doc-b', chunkIndex: 0, score: 0.8, text: 'text from list1 rank1' },
@@ -181,7 +181,7 @@ describe('rrfFuse', () => {
       expect(docC?.text).toBe('text from list2 rank0');
     });
 
-    it('preserves text when only one list has text', () => {
+    it('hydrates text from a later list when the first occurrence lacks it (F1)', () => {
       const list1: SearchResult[] = [
         { docId: 'doc-a', chunkIndex: 0, score: 0.9 },
       ];
@@ -191,10 +191,25 @@ describe('rrfFuse', () => {
 
       const result = rrfFuse([list1, list2]);
 
-      // doc-a in list1 at rank 0 has no text, list2 at rank 0 has text
-      // First occurrence (list1 rank0) has no text, so result should have undefined text
+      // Before F1, "first occurrence wins" locked in undefined even when another
+      // list had real text. Now fusion merges the first NON-EMPTY text, so a
+      // chunk that lost its text in one list is hydrated from the other.
       const docA = result.find((r) => r.docId === 'doc-a');
-      expect(docA?.text).toBeUndefined();
+      expect(docA?.text).toBe('text only in list2');
+    });
+
+    it('merges source and page metadata from whichever list carries them (F7)', () => {
+      const list1: SearchResult[] = [
+        { docId: 'doc-a', chunkIndex: 0, score: 0.9, text: 't', source: 'a.pdf' },
+      ];
+      const list2: SearchResult[] = [
+        { docId: 'doc-a', chunkIndex: 0, score: 0.7, page: 4 },
+      ];
+
+      const result = rrfFuse([list1, list2]);
+      const docA = result.find((r) => r.docId === 'doc-a');
+      expect(docA?.source).toBe('a.pdf');
+      expect(docA?.page).toBe(4);
     });
   });
 });

--- a/web_ui/src/lib/search/rrf-fusion.ts
+++ b/web_ui/src/lib/search/rrf-fusion.ts
@@ -13,7 +13,7 @@ import type { SearchResult } from '../../types/search';
 export function rrfFuse(resultsList: SearchResult[][], k: number = 60): SearchResult[] {
   const rrfScores: Record<
     string,
-    { score: number; docId: string; chunkIndex: number; text?: string }
+    { score: number; docId: string; chunkIndex: number; text?: string; source?: string; page?: number }
   > = {};
 
   for (const results of resultsList) {
@@ -21,19 +21,28 @@ export function rrfFuse(resultsList: SearchResult[][], k: number = 60): SearchRe
       const doc = results[rank];
       const key = `${doc.docId}:${doc.chunkIndex}`;
 
-      // First occurrence wins for the text field (highest rank = lowest rank number)
+      // Ensure an entry exists for this chunk key.
       if (!rrfScores[key]) {
         rrfScores[key] = {
           score: 0,
           docId: doc.docId,
           chunkIndex: doc.chunkIndex,
-          text: doc.text,
         };
       }
+      const entry = rrfScores[key];
+
+      // Merge metadata order-agnostically: first NON-EMPTY value wins for each
+      // field. This makes fusion robust regardless of which input list is first
+      // (defense in depth for F1 — a chunk found only by vector search carries
+      // its text once VectorIndex stores it; a chunk found by both takes text
+      // from whichever list actually has it).
+      if (entry.text === undefined && doc.text !== undefined) entry.text = doc.text;
+      if (entry.source === undefined && doc.source !== undefined) entry.source = doc.source;
+      if (entry.page === undefined && doc.page !== undefined) entry.page = doc.page;
 
       // RRF contribution: 1 / (k + rank + 1)
       // +1 because rank is 0-indexed
-      rrfScores[key].score += 1.0 / (k + rank + 1);
+      entry.score += 1.0 / (k + rank + 1);
     }
   }
 
@@ -45,5 +54,7 @@ export function rrfFuse(resultsList: SearchResult[][], k: number = 60): SearchRe
     chunkIndex: item.chunkIndex,
     score: item.score,
     text: item.text,
+    source: item.source,
+    page: item.page,
   }));
 }

--- a/web_ui/src/lib/search/vector-index.test.ts
+++ b/web_ui/src/lib/search/vector-index.test.ts
@@ -518,6 +518,29 @@ describe('VectorIndex', () => {
       expect(idMapping.get(5)).toEqual({ docId: 'test-doc', chunkIndex: 3 });
     });
 
+    it('stores chunk text/source/page metadata alongside the mapping (F1/F7)', async () => {
+      const instance = VectorIndex.getInstance();
+      await instance.initialize();
+
+      const vector = new Float32Array(384);
+      mockEdgeVecInstance.insert = vi.fn<(_vector: Float32Array) => number>().mockReturnValue(7);
+
+      await instance.addVector(vector, 'doc-1', 2, {
+        text: 'the chunk text',
+        source: 'report.pdf',
+        page: 4,
+      });
+
+      const idMapping = (instance as unknown as {
+        idMapping: Map<number, { docId: string; chunkIndex: number; text?: string; source?: string; page?: number }>;
+      }).idMapping;
+      const entry = idMapping.get(7);
+      expect(entry?.text).toBe('the chunk text');
+      expect(entry?.source).toBe('report.pdf');
+      expect(entry?.page).toBe(4);
+      instance.dispose();
+    });
+
     it('throws on invalid vector dimension', async () => {
       const instance = VectorIndex.getInstance();
       await instance.initialize();
@@ -532,6 +555,145 @@ describe('VectorIndex', () => {
 
       const vector = new Float32Array(384);
       await expect(instance.addVector(vector, 'doc', 0)).rejects.toThrow('not initialized');
+    });
+  });
+
+  // ------------------------------------------------------------------------
+  // Issue #22 F9: versioned re-index. A persisted index whose content version
+  // does not match VECTOR_INDEX_VERSION (CLS pooling / metadata schema change)
+  // must NOT be loaded — the native EdgeVec blob is never read and a reindex
+  // flag is set so the UI can prompt the user.
+  // ------------------------------------------------------------------------
+  describe('versioned re-index (F9)', () => {
+    /**
+     * Build a fake IndexedDB whose mappings store returns a configurable
+     * 'version' row (or none). Used to drive readPersistedVersion without
+     * loading the native EdgeVec blob.
+     */
+    function makeVersionedIdb(versionRow: unknown) {
+      const versionStore: Record<string, unknown> =
+        versionRow === undefined ? {} : { version: versionRow };
+      return {
+        open: vi.fn().mockImplementation(() => {
+          const req = {
+            onsuccess: null as null | (() => void),
+            onerror: null as null | (() => void),
+            onupgradeneeded: null as null | (() => void),
+            result: {
+              objectStoreNames: { contains: () => true },
+              close: vi.fn(),
+              transaction: () => ({
+                objectStore: () => ({
+                  get: (key: string) => {
+                    const r = {
+                      onsuccess: null as null | (() => void),
+                      result: versionStore[key] ?? null,
+                    };
+                    Promise.resolve().then(() => r.onsuccess && r.onsuccess());
+                    return r;
+                  },
+                }),
+                oncomplete: null,
+                onerror: null,
+              }),
+            },
+          };
+          Promise.resolve().then(() => req.onsuccess && req.onsuccess());
+          return req;
+        }),
+      } as unknown as typeof indexedDB;
+    }
+
+    it('skips EdgeVec.load and flags reindex when persisted version mismatches', async () => {
+      (globalThis as { indexedDB?: unknown }).indexedDB = makeVersionedIdb({ key: 'version', version: 1 });
+      try { (globalThis as { localStorage?: Storage }).localStorage?.removeItem('rag-reindex-required'); } catch { /* noop */ }
+
+      const instance = VectorIndex.getInstance();
+      await instance.initialize();
+      const edgevec = await import('edgevec');
+      // The typed edgevec module doesn't expose the static `load` added by the
+      // mock; cast through unknown like the load-ordering tests above.
+      const loadMock = (edgevec as unknown as { load: ReturnType<typeof vi.fn> }).load;
+      loadMock.mockClear();
+
+      const loaded = await instance.load();
+
+      expect(loaded).toBe(false);
+      expect(loadMock).not.toHaveBeenCalled();
+      instance.dispose();
+    });
+
+    it('treats a pre-v2 store with NO version key as incompatible (F9 upgrade path)', async () => {
+      // The realistic upgrade scenario: an index created before this PR has no
+      // 'version' row at all (mean-pooled v1 vectors). This MUST be treated as
+      // incompatible and discarded, NOT loaded.
+      (globalThis as { indexedDB?: unknown }).indexedDB = makeVersionedIdb(undefined);
+      try { (globalThis as { localStorage?: Storage }).localStorage?.removeItem('rag-reindex-required'); } catch { /* noop */ }
+
+      const instance = VectorIndex.getInstance();
+      await instance.initialize();
+      const edgevec = await import('edgevec');
+      const loadMock = (edgevec as unknown as { load: ReturnType<typeof vi.fn> }).load;
+      loadMock.mockClear();
+
+      const loaded = await instance.load();
+
+      expect(loaded).toBe(false);
+      expect(loadMock).not.toHaveBeenCalled();
+      instance.dispose();
+    });
+
+    it('does NOT flag reindex on a brand-new install with no prior corpus (PRR-001)', async () => {
+      // A fresh IndexedDB fires onupgradeneeded with oldVersion 0 (the DB did
+      // not exist before this open). This must be treated as "nothing to check"
+      // (null → proceed), NOT as a pre-v2 store — otherwise every new user sees
+      // a spurious "re-add your documents" notice.
+      const freshIdb = {
+        open: vi.fn().mockImplementation(() => {
+          const req = {
+            onsuccess: null as null | (() => void),
+            onerror: null as null | (() => void),
+            onupgradeneeded: null as null | ((event: IDBVersionChangeEvent) => void),
+            result: {
+              objectStoreNames: { contains: () => true },
+              close: vi.fn(),
+              transaction: () => ({
+                objectStore: () => ({
+                  get: () => {
+                    const r = { onsuccess: null as null | (() => void), result: null };
+                    Promise.resolve().then(() => r.onsuccess && r.onsuccess());
+                    return r;
+                  },
+                }),
+                oncomplete: null,
+                onerror: null,
+              }),
+            },
+          };
+          Promise.resolve()
+            .then(() => req.onupgradeneeded && req.onupgradeneeded({ oldVersion: 0, newVersion: 1 } as IDBVersionChangeEvent))
+            .then(() => req.onsuccess && req.onsuccess());
+          return req;
+        }),
+      } as unknown as typeof indexedDB;
+      (globalThis as { indexedDB?: unknown }).indexedDB = freshIdb;
+      try { (globalThis as { localStorage?: Storage }).localStorage?.removeItem('rag-reindex-required'); } catch { /* noop */ }
+
+      const instance = VectorIndex.getInstance();
+      await instance.initialize();
+      const edgevec = await import('edgevec');
+      const loadMock = (edgevec as unknown as { load: ReturnType<typeof vi.fn> }).load;
+      loadMock.mockClear();
+
+      const loaded = await instance.load();
+
+      // Fresh install: no reindex flag, and the normal load path proceeds
+      // (EdgeVec.load IS called — there's nothing incompatible to discard).
+      expect(loaded).toBe(false); // no saved index exists on a fresh install
+      try {
+        expect((globalThis as { localStorage?: Storage }).localStorage?.getItem('rag-reindex-required')).not.toBe('1');
+      } catch { /* private mode */ }
+      instance.dispose();
     });
   });
 });

--- a/web_ui/src/lib/search/vector-index.ts
+++ b/web_ui/src/lib/search/vector-index.ts
@@ -33,6 +33,21 @@ const DB_NAME = `${USER_PREFIX}-doc-qa-indexes`;
 const INDEX_NAME = `${USER_PREFIX}-doc-qa-index`;
 
 /**
+ * Vector index content version. Bump when the persisted idMapping schema OR the
+ * embedding space changes. On mismatch with a persisted version we treat the
+ * stored index as incompatible and force a re-index (F1/F7 metadata + F9 CLS
+ * pooling both change the schema/space from v1).
+ *
+ * NOTE: this is the *content* version stored as a key alongside the mapping —
+ * it is distinct from the IndexedDB open-schema version (the `1` passed to
+ * indexedDB.open below), which does not change here.
+ */
+export const VECTOR_INDEX_VERSION = 2;
+/** localStorage flag set when a version mismatch invalidates the stored corpus,
+ *  so the UI can show a one-time "re-add your documents" notice. */
+const REINDEX_FLAG_KEY = 'rag-reindex-required';
+
+/**
  * Default configuration for the vector index.
  */
 const DEFAULT_CONFIG: VectorIndexConfig = {
@@ -55,7 +70,7 @@ export class VectorIndex {
   private config: VectorIndexConfig;
   private ready: boolean = false;
   private initPromise: Promise<void> | null = null;
-  private idMapping: Map<number, { docId: string; chunkIndex: number }> = new Map();
+  private idMapping: Map<number, { docId: string; chunkIndex: number; text?: string; source?: string; page?: number }> = new Map();
   private disposed: boolean = false;
 
   /**
@@ -145,8 +160,15 @@ export class VectorIndex {
    * @param vector - The embedding vector to add
    * @param docId - Document ID this vector belongs to
    * @param chunkIndex - Chunk index within the document
+   * @param meta - Optional chunk text/source/page so search() can return real
+   *   text and citation metadata (F1/F7). Omitted by older callers.
    */
-  async addVector(vector: EmbeddingVector, docId: string, chunkIndex: number): Promise<void> {
+  async addVector(
+    vector: EmbeddingVector,
+    docId: string,
+    chunkIndex: number,
+    meta?: { text?: string; source?: string; page?: number }
+  ): Promise<void> {
     if (!this.isReady()) {
       throw new Error('VectorIndex not initialized. Call initialize() first.');
     }
@@ -167,8 +189,14 @@ export class VectorIndex {
       // EdgeVec.insert expects Float32Array, pass directly without conversion
       const internalId = this.index!.insert(vector as Float32Array);
 
-      // Store mapping from internal ID to document metadata
-      this.idMapping.set(internalId, { docId, chunkIndex });
+      // Store mapping from internal ID to document metadata + chunk text (F1/F7)
+      this.idMapping.set(internalId, {
+        docId,
+        chunkIndex,
+        text: meta?.text,
+        source: meta?.source,
+        page: meta?.page,
+      });
     } catch (error) {
       throw new Error(
         `Failed to add vector: ${error instanceof Error ? error.message : String(error)}`,
@@ -231,6 +259,9 @@ export class VectorIndex {
         this.idMapping.set(internalId, {
           docId: entry.docId!,
           chunkIndex: entry.chunkIndex,
+          text: entry.text,      // F1: real chunk text so search() returns it
+          source: entry.source,  // F7: filename for citations
+          page: entry.page,      // F7: page number for citations
         });
       }
       console.info(`[VectorIndex] Batch indexed ${result.inserted} vectors`);
@@ -275,6 +306,9 @@ export class VectorIndex {
           docId: metadata?.docId ?? 'unknown',
           chunkIndex: metadata?.chunkIndex ?? 0,
           score: result.score,
+          text: metadata?.text,     // F1: real chunk text
+          source: metadata?.source, // F7: filename
+          page: metadata?.page,     // F7: page number
         };
       });
     } catch (error) {
@@ -367,9 +401,13 @@ export class VectorIndex {
           id,
           docId: meta.docId,
           chunkIndex: meta.chunkIndex,
+          text: meta.text,
+          source: meta.source,
+          page: meta.page,
         }));
 
         store.put({ key: 'idMapping', data: mappingArray });
+        store.put({ key: 'version', version: VECTOR_INDEX_VERSION });
         tx.oncomplete = () => {
           db.close();
           resolve();
@@ -420,7 +458,13 @@ export class VectorIndex {
           if (result && result.data) {
             this.idMapping.clear();
             for (const item of result.data) {
-              this.idMapping.set(item.id, { docId: item.docId, chunkIndex: item.chunkIndex });
+              this.idMapping.set(item.id, {
+                docId: item.docId,
+                chunkIndex: item.chunkIndex,
+                text: item.text,
+                source: item.source,
+                page: item.page,
+              });
             }
           } else {
             this.idMapping.clear();
@@ -439,13 +483,124 @@ export class VectorIndex {
   }
 
   /**
+   * Read the persisted content version from IndexedDB WITHOUT loading the
+   * native EdgeVec blob. Return contract:
+   *  - `null`  → there is nothing to check: either IndexedDB is unavailable
+   *              (some test contexts) OR the database did not exist before this
+   *              call (a brand-new install with no prior corpus). The caller
+   *              skips the version check and proceeds with the normal load path.
+   *  - `0`     → a mappings store ALREADY EXISTED (pre-upgrade DB) but has no
+   *              version key. This is the signature of a pre-v2 index (v1,
+   *              mean-pooled) — treated as incompatible and forced through the
+   *              re-index path (F9).
+   *  - number  → the persisted version (compare to VECTOR_INDEX_VERSION).
+   *
+   * The fresh-install distinction is critical: opening a non-existent DB fires
+   * `onupgradeneeded` with `oldVersion === 0`, which would otherwise create the
+   * store as a read side-effect and then (finding no version row) look
+   * indistinguishable from a pre-v2 upgrade — producing a spurious re-index
+   * notice for every new user (PRR-001).
+   */
+  private async readPersistedVersion(): Promise<number | null> {
+    // In environments without IndexedDB, return null so the caller proceeds.
+    if (typeof indexedDB === 'undefined') {
+      return null;
+    }
+    return new Promise((resolve) => {
+      const request = indexedDB.open(DB_NAME, 1);
+      // Track whether the DB (and thus the mappings store) existed BEFORE this
+      // open call. A brand-new DB fires onupgradeneeded with oldVersion 0.
+      let createdFresh = false;
+
+      request.onerror = () => resolve(null);
+
+      request.onupgradeneeded = (event: IDBVersionChangeEvent) => {
+        createdFresh = event.oldVersion === 0;
+        const db = request.result;
+        if (!db.objectStoreNames.contains('mappings')) {
+          db.createObjectStore('mappings', { keyPath: 'key' });
+        }
+      };
+
+      request.onsuccess = () => {
+        const db = request.result;
+        // Fresh install (DB did not exist before): nothing to re-index.
+        if (createdFresh) {
+          db.close();
+          resolve(null);
+          return;
+        }
+        if (!db.objectStoreNames.contains('mappings')) {
+          db.close();
+          // Pre-existing DB but no mappings object store → pre-v2 shape.
+          resolve(0);
+          return;
+        }
+        const tx = db.transaction('mappings', 'readonly');
+        const store = tx.objectStore('mappings');
+        const getReq = store.get('version');
+        getReq.onsuccess = () => {
+          db.close();
+          const v = getReq.result?.version;
+          // No version row → pre-v2 (v1) index. Resolve 0 so the mismatch check
+          // forces a re-index rather than loading incompatible mean-pooled vectors.
+          resolve(typeof v === 'number' ? v : 0);
+        };
+        getReq.onerror = () => {
+          db.close();
+          resolve(0);
+        };
+      };
+    });
+  }
+
+  /**
+   * Mark the stored corpus as needing re-indexing (version mismatch). Sets a
+   * localStorage flag the UI reads once and clears on notice dismissal.
+   */
+  private flagReindexRequired(): void {
+    try {
+      if (typeof localStorage !== 'undefined') {
+        localStorage.setItem(REINDEX_FLAG_KEY, '1');
+      }
+    } catch {
+      /* private mode / storage disabled — non-fatal */
+    }
+  }
+
+  /**
    * Load the index from IndexedDB using EdgeVec's native load.
+   *
+   * The persisted content version is checked BEFORE the native EdgeVec blob is
+   * loaded: on mismatch we skip the load entirely (avoiding a stale v1 HNSW
+   * graph whose internal IDs would not match a v2 mapping), flag a re-index,
+   * and return false so the index is treated as empty. This is the F9 re-index
+   * path — triggered by the CLS-pooling change, which moves the embedding
+   * space and makes existing vectors incompatible.
    *
    * @returns true if a saved index was loaded, false if no saved index exists
    */
   async load(): Promise<boolean> {
     if (this.index === null) {
       throw new Error('VectorIndex not initialized');
+    }
+
+    // F9: check the persisted content version BEFORE loading the native blob.
+    // `null` means IndexedDB is unavailable (e.g. a test context) — proceed with
+    // the normal load path. Any non-null value that isn't VECTOR_INDEX_VERSION —
+    // including 0 (a pre-v2/v1 store with no version key, i.e. mean-pooled
+    // vectors from a previous build) — is incompatible and MUST be discarded so
+    // a CLS-pooling client never loads mean-pooled vectors.
+    const persistedVersion = await this.readPersistedVersion();
+    if (persistedVersion !== null && persistedVersion !== VECTOR_INDEX_VERSION) {
+      console.warn(
+        `[VectorIndex] Stored index version ${persistedVersion === 0 ? '1 (pre-versioned)' : persistedVersion} ` +
+        `is incompatible with current version ${VECTOR_INDEX_VERSION} (embedding space changed). ` +
+        `Discarding stored index — re-add documents to rebuild the search index.`
+      );
+      this.idMapping.clear();
+      this.flagReindexRequired();
+      return false;
     }
 
     let loadedIndex = null;

--- a/web_ui/src/lib/streaming/TokenStreamManager.ts
+++ b/web_ui/src/lib/streaming/TokenStreamManager.ts
@@ -4,9 +4,28 @@
  */
 
 import { SSEStreamConsumer } from '../api/streaming';
+import type { SearchResult } from '../../types/search';
 
 type TokenCallback = (token: string) => void;
-type DoneCallback = (data: { sources: string[]; contextLength: number; inferenceTime: number }) => void;
+
+/** Completion payload. Server (SSE) mode fills sources/contextLength/inferenceTime;
+ *  the browser-local RAG mode additionally fills citations, abstention, and
+ *  degradation signals. All RAG-only fields are optional so the server path is
+ *  unaffected. */
+type DoneCallback = (data: {
+  sources: string[];
+  contextLength: number;
+  inferenceTime: number;
+  /** Structured per-chunk citations aligned with the model's [1],[2] order (F7). */
+  chunks?: SearchResult[];
+  /** True when the pipeline abstained instead of answering (F2). */
+  abstain?: boolean;
+  abstainReason?: 'insufficient_evidence' | 'retrieval_degraded';
+  /** True when retrieval ran keyword-only (F4). */
+  retrievalDegraded?: boolean;
+  /** Number of context chunks dropped to fit the token budget (F11). */
+  contextTrimmed?: number;
+}) => void;
 type ErrorCallback = (error: string) => void;
 
 /**
@@ -106,9 +125,19 @@ export class TokenStreamManager {
 
   /**
    * Signal completion of the stream.
-   * @param data - Completion data including sources and inference metrics
+   * @param data - Completion data including sources, inference metrics, and
+   *   optional RAG citation/abstention/degradation signals.
    */
-  complete(data: { sources: string[]; contextLength: number; inferenceTime: number }): void {
+  complete(data: {
+    sources: string[];
+    contextLength: number;
+    inferenceTime: number;
+    chunks?: SearchResult[];
+    abstain?: boolean;
+    abstainReason?: 'insufficient_evidence' | 'retrieval_degraded';
+    retrievalDegraded?: boolean;
+    contextTrimmed?: number;
+  }): void {
     if (this.cancelled) return;
 
     // Flush any remaining tokens first

--- a/web_ui/src/pages/ChatPage.tsx
+++ b/web_ui/src/pages/ChatPage.tsx
@@ -147,7 +147,25 @@ function ChatPageInner({ messages: messagesProp, onMessagesChange, onSaveConvers
     streamManager.onDone((data) => {
       const updated = messagesRef.current.map((msg) =>
         msg.id === assistantMessageId
-          ? { ...msg, isStreaming: false, sources: data.sources }
+          ? {
+              ...msg,
+              isStreaming: false,
+              sources: data.sources,
+              // Structured citations from the retrieved chunks (F7). Map
+              // explicitly to CitationRef so the retrieval-only `score` field
+              // is not persisted into the message / Dexie (PRR-008), and keep
+              // the array in context order so pill [i+1] maps to chunks[i].
+              citations: data.chunks?.map((c) => ({
+                docId: c.docId,
+                chunkIndex: c.chunkIndex,
+                source: c.source,
+                page: c.page,
+                text: c.text,
+              })),
+              abstain: data.abstain,
+              abstainReason: data.abstainReason,
+              retrievalDegraded: data.retrievalDegraded,
+            }
           : msg
       );
       messagesRef.current = updated;
@@ -209,6 +227,11 @@ function ChatPageInner({ messages: messagesProp, onMessagesChange, onSaveConvers
                 sources = event.data.sources;
                 streamManager.complete({
                   sources,
+                  chunks: event.data.chunks,
+                  abstain: event.data.abstain,
+                  abstainReason: event.data.abstainReason,
+                  retrievalDegraded: event.data.retrievalDegraded,
+                  contextTrimmed: event.data.contextTrimmed,
                   contextLength: fullAnswer.length,
                   inferenceTime: Date.now() - startTime,
                 });

--- a/web_ui/src/pages/DocumentsPage.tsx
+++ b/web_ui/src/pages/DocumentsPage.tsx
@@ -21,7 +21,33 @@ export function DocumentsPage() {
   const [documents, setDocuments] = useState<DocumentEntry[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  // F9: one-time banner when the embedding model was upgraded and the stored
+  // vector index was discarded as incompatible (see VECTOR_INDEX_VERSION).
+  const [showReindexNotice, setShowReindexNotice] = useState(false);
   const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // F9: surface the re-index requirement once. The flag is set by VectorIndex
+  // on version mismatch; cleared here on dismiss so the user sees it once.
+  useEffect(() => {
+    try {
+      if (typeof localStorage !== 'undefined' && localStorage.getItem('rag-reindex-required') === '1') {
+        setShowReindexNotice(true);
+      }
+    } catch {
+      /* private mode / storage disabled */
+    }
+  }, []);
+
+  const dismissReindexNotice = useCallback(() => {
+    setShowReindexNotice(false);
+    try {
+      if (typeof localStorage !== 'undefined') {
+        localStorage.removeItem('rag-reindex-required');
+      }
+    } catch {
+      /* private mode / storage disabled */
+    }
+  }, []);
 
   // Load documents from IndexedDB on mount
   useEffect(() => {
@@ -106,7 +132,10 @@ export function DocumentsPage() {
       const vectorIndex = getVectorIndex();
       const keywordIndex = getKeywordIndex();
 
-      // Vector index: embed and add
+      // Vector index: embed and add. Pass the chunk's already-present text,
+      // source (filename) and page so vector search results carry real text and
+      // citation metadata (F1/F7). NOTE: this minimal metadata capture overlaps
+      // with PR-4 (#23), which owns broader ingestion work.
       if (embeddingService.isReady() && vectorIndex.isReady()) {
         try {
           const texts = chunks.map((c) => c.text);
@@ -115,6 +144,9 @@ export function DocumentsPage() {
             docId: chunk.docId!,
             chunkIndex: chunk.chunkIndex,
             vector: vectors[i],
+            text: chunk.text,     // F1: real chunk text for grounded context
+            source: chunk.source, // F7: filename for citations
+            page: chunk.page,     // F7: page number for citations
           }));
           await vectorIndex.addBatch(entries);
           await vectorIndex.save();
@@ -316,6 +348,47 @@ export function DocumentsPage() {
           </span>
         )}
       </div>
+
+      {/* F9: one-time re-index notice after an embedding-model upgrade. */}
+      {showReindexNotice && (
+        <div
+          role="status"
+          aria-live="polite"
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: 'var(--spacing-sm)',
+            padding: 'var(--spacing-sm) var(--spacing-md)',
+            borderRadius: '8px',
+            backgroundColor: 'var(--color-bubble-system)',
+            color: 'var(--color-text-muted)',
+            fontSize: 'var(--font-size-small)',
+            fontFamily: 'var(--font-family)',
+            flexShrink: 0,
+          }}
+        >
+          <span>
+            The search index was upgraded. Re-add your documents to rebuild the index and restore full retrieval quality.
+          </span>
+          <button
+            type="button"
+            onClick={dismissReindexNotice}
+            aria-label="Dismiss notice"
+            style={{
+              background: 'transparent',
+              border: 'none',
+              cursor: 'pointer',
+              color: 'var(--color-text-muted)',
+              fontSize: 'var(--font-size-body)',
+              padding: '0 var(--spacing-xs)',
+              flexShrink: 0,
+            }}
+          >
+            ×
+          </button>
+        </div>
+      )}
 
       {/* Drop zone */}
       <div style={{ flexShrink: 0 }}>

--- a/web_ui/src/types/chat.ts
+++ b/web_ui/src/types/chat.ts
@@ -13,11 +13,32 @@ export interface ChatImage {
   fileName?: string;
 }
 
+/** Structured, per-chunk citation reference rendered as a numbered pill (F7). */
+export interface CitationRef {
+  docId: string;
+  chunkIndex: number;
+  /** Filename of the source document. */
+  source?: string;
+  /** Page number within the source document, when known. */
+  page?: number;
+  /** Chunk text (or a snippet) shown on click-through. */
+  text?: string;
+}
+
 export interface ChatMessage {
   id: string;
   role: MessageRole;
   content: string;
+  /** Source filenames (legacy render path; kept for backward compatibility). */
   sources?: string[];
+  /** Structured numbered citations, aligned with the model's [1],[2] order (F7). */
+  citations?: CitationRef[];
+  /** True when the pipeline abstained (no usable evidence) instead of answering (F2). */
+  abstain?: boolean;
+  /** Why the pipeline abstained. */
+  abstainReason?: 'insufficient_evidence' | 'retrieval_degraded';
+  /** True when retrieval ran keyword-only because semantic search was unavailable (F4). */
+  retrievalDegraded?: boolean;
   timestamp: number;
   isStreaming?: boolean;
   /** Images the user attached to this message (multimodal). */

--- a/web_ui/src/types/embedding.ts
+++ b/web_ui/src/types/embedding.ts
@@ -15,6 +15,12 @@ export interface EmbeddingEntry {
   docId: string;
   chunkIndex: number;
   vector: EmbeddingVector;
+  /** Chunk text, so the vector index can return real text on search (F1). */
+  text?: string;
+  /** Source filename, threaded into citation metadata (F7). */
+  source?: string;
+  /** Page number, threaded into citation metadata (F7). */
+  page?: number;
 }
 
 /**

--- a/web_ui/src/types/search.ts
+++ b/web_ui/src/types/search.ts
@@ -15,6 +15,10 @@ export interface SearchResult {
   score: number;
   /** Optional text content of the chunk */
   text?: string;
+  /** Source filename for citation rendering (F7). */
+  source?: string;
+  /** Page number within the source document, when known (F7). */
+  page?: number;
 }
 
 /**

--- a/web_ui/vitest.config.ts
+++ b/web_ui/vitest.config.ts
@@ -45,6 +45,11 @@ export default defineConfig({
       // the imported path (moved/deleted). Owned by the UI/a11y sibling PR #25.
       'src/components/InferenceModeToggle.test.tsx',
       'src/components/MarkdownRenderer.test.tsx',
+      // SourceCitation.test.tsx: the structured-citations (F7) tests added in
+      // PR #29 pass, but a handful of pre-existing legacy-mode tests (keyboard,
+      // copy-callback, timer-cleanup) have environment-setup failures owned by
+      // the UI/a11y sibling PR #25. Kept excluded until #25 fixes the file's
+      // test environment; the F7 data flow is covered at the orchestrator layer.
       'src/components/SourceCitation.test.tsx',
       // Depend on the unbuilt edgevec WASM snippet (node_modules artifact not
       // present without a build step). Owned by RAG retrieval PR #22.


### PR DESCRIPTION
Closes #22

## Summary

Resolves all 12 findings from the `web_ui/` RAG retrieval-grounding & citation audit (PR-3 of 7), plus follow-ups from a swarm PR review.

The browser-local RAG pipeline no longer grounds the LLM on placeholder strings, no longer hallucinates through a zero-evidence path, degrades gracefully when the embedding model is unavailable, uses the correct BGE pooling + query prefix, defaults to the offline-first engine, budgets context to keep the user's question in-prompt, and renders citations that resolve to a filename + page + chunk text instead of an opaque `docId`.

### Findings closed

**CRITICAL**
- **F1** — Vector chunks no longer lose their text. `VectorIndex.idMapping` stores `text`/`source`/`page`; `search()` returns them; RRF merges metadata order-agnostically; `buildContext` emits a sentinel + `console.error` (never a placeholder) if a chunk ever lacks text.

**HIGH**
- **F2** — Zero-chunk retrieval (after floor + budget) short-circuits to an abstention event; the UI renders a distinct state.
- **F4** — Embedding-service failure degrades to keyword-only retrieval (the readiness boolean is no longer discarded).
- **F7** — Structured per-chunk citations (filename, page, text) flow end-to-end; `SourceCitation` renders numbered `[1] filename (p. N)` pills with click-through. Numbering invariant (`complete.chunks[i]` == chunk the model numbered `[i+1]`) preserved and tested.
- **F9** — CLS pooling (model requires it) + versioned re-index that discards incompatible stored indexes — including pre-version-key v1 stores — and flags a UI notice. **Fresh installs are correctly NOT flagged.**
- **F10** — Default engine is wllama (offline-first), not WebLLM (CDN).

**MEDIUM**
- **F3** — Relevance floor by `didRerank` score scale.
- **F8** — BGE query-instruction prefix on the query embedding only.
- **F11** — Token budget (from `DEFAULT_N_CTX`) drops overflow chunks so the question is never truncated.

**LOW / INFO**
- **F5** — Reranker no longer scores `[query, '']` pairs.
- **F6** — Removed duplicate `Context:` header + dead `buildContext` param.
- **F12** — Doc note distinguishes Python BM25 from browser FlexSearch.

### Swarm PR-review follow-ups (resolved)
- **PRR-001** — F9 fresh-install false-positive: a brand-new DB no longer triggers a spurious reindex notice (detects `oldVersion === 0`).
- **PRR-002** — Added SourceCitation structured-citations component tests (numbered pills, page suffix, click-through, precedence).
- **PRR-004** — Strengthened the reranker F5 test (asserts unscored pass-through, not just length).
- **PRR-005** — Reverted unrelated whitespace churn in `RAG_PIPELINE_FIXES_PLAN.md` (kept only the F12 note).
- **PRR-006** — Added an F11 partial-fit test (some chunks fit, some drop).
- **PRR-007** — Added an F8 test proving the prefix is query-only.
- **PRR-008** — `ChatPage` maps `SearchResult[]` → `CitationRef[]` explicitly so the retrieval-only `score` is not persisted to Dexie.
- **PRR-010** — Removed a contradictory duplicate JSDoc.
- **PRR-011** — Left as-is (documented): filtering empty-text chunks from citations would break the F7 numbering invariant; the existing degraded handling (pill renders, Copy hidden) is correct, and the F1 tripwire makes empty-text chunks unreachable post-fix.

### Coordination
- Builds on **#21** (closed). Contains the minimal metadata-capture overlap with **#23** (open) — flagged here, not duplicated. No encroachment on #24/#25/#26.

## Invariant audit
- **Build:** `npm run build` → `✓ built` (exit 0).
- **Typecheck:** `npx tsc --noEmit` and `npx tsc --noEmit -p tsconfig.test.json` → **0 errors** each.
- **Independent adversarial review (GLM-5.2)** ran on the implementation and on the review-follow-up fixes; final critic verdict: APPROVE.

## Test plan
Commands run from `web_ui/`:
```
$ npx vitest run src/lib/rag/ src/lib/search/ src/lib/embeddings/
Test Files  8 passed (8)
Tests       179 passed (179)
```
Regression tests added: F1 tripwire + RRF metadata merge; F2 abstention (LLM never called); F3 floor; F4 degradation (embedding not invoked) + fresh-gate; F7 numbering/order; F8 query-only prefix + passages-un-prefixed; F9 version-mismatch + no-version-key v1 + fresh-install-no-false-positive + CLS pooling; F10 offline default; F11 overflow + partial-fit + question-survives; F5 reranker unscored pass-through; vector-index addVector metadata.

### Known caveats
- **SourceCitation component tests** (`PRR-002`) pass when run, but `SourceCitation.test.tsx` remains in vitest's exclude list because a handful of *pre-existing* legacy-mode tests in the same file have environment-setup failures owned by sibling PR #25. The F7 data flow is covered at the orchestrator layer in the meantime. The exclude comment documents this accurately.
- **F9 stale v1 native blob** is lazily overwritten on the next `save()` (not eagerly deleted) — safe; documented.
- **`contextTrimmed`** is carried on the `complete` event but not yet rendered (available for a future indicator; intentionally deferred).
- **F10** is defensive/hardening: `ChatPage` injects an explicit engine, so the default only affects direct construction.
- Pre-fix persisted messages keep opaque `docId` `sources` and render via the legacy fallback until the conversation is cleared.
