### PR TITLE
fix(web_ui): document ingestion & storage integrity (Issue #23)

### DIFF
--- a/web_ui/src/components/DropZone.tsx
+++ b/web_ui/src/components/DropZone.tsx
@@ -11,6 +11,39 @@ interface DropZoneProps {
   disabled?: boolean;
 }
 
+/**
+ * F15: check whether a file matches an `accept` filter. The native file picker
+ * (<input type="file" accept>) applies this automatically, but the drag-and-
+ * drop path previously forwarded every dropped file regardless of `accept`.
+ * This shared helper normalizes both paths. `accept` is a comma-separated list
+ * of extensions (e.g. ".pdf,.docx,.txt") and/or MIME types; an undefined/empty
+ * accept matches everything.
+ */
+export function matchesAccept(file: File, accept?: string): boolean {
+  if (!accept || accept.trim().length === 0) {
+    return true;
+  }
+  const tokens = accept
+    .split(',')
+    .map((t) => t.trim().toLowerCase())
+    .filter(Boolean);
+  if (tokens.length === 0) {
+    return true;
+  }
+  const name = file.name.toLowerCase();
+  const mime = (file.type ?? '').toLowerCase();
+  return tokens.some((token) => {
+    if (token.startsWith('.')) {
+      return name.endsWith(token);
+    }
+    // MIME token — allow prefix matches like "text/*".
+    if (token.endsWith('/*')) {
+      return mime.startsWith(token.slice(0, -1));
+    }
+    return mime === token;
+  });
+}
+
 export const DropZone: React.FC<DropZoneProps> = React.memo(
   ({ onFilesSelected, accept, disabled = false }) => {
     const inputRef = useRef<HTMLInputElement>(null);
@@ -43,12 +76,15 @@ export const DropZone: React.FC<DropZoneProps> = React.memo(
           return;
         }
 
-        const files = Array.from(e.dataTransfer.files);
+        // F15: apply the same accept filter the native file picker uses, so
+        // unsupported files dropped via drag-and-drop are filtered out instead
+        // of reaching the extractor and failing later.
+        const files = Array.from(e.dataTransfer.files).filter((f) => matchesAccept(f, accept));
         if (files.length > 0) {
           onFilesSelected(files);
         }
       },
-      [disabled, onFilesSelected]
+      [disabled, onFilesSelected, accept]
     );
 
     const handleClick = useCallback(() => {

--- a/web_ui/src/lib/embeddings/embedding-service.test.ts
+++ b/web_ui/src/lib/embeddings/embedding-service.test.ts
@@ -407,6 +407,40 @@ describe('EmbeddingService', () => {
       const texts = ['hello', 123 as unknown as string, 'world'];
       await expect(instance.encodeBatch(texts)).rejects.toThrow('Text at index 1 is not a string');
     });
+
+    it('F14: throws on tensor row-count mismatch instead of silently misassigning vectors', async () => {
+      const embedding = createMockEmbedding();
+      const instance = EmbeddingService.getInstance();
+      await instance.initialize();
+
+      // Simulate a model/runtime returning FEWER rows than requested (e.g. a
+      // future model swap or pooling mismatch). dims[0] must equal batch.length.
+      mockPipelineCallable.mockImplementation((texts: string[]) => {
+        const requested = Array.isArray(texts) ? texts.length : 1;
+        // Return data for only (requested - 1) rows, with dims claiming that count.
+        const returned = Math.max(0, requested - 1);
+        const flatData = new Float32Array(embedding.length * returned);
+        for (let i = 0; i < returned; i++) {
+          flatData.set(embedding, i * embedding.length);
+        }
+        return Promise.resolve({ data: flatData, dims: [returned, embedding.length] });
+      });
+
+      const texts = ['hello', 'world', 'test'];
+      await expect(instance.encodeBatch(texts)).rejects.toThrow(/shape mismatch/i);
+    });
+
+    it('F14: throws when the tensor data is too small for the requested batch', async () => {
+      const instance = EmbeddingService.getInstance();
+      await instance.initialize();
+
+      // dims claim 2 rows but data only holds 1 row worth of elements.
+      mockPipelineCallable.mockImplementation(() =>
+        Promise.resolve({ data: new Float32Array(384), dims: [2, 384] })
+      );
+
+      await expect(instance.encodeBatch(['a', 'b'])).rejects.toThrow(/too small/i);
+    });
   });
 
   describe('isReady()', () => {

--- a/web_ui/src/lib/embeddings/embedding-service.ts
+++ b/web_ui/src/lib/embeddings/embedding-service.ts
@@ -258,6 +258,29 @@ export class EmbeddingService {
           normalize: true,
         }) as { data: Float32Array; dims: number[] };
 
+        // F14: validate the returned tensor shape before slicing. Without this
+        // check, a model/runtime returning fewer rows than requested (e.g. from
+        // a future model swap or a pooling mismatch) would silently produce
+        // zero-filled/short vectors misassigned to the wrong chunks. dims[0] is
+        // the row count; data.length must cover batch.length rows of
+        // EMBEDDING_DIMENSIONS each. (The single-text encode() already checks
+        // embedding length; this is the batch-path analog.)
+        const expectedRows = batch.length;
+        const actualRows =
+          Array.isArray(batchResults.dims) && batchResults.dims.length > 0
+            ? batchResults.dims[0]
+            : Math.floor(batchResults.data.length / EMBEDDING_DIMENSIONS);
+        if (actualRows !== expectedRows) {
+          throw new Error(
+            `Embedding batch shape mismatch: expected ${expectedRows} row(s) but the model returned ${actualRows}`
+          );
+        }
+        if (batchResults.data.length < expectedRows * EMBEDDING_DIMENSIONS) {
+          throw new Error(
+            `Embedding tensor too small: need ${expectedRows * EMBEDDING_DIMENSIONS} elements for ${expectedRows} vector(s), got ${batchResults.data.length}`
+          );
+        }
+
         // batchResults.data is flat with all embeddings concatenated
         // Split into individual embedding vectors
         const embeddingLength = EMBEDDING_DIMENSIONS;

--- a/web_ui/src/lib/embeddings/memory-aware.test.ts
+++ b/web_ui/src/lib/embeddings/memory-aware.test.ts
@@ -1,7 +1,6 @@
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   getDeviceMemory,
-  isDeviceMemoryKnown,
   getMemoryBudget,
   selectModelTier,
   getMemoryPressureStatus,
@@ -210,25 +209,6 @@ describe('memory-aware', () => {
       const budget = getMemoryBudget();
       expect(budget.browserOverheadMB).toBe(1024); // graduated, not 2048
       expect(budget.availableMB).toBe(5120); // 6144 - 1024
-    });
-  });
-
-  describe('isDeviceMemoryKnown', () => {
-    test('returns true when navigator.deviceMemory is a positive number', () => {
-      mockNavigator.deviceMemory = 8;
-      expect(isDeviceMemoryKnown()).toBe(true);
-    });
-
-    test('returns false when navigator.deviceMemory is undefined (Firefox/Safari)', () => {
-      mockNavigator.deviceMemory = undefined;
-      expect(isDeviceMemoryKnown()).toBe(false);
-    });
-
-    test('returns false when navigator.deviceMemory is 0 or negative', () => {
-      mockNavigator.deviceMemory = 0;
-      expect(isDeviceMemoryKnown()).toBe(false);
-      mockNavigator.deviceMemory = -2;
-      expect(isDeviceMemoryKnown()).toBe(false);
     });
   });
 

--- a/web_ui/src/lib/embeddings/memory-aware.test.ts
+++ b/web_ui/src/lib/embeddings/memory-aware.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   getDeviceMemory,
+  isDeviceMemoryKnown,
   getMemoryBudget,
   selectModelTier,
   getMemoryPressureStatus,
@@ -80,12 +81,15 @@ describe('memory-aware', () => {
       expect(budget.availableMB).toBe(2048);
     });
 
-    test('calculates availableMB with no deviceMemory (defaults to 8GB high-capacity, waives overhead — issue #21 F4)', () => {
+    test('calculates availableMB with no deviceMemory (defaults to 8GB high-capacity, waives overhead — issue #21 F4 / #23 F12 graduated taper)', () => {
       mockNavigator.deviceMemory = undefined;
       mockNavigator.userAgent = 'Chrome/120.0.0.0';
 
       const budget = getMemoryBudget();
 
+      // Unknown deviceMemory → getDeviceMemory() returns 8 (Chrome privacy cap,
+      // per #21 F4). The graduated taper (#23 F12) then yields overhead 0 at
+      // rawGD=8, so available = 8192 (consistent with #21's no-false-block intent).
       expect(budget.totalMB).toBe(8192);
       expect(budget.browserOverheadMB).toBe(0);
       expect(budget.availableMB).toBe(8192);
@@ -169,8 +173,9 @@ describe('memory-aware', () => {
     });
 
     test('returns "moderate" when availableMB >= 4096 and < 8192', () => {
-      // 7GB device, Chrome: total=7168, overhead=2048 (since 7<8, no waiver), available=5120
-      // 5120 >= 4096 is TRUE, 5120 >= 8192 is FALSE -> 'moderate'
+      // 7GB device, Chrome (F12 graduated overhead): total=7168,
+      // taper=(8-7)/4=0.25 → overhead=512 → available=6656.
+      // 6656 >= 4096 is TRUE, 6656 >= 8192 is FALSE -> 'moderate'
       mockNavigator.deviceMemory = 7;
       mockNavigator.userAgent = 'Chrome/120.0.0.0';
 
@@ -183,6 +188,47 @@ describe('memory-aware', () => {
       // availableMB = 4096 - 2048 = 2048 < 4096 -> 'critical'
 
       expect(getMemoryPressureStatus()).toBe('critical');
+    });
+
+    test('F12/#21: unknown deviceMemory (Firefox/Safari) does NOT classify as "critical" (avoids false-blocking)', () => {
+      // Combined fix: #21 F4 makes getDeviceMemory() return 8 (high-capacity)
+      // for unknown, and #23 F12's graduated taper yields overhead 0 at rawGD=8.
+      // Net: unknown hardware classifies as "normal", not "critical" — the core
+      // goal of both findings (don't false-block Firefox/Safari/CPU-engine users).
+      mockNavigator.deviceMemory = undefined;
+      mockNavigator.userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.1 Safari/605.1.15';
+
+      expect(getMemoryPressureStatus()).not.toBe('critical');
+    });
+
+    test('F12: graduated taper gives known mid-range hardware a proportionate (not full) overhead', () => {
+      // The novel #23 F12 contribution: a KNOWN 6GB machine no longer pays the
+      // full 2048MB overhead (the old binary cliff). taper=(8-6)/4=0.5 → 1024.
+      mockNavigator.deviceMemory = 6;
+      mockNavigator.userAgent = 'Chrome/120.0.0.0';
+
+      const budget = getMemoryBudget();
+      expect(budget.browserOverheadMB).toBe(1024); // graduated, not 2048
+      expect(budget.availableMB).toBe(5120); // 6144 - 1024
+    });
+  });
+
+  describe('isDeviceMemoryKnown', () => {
+    test('returns true when navigator.deviceMemory is a positive number', () => {
+      mockNavigator.deviceMemory = 8;
+      expect(isDeviceMemoryKnown()).toBe(true);
+    });
+
+    test('returns false when navigator.deviceMemory is undefined (Firefox/Safari)', () => {
+      mockNavigator.deviceMemory = undefined;
+      expect(isDeviceMemoryKnown()).toBe(false);
+    });
+
+    test('returns false when navigator.deviceMemory is 0 or negative', () => {
+      mockNavigator.deviceMemory = 0;
+      expect(isDeviceMemoryKnown()).toBe(false);
+      mockNavigator.deviceMemory = -2;
+      expect(isDeviceMemoryKnown()).toBe(false);
     });
   });
 

--- a/web_ui/src/lib/embeddings/memory-aware.ts
+++ b/web_ui/src/lib/embeddings/memory-aware.ts
@@ -40,16 +40,6 @@ export function getDeviceMemory(): number {
 }
 
 /**
- * Whether navigator.deviceMemory reported a real value. Firefox and Safari do
- * not implement the Device Memory API, so this returns false there. Used by
- * `getMemoryBudget` to avoid forcing those browsers into the worst-case tier.
- */
-export function isDeviceMemoryKnown(): boolean {
-  const deviceMemory = (navigator as { deviceMemory?: number }).deviceMemory;
-  return typeof deviceMemory === 'number' && deviceMemory > 0;
-}
-
-/**
  * Estimates available memory budget after accounting for browser overhead.
  *
  * F12 (reconciled with issue #21 F4): the binary "isHighCapacity = rawGD >= 8 ?

--- a/web_ui/src/lib/embeddings/memory-aware.ts
+++ b/web_ui/src/lib/embeddings/memory-aware.ts
@@ -27,7 +27,7 @@ export type MemoryPressureStatus = 'normal' | 'moderate' | 'critical';
  * browser overhead down below the model requirement, hard-blocking the CPU
  * wllama engine — the engine that exists precisely for WebGPU-less / memory
  * constrained machines. Treating unknown as high-capacity waives the overhead
- * subtraction (see getMemoryBudget's isHighCapacity branch) and lets the model
+ * subtraction (see getMemoryBudget's graduated taper) and lets the model
  * gate decide on its own merits instead of false-blocking on unknown hardware.
  * (issue #21 F4)
  */
@@ -40,12 +40,25 @@ export function getDeviceMemory(): number {
 }
 
 /**
- * Estimates available memory budget after accounting for browser overhead
- * Browser overhead varies by browser family
+ * Whether navigator.deviceMemory reported a real value. Firefox and Safari do
+ * not implement the Device Memory API, so this returns false there. Used by
+ * `getMemoryBudget` to avoid forcing those browsers into the worst-case tier.
+ */
+export function isDeviceMemoryKnown(): boolean {
+  const deviceMemory = (navigator as { deviceMemory?: number }).deviceMemory;
+  return typeof deviceMemory === 'number' && deviceMemory > 0;
+}
+
+/**
+ * Estimates available memory budget after accounting for browser overhead.
  *
- * Note: navigator.deviceMemory caps at 8GB for privacy in Chrome.
- * When raw value >= 8, we waive overhead subtraction because actual
- * RAM on such systems is far higher (typically 16GB+).
+ * F12 (reconciled with issue #21 F4): the binary "isHighCapacity = rawGD >= 8 ?
+ * 0 : overhead" cliff is replaced with a graduated taper so KNOWN mid-range
+ * hardware (5/6/7GB) gets a proportionate overhead estimate rather than the
+ * full worst-case subtraction. Unknown deviceMemory returns 8 from
+ * getDeviceMemory() (the Chrome privacy cap) per #21 F4, which tapers to zero
+ * overhead here — consistent with #21's intent of not false-blocking the CPU
+ * wllama engine on unknown hardware.
  */
 export function getMemoryBudget(): MemoryBudget {
   const rawGD = getDeviceMemory();
@@ -53,10 +66,12 @@ export function getMemoryBudget(): MemoryBudget {
 
   const userAgent = navigator.userAgent;
   const isFirefox = /Firefox/i.test(userAgent);
-  // navigator.deviceMemory caps at 8GB for privacy. Waive overhead when
-  // at the cap — the actual RAM on such systems is far higher.
-  const isHighCapacity = rawGD >= 8;
-  const browserOverheadMB = isHighCapacity ? 0 : (isFirefox ? 2560 : 2048);
+  const baseOverheadMB = isFirefox ? 2560 : 2048;
+  // Graduated taper: 1.0 at rawGD<=4, 0.0 at rawGD>=8. Linear between.
+  // (navigator.deviceMemory caps at 8 in Chrome, so reported 8 already means
+  // "8GB or more" — tapering to 0 there keeps those systems in 'normal'.)
+  const taper = Math.max(0, Math.min(1, (8 - rawGD) / 4));
+  const browserOverheadMB = Math.round(baseOverheadMB * taper);
 
   const availableMB = Math.max(0, totalMB - browserOverheadMB);
 

--- a/web_ui/src/lib/processing/extractor-factory.ts
+++ b/web_ui/src/lib/processing/extractor-factory.ts
@@ -35,14 +35,37 @@ const EXTRACTOR_MAP: Record<string, (file: File) => Promise<ExtractionResult>> =
  * to detect mismatches between the file's declared type and its extension.
  * A file with no MIME type (empty string) or application/octet-stream
  * is treated as "unknown" and accepted based on extension heuristic.
+ *
+ * F15: the allowlist includes common real-world MIME variants that browsers
+ * and OSes attach to these document types (e.g. `application/x-pdf`,
+ * `application/x-zip-compressed` on Windows, `application/download`), so
+ * legitimate files are not rejected. Previously only the canonical MIME per
+ * type passed, causing false rejects.
  */
 const MIME_COMPATIBILITY: Record<string, readonly string[]> = {
-  '.pdf': ['application/pdf'],
-  '.docx': ['application/vnd.openxmlformats-officedocument.wordprocessingml.document', 'application/zip'],
-  '.xlsx': ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', 'application/vnd.ms-excel', 'application/zip'],
+  '.pdf': ['application/pdf', 'application/x-pdf', 'application/force-download'],
+  '.docx': [
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    'application/zip',
+    'application/x-zip-compressed',
+    'application/octet-stream',
+  ],
+  '.xlsx': [
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    'application/vnd.ms-excel',
+    'application/zip',
+    'application/x-zip-compressed',
+    'application/octet-stream',
+  ],
   '.txt': ['text/plain', 'text/markdown', 'application/octet-stream'],
-  '.md':  ['text/plain', 'text/markdown', 'text/x-markdown', 'application/octet-stream'],
-  '.pptx': ['application/vnd.openxmlformats-officedocument.presentationml.presentation', 'application/vnd.ms-powerpoint', 'application/zip'],
+  '.md': ['text/plain', 'text/markdown', 'text/x-markdown', 'application/octet-stream'],
+  '.pptx': [
+    'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+    'application/vnd.ms-powerpoint',
+    'application/zip',
+    'application/x-zip-compressed',
+    'application/octet-stream',
+  ],
 };
 
 /**

--- a/web_ui/src/lib/processing/text-chunker.test.ts
+++ b/web_ui/src/lib/processing/text-chunker.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Tests for TextChunker (F6/F7/F8/F9 of issue #23).
+ *
+ * Covers:
+ *  - F7: chunkOverlap:1 terminates (acceptance criterion) and overlap depth
+ *  - F6: CJK/no-whitespace text does not collapse into a single mega-chunk
+ *  - F8: page attribution by char offset (later chunks get the right page)
+ *  - F9: abbreviation case preservation + e.g./i.e. protection
+ */
+
+import { describe, it, expect } from 'vitest';
+import { TextChunker } from './text-chunker';
+import type { ExtractedPage } from '../../types/document';
+
+describe('TextChunker', () => {
+  describe('basic chunking', () => {
+    it('chunks plain ASCII text into one or more chunks', () => {
+      const chunker = new TextChunker(10, 2);
+      const text = 'The quick brown fox jumps over the lazy dog repeatedly today.';
+      const chunks = chunker.chunkText(text, 'test.txt');
+      expect(chunks.length).toBeGreaterThan(0);
+      for (const c of chunks) {
+        expect(c.source).toBe('test.txt');
+        expect(c.text.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('assigns a charOffset to every chunk', () => {
+      const chunker = new TextChunker(4, 1);
+      const text = 'One sentence here. Another sentence follows. A third one ends.';
+      const chunks = chunker.chunkText(text, 'test.txt');
+      expect(chunks.length).toBeGreaterThan(1);
+      for (const c of chunks) {
+        expect(typeof c.charOffset).toBe('number');
+        expect(c.charOffset!).toBeGreaterThanOrEqual(0);
+      }
+    });
+  });
+
+  describe('F7: chunkOverlap = 1 (off-by-zero fix)', () => {
+    it('TERMINATES when chunkOverlap is 1 (acceptance criterion)', () => {
+      // A single over-long sentence with >chunkSize words forces the long-
+      // sentence split path that previously looped forever at overlap=1.
+      const chunker = new TextChunker(8, 1);
+      const words = Array.from({ length: 60 }, (_, i) => `word${i}`);
+      const longSentence = words.join(' ');
+
+      // The call must return (not hang). Wrap with a bounded guard via a flag.
+      let result;
+      let returned = false;
+      setTimeout(() => {
+        if (!returned) {
+          throw new Error('TextChunker with overlap=1 did not terminate within timeout');
+        }
+      }, 5000);
+      result = chunker.chunkText(longSentence, 'long.txt');
+      returned = true;
+
+      expect(result.length).toBeGreaterThan(0);
+      // Each chunk should be at most chunkSize words (8).
+      for (const c of result) {
+        const wc = c.text.split(/\s+/).length;
+        expect(wc).toBeLessThanOrEqual(8);
+      }
+    });
+
+    it('makes forward progress — chunk indices are unique and increasing', () => {
+      const chunker = new TextChunker(8, 1);
+      const words = Array.from({ length: 40 }, (_, i) => `w${i}`);
+      const chunks = chunker.chunkText(words.join(' '), 'long.txt');
+      const indices = chunks.map((c) => c.chunkIndex);
+      // Strictly increasing unique indices.
+      for (let i = 1; i < indices.length; i++) {
+        expect(indices[i]).toBeGreaterThan(indices[i - 1]);
+      }
+    });
+
+    it('overlap=1 produces a small (1-word) overlap, not the whole chunk', () => {
+      const chunker = new TextChunker(8, 1);
+      const words = Array.from({ length: 40 }, (_, i) => `word${i}`);
+      const chunks = chunker.chunkText(words.join(' '), 'long.txt');
+      expect(chunks.length).toBeGreaterThan(1);
+      // The first word of chunk[n+1] should equal the last word of chunk[n]
+      // (that's the 1-word overlap). It should NOT equal the first word of
+      // chunk[n] (which would indicate the whole-chunk regression).
+      for (let i = 1; i < chunks.length; i++) {
+        const prevWords = chunks[i - 1].text.split(/\s+/);
+        const currWords = chunks[i].text.split(/\s+/);
+        // With overlap=1, the first word of the current chunk repeats the last
+        // word of the previous chunk.
+        expect(currWords[0]).toBe(prevWords[prevWords.length - 1]);
+      }
+    });
+  });
+
+  describe('F6: CJK / no-whitespace chunking', () => {
+    it('CJK text without spaces is split into multiple chunks, not one mega-chunk', () => {
+      // 200 Chinese characters with no spaces. The ASCII path would treat the
+      // whole thing as ~1 "word" and never split it.
+      const chunker = new TextChunker(50, 10);
+      // Use a repeating CJK sentence with a terminator so sentence splitting works.
+      const sentence = '今天天气真好我们一起去公园散步吧。';
+      const text = sentence.repeat(20); // ~720 chars
+      const chunks = chunker.chunkText(text, 'cjk.txt');
+
+      expect(chunks.length).toBeGreaterThan(1);
+      // No single chunk should swallow the whole document.
+      for (const c of chunks) {
+        expect(c.text.length).toBeLessThan(text.length);
+      }
+      // Reassembled text covers the input content (allowing for overlap).
+      const rejoined = chunks.map((c) => c.text).join('');
+      // The CJK characters should all be present somewhere.
+      for (const ch of sentence) {
+        expect(rejoined).toContain(ch);
+      }
+    });
+
+    it('ASCII text is still chunked by words (not chars) — regression guard', () => {
+      const chunker = new TextChunker(5, 1);
+      const text = 'alpha bravo charlie delta echo foxtrot golf hotel india juliet';
+      const chunks = chunker.chunkText(text, 'ascii.txt');
+      expect(chunks.length).toBeGreaterThan(1);
+      // Each ASCII chunk should be at most chunkSize words.
+      for (const c of chunks) {
+        expect(c.text.split(/\s+/).length).toBeLessThanOrEqual(5);
+      }
+    });
+  });
+
+  describe('F8: page attribution by char offset', () => {
+    it('attributes later chunks to the correct page (not just page 1)', () => {
+      // Two pages of distinct content. Page 1 is short; page 2 is long enough
+      // to produce multiple chunks. The page-2 chunks must report page 2.
+      const page1Text = 'Page one introduction text here. Short page.';
+      const page2Text = Array.from({ length: 20 }, (_, i) => `Detail number ${i} on the second page.`).join(' ');
+      const pages: ExtractedPage[] = [
+        { pageNumber: 1, text: page1Text },
+        { pageNumber: 2, text: page2Text },
+      ];
+      const fullText = `${page1Text}\n\n${page2Text}`;
+
+      const chunker = new TextChunker(10, 2);
+      const chunks = chunker.chunkText(fullText, 'doc.pdf', pages);
+
+      expect(chunks.length).toBeGreaterThan(1);
+      // At least one chunk should be attributed to page 2.
+      const page2Chunks = chunks.filter((c) => c.page === 2);
+      expect(page2Chunks.length).toBeGreaterThan(0);
+      // And at least one chunk attributed to page 1.
+      const page1Chunks = chunks.filter((c) => c.page === 1);
+      expect(page1Chunks.length).toBeGreaterThan(0);
+    });
+
+    it('returns undefined page when no pages are provided', () => {
+      const chunker = new TextChunker(5, 1);
+      const chunks = chunker.chunkText('alpha bravo charlie delta echo foxtrot', 'none.txt');
+      expect(chunks.length).toBeGreaterThan(0);
+      for (const c of chunks) {
+        expect(c.page).toBeUndefined();
+      }
+    });
+  });
+
+  describe('F9: abbreviation protection', () => {
+    it('preserves the original casing of protected abbreviations (Dr. not dr.)', () => {
+      const chunker = new TextChunker();
+      const chunks = chunker.chunkText('See Dr. Smith today. He is here.', 'test.txt');
+      const rejoined = chunks.map((c) => c.text).join(' ');
+      // The abbreviation must keep its capital D.
+      expect(rejoined).toContain('Dr.');
+      expect(rejoined).not.toContain('dr. Smith');
+    });
+
+    it('does not split on dotted abbreviations e.g. and i.e.', () => {
+      const chunker = new TextChunker();
+      // A chunker with a large chunk size keeps the whole text in one chunk;
+      // what matters is that the sentence splitter did not fragment it.
+      const text = 'Buy fruit, e.g. apples. They are cheap.';
+      const chunks = chunker.chunkText(text, 'test.txt');
+      const rejoined = chunks.map((c) => c.text).join(' ');
+      expect(rejoined).toContain('e.g.');
+      // splitSentences should not treat "e.g." as a sentence boundary.
+      const sentences = chunker.splitSentences(text);
+      // "e.g." should not have created a break between "apples" and the next clause.
+      const rejoinedSentences = sentences.join(' ');
+      expect(rejoinedSentences).toContain('e.g.');
+    });
+
+    it('preserves case of single-letter initials (A. B.)', () => {
+      const chunker = new TextChunker();
+      const chunks = chunker.chunkText('I spoke with J. R. yesterday. He agreed.', 'test.txt');
+      const rejoined = chunks.map((c) => c.text).join(' ');
+      expect(rejoined).toContain('J.');
+      expect(rejoined).toContain('R.');
+    });
+  });
+});

--- a/web_ui/src/lib/processing/text-chunker.ts
+++ b/web_ui/src/lib/processing/text-chunker.ts
@@ -9,10 +9,23 @@ import type { DocumentChunk, ExtractedPage } from '../../types/document';
 const ABBREVIATIONS = new Set([
   'dr', 'mr', 'mrs', 'ms', 'prof', 'jr', 'sr', 'st', 'ave', 'blvd',
   'dept', 'rev', 'vol', 'fig', 'ed', 'eds', 'repr', 'trans', 'pt',
-  'ch', 'sec', 'app', 'ex', 'cf', 'eg', 'ie', 'etc', 'approx',
+  'ch', 'sec', 'app', 'ex', 'cf', 'etc', 'approx',
   'esp', 'viz', 'al', 'vs', 'inc', 'corp', 'ltd', 'govt', 'est',
   'acct', 'tel', 'ref',
+  // F9: 'eg'/'ie' removed from the contiguous set — they never matched real
+  // dotted text (e.g./i.e.). Dotted forms are handled separately below.
 ]);
+
+/**
+ * Dotted multi-letter abbreviations (F9) written with internal periods, e.g.
+ * "e.g." and "i.e.". Each entry is [firstLetter, secondLetter]; the protector
+ * replaces the periods with the null marker so they don't trigger a sentence
+ * split, preserving the original casing of both letters.
+ */
+const DOTTED_ABBREVIATIONS: ReadonlyArray<readonly [string, string]> = [
+  ['e', 'g'],
+  ['i', 'e'],
+];
 
 /**
  * Text chunker that splits documents into overlapping chunks
@@ -79,24 +92,42 @@ export class TextChunker {
    * Split paragraph into sentences, respecting common abbreviations.
    * Ports Python's _split_sentences method.
    *
+   * F9: abbreviation protection now PRESERVES the original casing (previously
+   * it lowercased protected abbreviations, e.g. "Dr." -> "dr."). Dotted forms
+   * (e.g./i.e.) are also protected.
+   *
+   * F6: CJK sentence terminators (。！？) are recognized as boundaries so CJK
+   * text without ASCII whitespace/punctuation is still segmented.
+   *
    * @param paragraph - Text to split into sentences
    * @returns Array of sentence strings
    */
   splitSentences(paragraph: string): string[] {
-    // Protect abbreviations by temporarily replacing '.' with null char
+    // Protect abbreviations by temporarily replacing '.' with null char.
+    // F9: capture the matched token so the original casing is restored (the
+    // previous code substituted a lowercase literal, corrupting "Dr." -> "dr.").
     let protected_ = paragraph;
     for (const abbr of ABBREVIATIONS) {
       protected_ = protected_.replace(
-        new RegExp(`\\b${abbr}\\.`, 'gi'),
-        `${abbr}\x00`
+        new RegExp(`\\b(${abbr})\\.`, 'gi'),
+        (_m, g1) => `${g1}\x00`
+      );
+    }
+
+    // F9: protect dotted abbreviations (e.g., i.e.) preserving case of both letters.
+    for (const [a, b] of DOTTED_ABBREVIATIONS) {
+      protected_ = protected_.replace(
+        new RegExp(`\\b(${a})\\.(${b})\\.`, 'gi'),
+        (_m, g1, g2) => `${g1}\x00${g2}\x00`
       );
     }
 
     // Protect single initials (A., B., etc.)
     protected_ = protected_.replace(/\b([A-Z])\./g, '$1\x00');
 
-    // Split on sentence boundaries (after .!?) followed by whitespace
-    const sentences = protected_.split(/(?<=[.!?])\s+/);
+    // Split on sentence boundaries: ASCII (.!?) followed by whitespace, OR CJK
+    // terminators (。！？) which need no trailing whitespace (F6).
+    const sentences = protected_.split(/(?<=[.!?])\s+|(?<=[。！？])/);
 
     return sentences
       .map((s) => s.replace(/\x00/g, '.').trim())
@@ -107,62 +138,129 @@ export class TextChunker {
    * Calculate sentences to keep for overlap from the end of a chunk.
    * Ports Python's _calculate_overlap method.
    *
+   * F6: unit-aware — counts characters for CJK-dense sentences, words
+   * otherwise, matching the chunk-sizing decision.
+   *
    * @param sentences - Array of sentences in the current chunk
-   * @param overlapSize - Maximum word count for overlap
-   * @returns Tuple of [overlap sentences, overlap word count]
+   * @param overlapSize - Maximum unit count for overlap
+   * @returns Tuple of [overlap sentences, overlap unit count]
    */
   private calculateOverlap(
     sentences: string[],
     overlapSize: number
   ): [string[], number] {
     const overlapSentences: string[] = [];
-    let overlapWordCount = 0;
+    let overlapUnitCount = 0;
 
     for (let i = sentences.length - 1; i >= 0; i--) {
       const s = sentences[i];
-      const sWordCount = s.split(/\s+/).length;
+      const sUnitCount = this.countUnits(s);
 
-      if (overlapWordCount + sWordCount <= overlapSize) {
+      if (overlapUnitCount + sUnitCount <= overlapSize) {
         overlapSentences.unshift(s);
-        overlapWordCount += sWordCount;
+        overlapUnitCount += sUnitCount;
       } else {
         break;
       }
     }
 
-    return [overlapSentences, overlapWordCount];
+    return [overlapSentences, overlapUnitCount];
   }
 
   /**
-   * Find the page number for a chunk text using prefix matching.
-   * Ports Python's internal _find_page helper.
-   *
-   * @param chunkText - The chunk text to match
-   * @param paraPageMap - Map of text prefixes to page numbers
-   * @returns Page number or undefined if not found
+   * F8: find the page whose [startChar, endChar) range contains the chunk's
+   * start offset into the cleaned full text. Replaces the unreliable prefix
+   * matching (which only attributed chunk 0 correctly). Falls back to
+   * undefined when no page boundaries were provided or none contain the offset.
    */
-  private findPage(
-    chunkText: string,
-    paraPageMap: Map<string, number>
+  private findPageByOffset(
+    offset: number,
+    pageBoundaries: Array<{ pageNumber: number; startChar: number; endChar: number }>
   ): number | undefined {
-    if (!paraPageMap.size) {
+    if (pageBoundaries.length === 0) {
       return undefined;
     }
-
-    // Try longest prefix match first
-    for (let length = chunkText.length; length > 0; length--) {
-      const prefix = chunkText.slice(0, length).trim();
-      if (prefix && paraPageMap.has(prefix)) {
-        return paraPageMap.get(prefix);
+    for (const b of pageBoundaries) {
+      if (offset >= b.startChar && offset < b.endChar) {
+        return b.pageNumber;
       }
     }
-
+    // Offset at/after the last page boundary (e.g. trailing whitespace) → last page.
+    const last = pageBoundaries[pageBoundaries.length - 1];
+    if (offset >= last.startChar) {
+      return last.pageNumber;
+    }
     return undefined;
   }
 
   /**
+   * F6: detect whether text is CJK-dense (or otherwise lacks whitespace word
+   * boundaries). When true, the chunker switches from word-count to
+   * character-count sizing so such documents don't collapse into one giant
+   * chunk.
+   *
+   * Heuristic: count whitespace characters. Real CJK / no-space text has
+   * essentially ZERO spaces, so the space-to-character ratio is the most
+   * reliable signal. A threshold of "< 1 space per 20 characters" catches CJK
+   * paragraphs (which have no inter-word spaces) while leaving normal English
+   * (≈1 space per 5-6 chars) on the word-based path. The earlier avg-token-
+   * length > 6 heuristic was too aggressive: English with 6+ char words
+   * (e.g. "word0 word1 ...") falsely tripped it.
+   */
+  private isCjkDense(text: string): boolean {
+    if (text.length === 0) {
+      return false;
+    }
+    const spaceCount = (text.match(/\s/g) ?? []).length;
+    // Fewer than 1 whitespace char per 20 characters → treat as space-less.
+    return spaceCount * 20 < text.length;
+  }
+
+  /**
+   * F6: count "units" in text — words for whitespace-delimited text, characters
+   * for CJK-dense text. Returns the count to use for chunk-size decisions.
+   */
+  private countUnits(text: string): number {
+    if (this.isCjkDense(text)) {
+      return text.length;
+    }
+    return text.split(/\s+/).filter(Boolean).length;
+  }
+
+  /**
+   * F6: split a unit string into N pieces for CJK-dense (character-based) or
+   * ASCII (word-based) text. Returns the joined piece and the consumed units.
+   */
+  private sliceUnits(text: string, count: number): string {
+    if (this.isCjkDense(text)) {
+      return text.slice(0, count);
+    }
+    return text.split(/\s+/).slice(0, count).join(' ');
+  }
+
+  /**
+   * F6: take the trailing `count` units from text (for overlap).
+   */
+  private trailingUnits(text: string, count: number): string {
+    if (this.isCjkDense(text)) {
+      return count > 0 ? text.slice(-count) : '';
+    }
+    const words = text.split(/\s+/);
+    return words.slice(-count).join(' ');
+  }
+
+  /**
    * Split text into overlapping chunks respecting paragraph and sentence boundaries.
-   * Ports Python's chunk_text method.
+   *
+   * F6: CJK/no-whitespace text is chunked by character count instead of word
+   * count, so it doesn't collapse into a single mega-chunk.
+   * F7: the long-sentence split loop now guarantees forward progress for every
+   * overlap value (overlap=1 no longer loops forever).
+   * F8: page attribution uses each chunk's char offset into the cleaned full
+   * text, cross-referenced against per-page boundaries, instead of prefix
+   * matching. Offsets are assigned in a post-processing pass (forward substring
+   * search in whitespace-normalized space) so the chunking state machine stays
+   * simple and the attribution is robust against paragraph-boundary joins.
    *
    * @param text - Full text to chunk
    * @param source - Source identifier (e.g., filename)
@@ -174,29 +272,14 @@ export class TextChunker {
     source: string,
     pages?: ExtractedPage[]
   ): DocumentChunk[] {
-    text = this.cleanText(text);
+    const cleanedText = this.cleanText(text);
 
-    // Build page mapping from PDF pages
-    const paraPageMap = new Map<string, number>();
-    if (pages) {
-      for (const page of pages) {
-        const cleaned = page.text.trim().replace(/\s+/g, ' ');
-        for (const segment of cleaned.split('\n\n')) {
-          const seg = segment.trim();
-          if (seg) {
-            // Store first 80 chars as key (same as Python)
-            paraPageMap.set(seg.slice(0, 80), page.pageNumber);
-          }
-        }
-      }
-    }
-
-    const paragraphs = text.split('\n\n').filter((p) => p.trim());
+    const paragraphs = cleanedText.split('\n\n').filter((p) => p.trim());
 
     const chunks: DocumentChunk[] = [];
     let chunkIndex = 0;
     let currentChunkSentences: string[] = [];
-    let currentChunkWordCount = 0;
+    let currentChunkUnitCount = 0;
 
     for (const paragraph of paragraphs) {
       const sentences = this.splitSentences(paragraph);
@@ -207,36 +290,59 @@ export class TextChunker {
           continue;
         }
 
-        const sentenceWordCount = sentence.split(/\s+/).length;
+        const sentenceUnitCount = this.countUnits(sentence);
 
         // If sentence alone exceeds chunk_size and we're starting fresh
         if (
-          sentenceWordCount > this.chunkSize &&
+          sentenceUnitCount > this.chunkSize &&
           currentChunkSentences.length === 0
         ) {
-          // Split sentence into word chunks
-          const words = sentence.split(/\s+/);
-          while (words.length > 0) {
-            const chunkWords = words.slice(0, this.chunkSize);
-            const chunkTextStr = chunkWords.join(' ');
+          // Split the (over-long) sentence into unit chunks.
+          // F6: ASCII → word-based; CJK-dense → character-based.
+          const cjk = this.isCjkDense(sentence);
+          let remaining = sentence;
+          // Safety cap to guarantee termination even if a future edit breaks the
+          // overlap invariant (defense in depth for F7).
+          let guard = 0;
+          const guardMax = Math.ceil(sentence.length / Math.max(1, this.chunkSize)) * 4 + 16;
+          while (remaining.trim().length > 0 && guard++ < guardMax) {
+            const remainingUnits = cjk ? remaining.length : remaining.split(/\s+/).length;
+            if (remainingUnits === 0) {
+              break;
+            }
+            const piece = this.sliceUnits(remaining, this.chunkSize);
 
             chunks.push({
-              text: chunkTextStr,
+              text: piece,
               source,
               chunkIndex,
-              page: this.findPage(chunkTextStr, paraPageMap),
             });
             chunkIndex++;
 
-            words.splice(0, this.chunkSize);
+            // Remove the consumed units from `remaining`.
+            if (cjk) {
+              remaining = remaining.slice(this.chunkSize);
+            } else {
+              remaining = remaining.split(/\s+/).slice(this.chunkSize).join(' ');
+            }
 
-            if (words.length > 0) {
-              // Overlap handling for split sentence
-              const overlapWords =
+            if (remaining.trim().length > 0) {
+              // F7: overlap handling for the split sentence. Guarantee forward
+              // progress: overlapCount is at least 1 when overlap>0, and is
+              // strictly less than the piece's unit count (min with chunkSize-1),
+              // so each iteration consumes more than it re-adds. Previously
+              // `slice(-Math.floor(overlap/2))` made overlap=1 take the ENTIRE
+              // chunk (slice(-0)===slice(0)) and the loop never terminated.
+              const overlapCount =
                 this.chunkOverlap > 0
-                  ? chunkWords.slice(-Math.floor(this.chunkOverlap / 2))
-                  : [];
-              words.unshift(...overlapWords);
+                  ? Math.min(Math.max(1, Math.floor(this.chunkOverlap / 2)), this.chunkSize - 1)
+                  : 0;
+              if (overlapCount > 0) {
+                const overlapPiece = this.trailingUnits(piece, overlapCount);
+                remaining = cjk
+                  ? overlapPiece + remaining
+                  : [overlapPiece, remaining].filter(Boolean).join(' ');
+              }
             }
           }
           continue; // Move to next sentence
@@ -245,28 +351,27 @@ export class TextChunker {
         // If adding this sentence would exceed chunk_size, finalize current chunk
         if (
           currentChunkSentences.length > 0 &&
-          currentChunkWordCount + sentenceWordCount > this.chunkSize
+          currentChunkUnitCount + sentenceUnitCount > this.chunkSize
         ) {
           const chunkTextStr = currentChunkSentences.join(' ');
           chunks.push({
             text: chunkTextStr,
             source,
             chunkIndex,
-            page: this.findPage(chunkTextStr, paraPageMap),
           });
           chunkIndex++;
 
           // Handle overlap using helper method
-          const [overlapSentences, overlapWordCount] = this.calculateOverlap(
+          const [overlapSentences, overlapUnitCount] = this.calculateOverlap(
             currentChunkSentences,
             this.chunkOverlap
           );
           currentChunkSentences = overlapSentences;
-          currentChunkWordCount = overlapWordCount;
+          currentChunkUnitCount = overlapUnitCount;
         }
 
         currentChunkSentences.push(sentence);
-        currentChunkWordCount += sentenceWordCount;
+        currentChunkUnitCount += sentenceUnitCount;
       }
     }
 
@@ -277,11 +382,77 @@ export class TextChunker {
         text: chunkTextStr,
         source,
         chunkIndex,
-        page: this.findPage(chunkTextStr, paraPageMap),
       });
     }
 
+    // F8: assign charOffset + page attribution in a post-processing pass. Build
+    // a whitespace-normalized view of the full text and locate each chunk's
+    // (similarly normalized) text with a forward-only cursor, so attribution is
+    // robust against paragraph-boundary joins. Page boundaries are computed in
+    // the SAME normalized space from the cleaned page texts.
+    this.assignOffsetsAndPages(chunks, cleanedText, pages);
+
     return chunks;
+  }
+
+  /**
+   * F8: assign `charOffset` and `page` to each chunk by locating its text in a
+   * whitespace-normalized view of the cleaned full text. Page boundaries are
+   * derived from cleaned+normalized page texts (cumulative offsets + single-
+   * space separators), matching the normalized full text. A forward-only cursor
+   * keeps each chunk's offset monotonically increasing even with overlap.
+   */
+  private assignOffsetsAndPages(
+    chunks: DocumentChunk[],
+    cleanedFullText: string,
+    pages?: ExtractedPage[]
+  ): void {
+    // Whitespace-normalize the full text: collapse all runs (\n\n paragraph
+    // breaks and intra-sentence spaces) to single spaces. Chunk texts are built
+    // by joining sentences with single spaces, so they match this view.
+    const normalizedFull = cleanedFullText.replace(/\s+/g, ' ').trim();
+
+    // Build page boundaries in the same normalized space.
+    const pageBoundaries: Array<{ pageNumber: number; startChar: number; endChar: number }> = [];
+    if (pages && pages.length > 0) {
+      let offset = 0;
+      for (const page of pages) {
+        const normalizedPage = this.cleanText(page.text).replace(/\s+/g, ' ').trim();
+        if (normalizedPage.length === 0) {
+          continue;
+        }
+        const start = offset;
+        const end = start + normalizedPage.length;
+        pageBoundaries.push({ pageNumber: page.pageNumber, startChar: start, endChar: end });
+        offset = end + 1; // +1 for the single-space separator in normalized space
+      }
+    }
+
+    let cursor = 0;
+    for (const chunk of chunks) {
+      const needle = chunk.text.replace(/\s+/g, ' ').trim();
+      if (needle.length === 0) {
+        continue;
+      }
+      // Forward-only search: find the chunk's text at or after the cursor.
+      let idx = normalizedFull.indexOf(needle, cursor);
+      if (idx === -1) {
+        // Fall back to a search from the start (overlap may have rewound past
+        // the cursor in edge cases). If still not found, leave the offset/page
+        // unset rather than attributing incorrectly.
+        idx = normalizedFull.indexOf(needle);
+        if (idx === -1) {
+          continue;
+        }
+      }
+      chunk.charOffset = idx;
+      chunk.page = this.findPageByOffset(idx, pageBoundaries);
+      // Advance the cursor past this chunk's start so the next chunk (which
+      // begins later in the document) is located after it. Use idx + 1 rather
+      // than idx + needle.length so overlapping chunks (which share a suffix
+      // with the previous chunk) are still found at their correct position.
+      cursor = idx + 1;
+    }
   }
 
   /**

--- a/web_ui/src/lib/processing/text-chunker.ts
+++ b/web_ui/src/lib/processing/text-chunker.ts
@@ -439,9 +439,15 @@ export class TextChunker {
       if (idx === -1) {
         // Fall back to a search from the start (overlap may have rewound past
         // the cursor in edge cases). If still not found, leave the offset/page
-        // unset rather than attributing incorrectly.
+        // unset rather than attributing incorrectly — but surface it so silent
+        // page-attribution loss is observable (PRR-006).
         idx = normalizedFull.indexOf(needle);
         if (idx === -1) {
+          console.warn(
+            '[TextChunker] Could not locate a chunk in the normalized full text; ' +
+              'leaving its charOffset/page unset. Chunk preview: ' +
+              needle.slice(0, 60)
+          );
           continue;
         }
       }

--- a/web_ui/src/lib/processing/xlsx-extractor.ts
+++ b/web_ui/src/lib/processing/xlsx-extractor.ts
@@ -44,18 +44,19 @@ export async function extractXlsxText(file: File): Promise<ExtractionResult> {
       // Convert sheet to JSON to inspect contents. With `header: 1`, SheetJS
       // returns an array-of-arrays (each row is a cell array), NOT an array of
       // records — so the element type is `unknown[]`.
+      //
+      // F16: keep `blankrows: true` (the default) so each row's array index
+      // corresponds to its ORIGINAL spreadsheet row number. The previous code
+      // dropped blank rows before numbering, so "Row N" labels slid out of sync
+      // with the source file. Empty rows are now skipped at render time while
+      // preserving their original row index.
       const sheetData = XLSX.utils.sheet_to_json<unknown[]>(sheet, {
         header: 1,
         defval: '',
-        blankrows: false,
+        blankrows: true,
       });
 
-      // Filter out completely empty rows
-      const nonEmptyRows = sheetData.filter((row: unknown[]) =>
-        row.some((cell: unknown) => cell !== null && cell !== undefined && cell !== '')
-      );
-
-      if (nonEmptyRows.length === 0) {
+      if (sheetData.length === 0) {
         // Skip empty sheets
         continue;
       }
@@ -66,10 +67,21 @@ export async function extractXlsxText(file: File): Promise<ExtractionResult> {
       const sheetTextLines: string[] = [];
       sheetTextLines.push(`Sheet: ${sheetName}`);
 
-      // Process each row with row numbers
-      for (let rowIndex = 0; rowIndex < nonEmptyRows.length; rowIndex++) {
-        const row = nonEmptyRows[rowIndex];
+      // Process each row using its ORIGINAL index so the displayed "Row N"
+      // matches the spreadsheet's native row number (F16).
+      for (let rowIndex = 0; rowIndex < sheetData.length; rowIndex++) {
+        const row = sheetData[rowIndex];
+        // The source row number is the 1-based position in the original sheet.
         const rowNumber = rowIndex + 1;
+
+        // Skip rows that are entirely empty (do not emit a "Row N:" line), but
+        // do NOT renumber subsequent rows — rowNumber stays the original index.
+        const isEmpty = !row.some(
+          (cell: unknown) => cell !== null && cell !== undefined && cell !== ''
+        );
+        if (isEmpty) {
+          continue;
+        }
 
         // Convert row cells to text
         const rowText = row

--- a/web_ui/src/lib/search/keyword-index.test.ts
+++ b/web_ui/src/lib/search/keyword-index.test.ts
@@ -196,6 +196,38 @@ describe('KeywordIndex', () => {
     });
   });
 
+  describe('F11: search skips unmapped ids instead of fabricating unknown docId', () => {
+    it('returns only resolvable results, dropping ids absent from idMapping', () => {
+      const index = KeywordIndex.getInstance();
+      // Force-ready so search() runs without a full initialize() (the flexsearch
+      // Index and IDB are mocked). isReady() requires ready=true, disposed=false,
+      // and a non-null index.
+      (index as unknown as { ready: boolean }).ready = true;
+      (index as unknown as { disposed: boolean }).disposed = false;
+      (index as unknown as { index: unknown }).index = { search: mockSearch };
+
+      // Populate the internal idMapping with one resolvable chunk.
+      const internals = index as unknown as {
+        idMapping: Map<string, { docId: string; chunkIndex: number; text: string; source?: string; page?: number }>;
+      };
+      internals.idMapping.set('docA:0', { docId: 'docA', chunkIndex: 0, text: 'alpha' });
+
+      // Mock flexsearch search to return one mapped + one unmapped id.
+      mockSearch.mockReturnValueOnce(['docA:0', 'docZ:9']);
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const results = index.search('alpha');
+      warnSpy.mockRestore();
+
+      // Only the resolvable id is returned; the unmapped one is skipped (not
+      // fabricated as docId:'unknown').
+      expect(results).toHaveLength(1);
+      expect(results[0].docId).toBe('docA');
+
+      index.dispose();
+    });
+  });
+
   // -------------------------------------------------------------------------
   // User isolation via sessionStorage prefix (FR-007)
   // DB_NAME is private; we observe it via the indexedDB.open mock calls.
@@ -254,9 +286,20 @@ describe('KeywordIndex', () => {
       index.dispose();
     });
 
-    it('Same session produces same prefix on reload', async () => {
-      sessionStorage.clear();
-      sessionStorage.setItem('doc-qa-user-id', 'same-sess-00112233');
+    it('F1: stable profile prefix produces the same DB name across reloads', async () => {
+      // F1 changed the namespace from a per-session sessionStorage UUID to a
+      // stable localStorage-backed profile id. Provide a controllable
+      // localStorage so the test is deterministic.
+      const store: Record<string, string> = {};
+      Object.defineProperty(globalThis, 'localStorage', {
+        value: {
+          getItem: (k: string) => store[k] ?? null,
+          setItem: (k: string, v: string) => { store[k] = v; },
+          removeItem: (k: string) => { delete store[k]; },
+        },
+        writable: true,
+        configurable: true,
+      });
 
       vi.resetModules();
       const { KeywordIndex: K } = await import('./keyword-index');
@@ -270,7 +313,7 @@ describe('KeywordIndex', () => {
       const n1 = openMock.mock.calls[0]?.[0];
       i1.dispose();
 
-      // same session, same module after first reset: prefix must be identical
+      // A second instance reads the same persisted profile prefix → same DB name.
       const i2 = K.getInstance();
       openMock.mockClear();
       try { await i2.initialize(); } catch {}
@@ -281,7 +324,21 @@ describe('KeywordIndex', () => {
       expect(n1).toMatch(/-doc-qa-keywords$/);
     });
 
-    it('Different sessionStorage values produce different DB_NAMEs', async () => {
+    it('F1: sessionStorage no longer affects the DB name (persistence is profile-scoped)', async () => {
+      // The fix: changing sessionStorage must NOT change the DB name, because
+      // documents must survive a browser-session restart (sessionStorage is
+      // cleared on close). Only the stable profile id (localStorage) matters.
+      const store: Record<string, string> = {};
+      Object.defineProperty(globalThis, 'localStorage', {
+        value: {
+          getItem: (k: string) => store[k] ?? null,
+          setItem: (k: string, v: string) => { store[k] = v; },
+          removeItem: (k: string) => { delete store[k]; },
+        },
+        writable: true,
+        configurable: true,
+      });
+
       sessionStorage.clear();
       sessionStorage.setItem('doc-qa-user-id', 'user-aaaa-11111111');
       vi.resetModules();
@@ -296,6 +353,7 @@ describe('KeywordIndex', () => {
       const na = openMock.mock.calls[0]?.[0];
       ia.dispose();
 
+      // Change sessionStorage — must NOT change the DB name anymore.
       sessionStorage.setItem('doc-qa-user-id', 'user-bbbb-22222222');
       vi.resetModules();
 
@@ -308,9 +366,8 @@ describe('KeywordIndex', () => {
       const nb = openMock.mock.calls[0]?.[0];
       ib.dispose();
 
-      expect(na).not.toBe(nb);
+      expect(na).toBe(nb);
       expect(na).toMatch(/-doc-qa-keywords$/);
-      expect(nb).toMatch(/-doc-qa-keywords$/);
     });
   });
 });

--- a/web_ui/src/lib/search/keyword-index.ts
+++ b/web_ui/src/lib/search/keyword-index.ts
@@ -9,29 +9,16 @@
 import { Index } from 'flexsearch';
 import type { SearchResult } from '../../types/search';
 import type { DocumentChunk } from '../../types/document';
+import { getStorageDbNames } from '../storage/profile';
 
 /**
- * Generate a stable, user-scoped prefix for IndexedDB names.
- * Uses sessionStorage UUID if available, else falls back to origin-derived
- * hash. Result is stable across page reloads in the same browser session.
+ * F1: the per-store IndexedDB names now derive from the stable localStorage
+ * profile prefix (see ../storage/profile) instead of a per-session
+ * sessionStorage UUID, so the keyword index persists across browser restarts
+ * and is shared across tabs.
  */
-function getUserPrefix(): string {
-  const KEY = 'doc-qa-user-id';
-  if (typeof sessionStorage !== 'undefined') {
-    let id = sessionStorage.getItem(KEY);
-    if (!id) {
-      id = (typeof crypto !== 'undefined' && 'randomUUID' in crypto)
-        ? crypto.randomUUID()
-        : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
-      try { sessionStorage.setItem(KEY, id); } catch { /* private mode */ }
-    }
-    return id.slice(0, 8); // short prefix
-  }
-  return 'anon';
-}
-
-const USER_PREFIX = getUserPrefix();
-const DB_NAME = `${USER_PREFIX}-doc-qa-keywords`;
+const DB_NAMES = getStorageDbNames();
+const DB_NAME = DB_NAMES.keyword;
 const DB_VERSION = 1;
 const STORE_NAME = 'keyword-index';
 
@@ -231,17 +218,27 @@ export class KeywordIndex {
       // to the synchronous array shape actually produced here.
       const results = this.index!.search(query, { limit, suggest: true }) as Array<string | number>;
 
-      return results.map((id: string | number, rank: number) => {
+      // F11: skip entries whose FlexSearch id has no resolvable metadata
+      // instead of fabricating `docId:'unknown'` results (mirrors VectorIndex).
+      const mapped: SearchResult[] = [];
+      let rank = 0;
+      for (const id of results) {
         const meta = this.idMapping.get(String(id));
-        return {
-          docId: meta?.docId ?? 'unknown',
-          chunkIndex: meta?.chunkIndex ?? 0,
+        if (!meta) {
+          console.warn(`[KeywordIndex] Skipping search result with unmapped id ${id}`);
+          continue;
+        }
+        mapped.push({
+          docId: meta.docId,
+          chunkIndex: meta.chunkIndex,
           score: 1 / (rank + 1), // Position-based scoring: higher rank = higher score
-          text: meta?.text,
-          source: meta?.source, // F7: filename for citations
-          page: meta?.page,     // F7: page number for citations
-        };
-      });
+          text: meta.text,
+          source: meta.source, // F7: filename for citations
+          page: meta.page,     // F7: page number for citations
+        });
+        rank++;
+      }
+      return mapped;
     } catch (error) {
       console.error('[KeywordIndex] Search failed:', error);
       return [];

--- a/web_ui/src/lib/search/vector-index.test.ts
+++ b/web_ui/src/lib/search/vector-index.test.ts
@@ -245,6 +245,51 @@ describe('VectorIndex', () => {
       // Restore original
       (instance as unknown as { loadMapping: () => Promise<void> }).loadMapping = originalLoadMapping;
     });
+
+    it('F17: a fresh-boot "not found" rejection returns false and logs at info, not error', async () => {
+      // F17: the edgevec stub now rejects on miss (matching the real backend),
+      // so a fresh boot surfaces a Promise rejection. load() must treat a
+      // "not found" rejection as the benign no-index-yet case (return false,
+      // console.info) rather than logging an error (acceptance criterion #5).
+      const instance = VectorIndex.getInstance();
+      await instance.initialize();
+
+      const edgevec = await import('edgevec');
+      (edgevec as unknown as { load: ReturnType<typeof vi.fn> }).load.mockRejectedValueOnce(
+        new Error('EdgeVec index not found: abc12345-doc-qa-index')
+      );
+
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+
+      const result = await instance.load();
+
+      expect(result).toBe(false);
+      // Must NOT log an error for the expected fresh-boot case.
+      expect(errorSpy).not.toHaveBeenCalled();
+      // Must log at info level (benign no-index notice).
+      expect(infoSpy).toHaveBeenCalled();
+
+      errorSpy.mockRestore();
+      infoSpy.mockRestore();
+    });
+
+    it('F17: a genuine corruption error (not "not found") still logs at error level', async () => {
+      const instance = VectorIndex.getInstance();
+      await instance.initialize();
+
+      const edgevec = await import('edgevec');
+      (edgevec as unknown as { load: ReturnType<typeof vi.fn> }).load.mockRejectedValueOnce(
+        new Error('ERR_CORRUPTION: deserialization failed')
+      );
+
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const result = await instance.load();
+
+      expect(result).toBe(false);
+      expect(errorSpy).toHaveBeenCalled();
+      errorSpy.mockRestore();
+    });
   });
 
   describe('addBatch - KEY: uses startId = liveCount()', () => {
@@ -333,20 +378,25 @@ describe('VectorIndex', () => {
       expect(results[1]).toEqual({ docId: 'doc-xyz', chunkIndex: 12, score: 0.87 });
     });
 
-    it('handles missing idMapping entries with unknown docId', async () => {
+    it('F11: skips missing idMapping entries instead of fabricating unknown docId', async () => {
       const instance = VectorIndex.getInstance();
       await instance.initialize();
 
-      // Mock search to return a result with an ID not in mapping
+      // Mock search to return a result with an ID not in the mapping.
       mockEdgeVecInstance.search = vi.fn<(_query: Float32Array, k: number) => Array<{ id: number; score: number }>>()
         .mockReturnValue([
           { id: 99, score: 0.75 },
         ]);
 
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const results = await instance.search(new Float32Array(384), { k: 1 });
 
-      // Should return 'unknown' for missing docId
-      expect(results[0]).toEqual({ docId: 'unknown', chunkIndex: 0, score: 0.75 });
+      // F11: an unmapped internal id must be SKIPPED, not returned as a
+      // fabricated `docId:'unknown'` placeholder. The empty result avoids
+      // polluting RAG retrieval with phantom chunks.
+      expect(results).toHaveLength(0);
+      expect(warnSpy).toHaveBeenCalled();
+      warnSpy.mockRestore();
     });
 
     it('respects efSearch option', async () => {

--- a/web_ui/src/lib/search/vector-index.ts
+++ b/web_ui/src/lib/search/vector-index.ts
@@ -7,30 +7,17 @@
 import type { EmbeddingEntry, EmbeddingVector } from '../../types/embedding';
 import type { SearchResult, VectorIndexConfig, VectorSearchOptions } from '../../types/search';
 import initWasm, { EdgeVec, EdgeVecConfig } from 'edgevec';
+import { getStorageDbNames } from '../storage/profile';
 
 /**
- * Generate a stable, user-scoped prefix for IndexedDB names.
- * Uses sessionStorage UUID if available, else falls back to origin-derived
- * hash. Result is stable across page reloads in the same browser session.
+ * F1: the per-store IndexedDB names now derive from the stable localStorage
+ * profile prefix (see ../storage/profile) instead of a per-session
+ * sessionStorage UUID, so the vector index persists across browser restarts and
+ * is shared across tabs.
  */
-function getUserPrefix(): string {
-  const KEY = 'doc-qa-user-id';
-  if (typeof sessionStorage !== 'undefined') {
-    let id = sessionStorage.getItem(KEY);
-    if (!id) {
-      id = (typeof crypto !== 'undefined' && 'randomUUID' in crypto)
-        ? crypto.randomUUID()
-        : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
-      try { sessionStorage.setItem(KEY, id); } catch { /* private mode */ }
-    }
-    return id.slice(0, 8); // short prefix
-  }
-  return 'anon';
-}
-
-const USER_PREFIX = getUserPrefix();
-const DB_NAME = `${USER_PREFIX}-doc-qa-indexes`;
-const INDEX_NAME = `${USER_PREFIX}-doc-qa-index`;
+const DB_NAMES = getStorageDbNames();
+const DB_NAME = DB_NAMES.vectorMapping;
+const INDEX_NAME = DB_NAMES.vector;
 
 /**
  * Vector index content version. Bump when the persisted idMapping schema OR the
@@ -299,18 +286,27 @@ export class VectorIndex {
       // Pass Float32Array directly without conversion
       const results = this.index!.search(queryVector as Float32Array, k) as Array<{ id: number; score: number }>;
 
-      // Map results to SearchResult format
-      return results.map((result) => {
+      // Map results to SearchResult format. F11: skip entries whose internal id
+      // has no resolvable metadata (orphaned ids from a non-atomic save or a
+      // mapping desync) instead of fabricating `docId:'unknown'` results, which
+      // silently polluted RAG retrieval with placeholder chunks.
+      const mapped: SearchResult[] = [];
+      for (const result of results) {
         const metadata = this.idMapping.get(result.id);
-        return {
-          docId: metadata?.docId ?? 'unknown',
-          chunkIndex: metadata?.chunkIndex ?? 0,
+        if (!metadata) {
+          console.warn(`[VectorIndex] Skipping search result with unmapped internal id ${result.id}`);
+          continue;
+        }
+        mapped.push({
+          docId: metadata.docId,
+          chunkIndex: metadata.chunkIndex,
           score: result.score,
-          text: metadata?.text,     // F1: real chunk text
-          source: metadata?.source, // F7: filename
-          page: metadata?.page,     // F7: page number
-        };
-      });
+          text: metadata.text,     // F1: real chunk text
+          source: metadata.source, // F7: filename
+          page: metadata.page,     // F7: page number
+        });
+      }
+      return mapped;
     } catch (error) {
       throw new Error(
         `Search failed: ${error instanceof Error ? error.message : String(error)}`,
@@ -362,11 +358,16 @@ export class VectorIndex {
     }
 
     try {
-      // Use EdgeVec's native save with custom index name
-      await this.index!.save(INDEX_NAME);
-
-      // Persist idMapping alongside the EdgeVec index (FIX #2)
+      // F11: persist idMapping BEFORE the EdgeVec snapshot. The two writes span
+      // different databases/transactions so they cannot be made fully atomic,
+      // but writing the mapping first means a crash between the two leaves the
+      // PREVIOUS consistent state (old snapshot + old mapping) rather than a
+      // new snapshot whose internal IDs have no resolvable metadata. A mapping
+      // without its snapshot is harmless (loads as empty); a snapshot without
+      // its mapping yields orphaned internal IDs that previously produced
+      // fabricated `docId:'unknown'` search results.
       await this.saveMapping();
+      await this.index!.save(INDEX_NAME);
 
       console.info(`[VectorIndex] Saved ${this.size()} vectors to IndexedDB`);
     } catch (error) {
@@ -630,7 +631,19 @@ export class VectorIndex {
       console.info(`[VectorIndex] Loaded ${this.size()} vectors from IndexedDB`);
       return true;
     } catch (error) {
-      console.error('[VectorIndex] Load failed:', error);
+      // F17: a "not found" rejection is the expected fresh-boot case (no saved
+      // index yet). The edgevec stub now rejects on miss (matching the real
+      // backend), so log it at info level rather than error — a fresh boot with
+      // no prior index must not produce an ERR_CORRUPTION console error. Any
+      // other failure (genuine deserialization/corruption) still logs as error.
+      const message = error instanceof Error ? error.message : String(error);
+      // m3: match case-insensitively so a future backend message variant
+      // ("Not Found" / "NOT FOUND") still routes to the benign fresh-boot path.
+      if (/not found/i.test(message)) {
+        console.info('[VectorIndex] No saved index found (fresh boot).');
+      } else {
+        console.error('[VectorIndex] Load failed:', error);
+      }
       // Dispose loadedIndex to avoid WASM memory leak
       if (loadedIndex) {
         if (typeof loadedIndex[Symbol.dispose] === 'function') {

--- a/web_ui/src/lib/storage/document-store.test.ts
+++ b/web_ui/src/lib/storage/document-store.test.ts
@@ -171,47 +171,55 @@ describe('document-store', () => {
     });
   });
 
-  describe('getUserPrefix', () => {
-    it('returns existing sessionStorage value when present', () => {
-      mockSessionStorage.setItem('doc-qa-user-id', 'test-user-12345678');
-      expect(getUserPrefix()).toBe('test-use'); // getUserPrefix returns first 8 chars
-      mockSessionStorage.removeItem('doc-qa-user-id');
+  describe('getUserPrefix (F1: stable localStorage-backed profile)', () => {
+    let mockLocalStorage: Record<string, string>;
+
+    beforeEach(() => {
+      mockLocalStorage = {};
+      // getProfilePrefix reads localStorage directly; provide a controllable
+      // in-memory localStorage for these assertions.
+      Object.defineProperty(globalThis, 'localStorage', {
+        value: {
+          getItem: (key: string) => mockLocalStorage[key] ?? null,
+          setItem: (key: string, value: string) => { mockLocalStorage[key] = value; },
+          removeItem: (key: string) => { delete mockLocalStorage[key]; },
+        },
+        writable: true,
+        configurable: true,
+      });
     });
 
-    it('generates and stores a new prefix when sessionStorage is empty', () => {
-      mockSessionStorage.removeItem('doc-qa-user-id');
+    it('returns the existing persisted profile prefix when present', () => {
+      mockLocalStorage['doc-qa-profile-id'] = 'abcdef12';
+      expect(getUserPrefix()).toBe('abcdef12');
+    });
+
+    it('mints and persists a new lowercase-alphanumeric prefix when none exists', () => {
       const prefix = getUserPrefix();
       expect(prefix).toBeTruthy();
-      expect(prefix.length).toBeGreaterThanOrEqual(3);
+      // Constrained to lowercase alphanumerics so DB_NAME matches its regex.
+      expect(prefix).toMatch(/^[a-z0-9]+$/);
+      // Persisted for future boots.
+      expect(mockLocalStorage['doc-qa-profile-id']).toBe(prefix);
     });
 
-    it('returns short prefix (first 8 chars) when full UUID is stored', () => {
-      mockSessionStorage.setItem('doc-qa-user-id', 'abcdef1234567890abcdef1234567890');
-      expect(getUserPrefix()).toBe('abcdef12');
-      mockSessionStorage.removeItem('doc-qa-user-id');
+    it('is stable across repeated reads (same prefix returned every time)', () => {
+      const first = getUserPrefix();
+      const second = getUserPrefix();
+      expect(second).toBe(first);
     });
 
-    it('returns "anon" when sessionStorage is unavailable', () => {
-      const originalSessionStorage = globalThis.sessionStorage;
-      Object.defineProperty(globalThis, 'sessionStorage', { value: undefined, writable: true });
+    it('returns "anon" fallback when localStorage is unavailable', () => {
+      Object.defineProperty(globalThis, 'localStorage', { value: undefined, writable: true, configurable: true });
       expect(getUserPrefix()).toBe('anon');
-      Object.defineProperty(globalThis, 'sessionStorage', { value: originalSessionStorage, writable: true });
     });
   });
 
-  describe('user isolation (prefix behavior)', () => {
-    it('Different sessionStorage values produce different prefixes', () => {
-      mockSessionStorage.setItem('doc-qa-user-id', 'aaaa1111');
-      const prefixA = getUserPrefix();
-
-      mockSessionStorage.setItem('doc-qa-user-id', 'bbbb2222');
-      const prefixB = getUserPrefix();
-
-      expect(prefixA).not.toBe(prefixB);
-      expect(prefixA).toBe('aaaa1111');
-      expect(prefixB).toBe('bbbb2222');
-
-      mockSessionStorage.removeItem('doc-qa-user-id');
+  describe('DB_NAME shape (F1)', () => {
+    it('derives from the stable profile prefix and matches the isolation regex', () => {
+      // DB_NAME is computed at module load from the profile prefix; with a
+      // localStorage-backed prefix it must still match the historical shape.
+      expect(DB_NAME).toMatch(/^[a-z0-9-]{3,8}-doc-qa-documents$/);
     });
   });
 });

--- a/web_ui/src/lib/storage/document-store.ts
+++ b/web_ui/src/lib/storage/document-store.ts
@@ -4,29 +4,23 @@
  */
 
 import type { DocumentEntry } from '../../types/document';
+import { getProfilePrefix, getStorageDbNames } from './profile';
 
 /**
  * Generate a stable, user-scoped prefix for IndexedDB names.
- * Uses sessionStorage UUID if available, else falls back to origin-derived
- * hash. Result is stable across page reloads in the same browser session.
+ *
+ * F1: this previously read a per-session UUID from `sessionStorage`, which is
+ * cleared on browser-session end and isolated per tab — destroying persistence
+ * and splitting tabs. It now delegates to the stable `localStorage`-backed
+ * profile id in `./profile`. Kept as a thin re-export for existing importers
+ * (the document-store test) and any external callers.
  */
 export function getUserPrefix(): string {
-  const KEY = 'doc-qa-user-id';
-  if (typeof sessionStorage !== 'undefined') {
-    let id = sessionStorage.getItem(KEY);
-    if (!id) {
-      id = (typeof crypto !== 'undefined' && 'randomUUID' in crypto)
-        ? crypto.randomUUID()
-        : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
-      try { sessionStorage.setItem(KEY, id); } catch { /* private mode */ }
-    }
-    return id.slice(0, 8); // short prefix
-  }
-  return 'anon';
+  return getProfilePrefix();
 }
 
-const USER_PREFIX = getUserPrefix();
-export const DB_NAME = `${USER_PREFIX}-doc-qa-documents`;
+const DB_NAMES = getStorageDbNames();
+export const DB_NAME = DB_NAMES.documents;
 const DB_VERSION = 1;
 const STORE_NAME = 'documents';
 

--- a/web_ui/src/lib/storage/profile.test.ts
+++ b/web_ui/src/lib/storage/profile.test.ts
@@ -109,6 +109,105 @@ describe('profile (F1 stable namespace)', () => {
       });
       await expect(migrateOrphanedNamespaces()).resolves.toBeUndefined();
     });
+
+    it('PRR-003/PRR-002: copies orphan documents into the current namespace and sets the re-index flag', async () => {
+      // Minimal fake IndexedDB. Request handlers (onsuccess/oncomplete) are
+      // invoked on the next macrotask via a setter so they fire AFTER the caller
+      // attaches them (mirroring real IDB async semantics).
+      const current = getProfilePrefix();
+      const orphanPrefix = 'oldold01';
+      const orphanDocs = [
+        { id: 'doc-a', fileName: 'a.pdf', status: 'ready' },
+        { id: 'doc-b', fileName: 'b.pdf', status: 'ready' },
+      ];
+
+      // dbName → { storeName → record[] }. Orphan documents store pre-seeded.
+      const dbStore: Record<string, Record<string, Array<Record<string, unknown>>>> = {
+        [`${orphanPrefix}-doc-qa-documents`]: { documents: [...orphanDocs] },
+        [`${orphanPrefix}-doc-qa-keywords`]: { 'keyword-index': [{ key: 'data', entries: [], documentChunks: {} }] },
+      };
+
+      const databases = vi.fn(async () => [
+        { name: `${orphanPrefix}-doc-qa-documents` },
+        { name: `${orphanPrefix}-doc-qa-keywords` },
+        { name: `${current}-doc-qa-documents` },
+      ]);
+
+      // Helper: an IDBRequest-like object whose `onsuccess` fires next tick.
+      function makeRequest(fire: (r: any) => void): any {
+        const r: any = { result: undefined, onsuccess: null, onerror: null };
+        setTimeout(() => {
+          fire(r);
+          if (typeof r.onsuccess === 'function') r.onsuccess();
+        }, 0);
+        return r;
+      }
+
+      function open(dbName: string): any {
+        const stores = (dbStore[dbName] ?? (dbStore[dbName] = {}));
+        const req: any = {
+          result: undefined,
+          onupgradeneeded: null,
+          onsuccess: null,
+          onerror: null,
+        };
+        const buildResult = () => ({
+          objectStoreNames: { contains: (n: string) => Object.keys(stores).includes(n) },
+          close: vi.fn(),
+          createObjectStore: (n: string) => {
+            if (!stores[n]) stores[n] = [];
+            return {};
+          },
+          transaction: (storeName: string, _mode: string) => {
+            const bucket = stores[storeName] ?? (stores[storeName] = []);
+            const tx: any = { oncomplete: null, onerror: null };
+            tx.objectStore = () => ({
+              getAll: () => makeRequest((r: any) => { r.result = [...bucket]; }),
+              get: (_key: string) => makeRequest((r: any) => { r.result = null; }),
+              put: (rec: Record<string, unknown>) => {
+                bucket.push(rec);
+                return makeRequest(() => {});
+              },
+            });
+            setTimeout(() => {
+              if (typeof tx.oncomplete === 'function') tx.oncomplete();
+            }, 0);
+            return tx;
+          },
+        });
+        setTimeout(() => {
+          // Real IDB fires onupgradeneeded (creating stores) when the DB/store
+          // is new, then onsuccess. mergeIntoStore opens at version 1; the
+          // target documents DB is fresh, so simulate the upgrade.
+          if (typeof req.onupgradeneeded === 'function') {
+            req.result = buildResult();
+            req.onupgradeneeded({ target: { result: req.result, oldVersion: 0 } });
+          }
+          req.result = buildResult();
+          if (typeof req.onsuccess === 'function') req.onsuccess();
+        }, 0);
+        return req;
+      }
+
+      Object.defineProperty(globalThis, 'indexedDB', {
+        value: { databases, open: vi.fn((name: string) => open(name)) },
+        writable: true,
+        configurable: true,
+      });
+
+      await migrateOrphanedNamespaces();
+
+      // The orphan documents were copied into the current profile's documents DB.
+      const targetDocs = dbStore[`${current}-doc-qa-documents`]?.documents ?? [];
+      expect(targetDocs.some((d) => d.id === 'doc-a')).toBe(true);
+      expect(targetDocs.some((d) => d.id === 'doc-b')).toBe(true);
+
+      // PRR-002: the re-index flag is set because the vector index can't be copied.
+      expect(mockLocalStorage['rag-reindex-required']).toBe('1');
+
+      // Migration marked complete.
+      expect(mockLocalStorage['doc-qa-profile-migrated']).toBe('1');
+    });
   });
 
   describe('listStalePrefixes', () => {

--- a/web_ui/src/lib/storage/profile.test.ts
+++ b/web_ui/src/lib/storage/profile.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for the stable profile namespace helper (F1).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  getProfilePrefix,
+  getStorageDbNames,
+  migrateOrphanedNamespaces,
+  listStalePrefixes,
+} from './profile';
+
+describe('profile (F1 stable namespace)', () => {
+  let mockLocalStorage: Record<string, string>;
+
+  beforeEach(() => {
+    mockLocalStorage = {};
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: {
+        getItem: (key: string) => mockLocalStorage[key] ?? null,
+        setItem: (key: string, value: string) => { mockLocalStorage[key] = value; },
+        removeItem: (key: string) => { delete mockLocalStorage[key]; },
+      },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  describe('getProfilePrefix', () => {
+    it('mints a lowercase-alphanumeric prefix on first read', () => {
+      const prefix = getProfilePrefix();
+      expect(prefix).toMatch(/^[a-z0-9]+$/);
+      expect(prefix).toBe(getProfilePrefix()); // stable
+    });
+
+    it('persists the prefix in localStorage so it survives across sessions', () => {
+      const prefix = getProfilePrefix();
+      expect(mockLocalStorage['doc-qa-profile-id']).toBe(prefix);
+    });
+
+    it('returns the existing prefix when one is already persisted', () => {
+      mockLocalStorage['doc-qa-profile-id'] = 'deadbeef';
+      expect(getProfilePrefix()).toBe('deadbeef');
+    });
+
+    it('returns "anon" when localStorage is unavailable', () => {
+      Object.defineProperty(globalThis, 'localStorage', { value: undefined, writable: true, configurable: true });
+      expect(getProfilePrefix()).toBe('anon');
+    });
+
+    it('re-mints when the stored value is malformed', () => {
+      mockLocalStorage['doc-qa-profile-id'] = 'has UPPERCASE and spaces';
+      const prefix = getProfilePrefix();
+      expect(prefix).toMatch(/^[a-z0-9]+$/);
+      expect(prefix).not.toBe('has UPPERCASE and spaces');
+    });
+  });
+
+  describe('getStorageDbNames', () => {
+    it('derives all four names from the same prefix', () => {
+      mockLocalStorage['doc-qa-profile-id'] = 'abc12345';
+      const names = getStorageDbNames();
+      expect(names.documents).toBe('abc12345-doc-qa-documents');
+      expect(names.vectorMapping).toBe('abc12345-doc-qa-indexes');
+      expect(names.vector).toBe('abc12345-doc-qa-index');
+      expect(names.keyword).toBe('abc12345-doc-qa-keywords');
+    });
+  });
+
+  describe('migrateOrphanedNamespaces', () => {
+    it('is a no-op when indexedDB.databases() is unavailable (Firefox/Safari) and does NOT set the migration flag', async () => {
+      // No indexedDB.databases() function present.
+      await migrateOrphanedNamespaces();
+      expect(mockLocalStorage['doc-qa-profile-migrated']).toBeUndefined();
+    });
+
+    it('sets the migration flag when the enumeration API is available and there are no orphans', async () => {
+      const databases = vi.fn(async () => [
+        { name: `${getProfilePrefix()}-doc-qa-documents` }, // only the current profile
+      ]);
+      Object.defineProperty(globalThis, 'indexedDB', {
+        value: { databases },
+        writable: true,
+        configurable: true,
+      });
+      await migrateOrphanedNamespaces();
+      expect(mockLocalStorage['doc-qa-profile-migrated']).toBe('1');
+    });
+
+    it('does not re-run after the migration flag is set', async () => {
+      mockLocalStorage['doc-qa-profile-migrated'] = '1';
+      const databases = vi.fn(async () => [] as Array<{ name?: string }>);
+      Object.defineProperty(globalThis, 'indexedDB', {
+        value: { databases },
+        writable: true,
+        configurable: true,
+      });
+      await migrateOrphanedNamespaces();
+      expect(databases).not.toHaveBeenCalled();
+    });
+
+    it('never throws even if the enumeration API rejects', async () => {
+      const databases = vi.fn(async () => {
+        throw new Error('boom');
+      });
+      Object.defineProperty(globalThis, 'indexedDB', {
+        value: { databases },
+        writable: true,
+        configurable: true,
+      });
+      await expect(migrateOrphanedNamespaces()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('listStalePrefixes', () => {
+    it('returns [] when the enumeration API is unavailable', async () => {
+      Object.defineProperty(globalThis, 'indexedDB', { value: {}, writable: true, configurable: true });
+      expect(await listStalePrefixes()).toEqual([]);
+    });
+
+    it('returns only prefixes that are not the current profile', async () => {
+      const current = getProfilePrefix();
+      const databases = vi.fn(async () => [
+        { name: `${current}-doc-qa-documents` },
+        { name: 'orphan01-doc-qa-documents' },
+        { name: 'orphan02-doc-qa-keywords' },
+      ]);
+      Object.defineProperty(globalThis, 'indexedDB', {
+        value: { databases },
+        writable: true,
+        configurable: true,
+      });
+      const stale = await listStalePrefixes();
+      expect(stale).toContain('orphan01');
+      expect(stale).toContain('orphan02');
+      expect(stale).not.toContain(current);
+    });
+  });
+});

--- a/web_ui/src/lib/storage/profile.ts
+++ b/web_ui/src/lib/storage/profile.ts
@@ -110,8 +110,10 @@ const ORPHAN_DB_RE = /^([a-z0-9]{3,8})-doc-qa-(documents|indexes|keywords)$/;
  *
  * - Chrome/Edge: `indexedDB.databases()` is available; migration copies the
  *   most-recently-written orphan document set + keyword index into the stable
- *   namespace. The vector index is discarded with a re-index notice (its WASM
- *   blob is not safely copyable across names).
+ *   namespace. The vector index is NOT copied (its WASM blob is not safely
+ *   copyable across names); when any documents are migrated, the
+ *   `rag-reindex-required` flag is set so the existing one-time re-index notice
+ *   surfaces and the user knows to re-add documents for semantic search.
  * - Firefox/Safari: `indexedDB.databases()` is unavailable; migration is
  *   skipped and the flag is NOT set, so a later session on an enumerating
  *   browser can still migrate.
@@ -175,12 +177,27 @@ export async function migrateOrphanedNamespaces(): Promise<void> {
   // orphans (merging), preferring the current profile's namespace as target.
   // This is a read-all/write-all loop wrapped in try/catch; partial failures do
   // not abort the rest and never surface to the UI.
+  let migratedDocCount = 0;
   for (const orphanPrefix of orphanPrefixes) {
     try {
-      await copyDocumentStore(`${orphanPrefix}-doc-qa-documents`, `${currentPrefix}-doc-qa-documents`);
+      migratedDocCount += await copyDocumentStore(`${orphanPrefix}-doc-qa-documents`, `${currentPrefix}-doc-qa-documents`);
       await copyKeywordIndex(`${orphanPrefix}-doc-qa-keywords`, `${currentPrefix}-doc-qa-keywords`);
     } catch (error) {
       console.warn(`[profile] Could not migrate orphan namespace ${orphanPrefix}:`, error);
+    }
+  }
+
+  // PRR-002: the vector index cannot be copied across names, so any migrated
+  // documents lack semantic-search vectors. Set the existing re-index flag so
+  // the one-time notice tells the user to re-add their documents (rather than
+  // silently presenting a corpus that keyword-searches but won't semantic-search).
+  if (migratedDocCount > 0) {
+    try {
+      if (typeof localStorage !== 'undefined') {
+        localStorage.setItem('rag-reindex-required', '1');
+      }
+    } catch {
+      /* private mode / storage disabled — non-fatal */
     }
   }
 
@@ -197,14 +214,15 @@ export async function migrateOrphanedNamespaces(): Promise<void> {
 /**
  * Copy all documents from a source IndexedDB store into a target database's
  * store, merging (by keyPath `id`). Opens each DB read-only/write-only; never
- * deletes the source. Best-effort.
+ * deletes the source. Returns the number of documents copied. Best-effort.
  */
-async function copyDocumentStore(sourceDbName: string, targetDbName: string): Promise<void> {
+async function copyDocumentStore(sourceDbName: string, targetDbName: string): Promise<number> {
   const docs = await readAllFromStore<{ id: string }>(sourceDbName, 'documents');
   if (docs.length === 0) {
-    return;
+    return 0;
   }
   await mergeIntoStore(targetDbName, 'documents', 'id', docs);
+  return docs.length;
 }
 
 /** Copy keyword-index entries from source to target (merge by keyPath `key`). */
@@ -315,6 +333,15 @@ export async function listStalePrefixes(): Promise<string[]> {
 /**
  * Delete all IndexedDB databases for a given profile prefix.
  * Intended for the Settings "Clear Cache" UI (PR-5). Best-effort.
+ *
+ * NOTE (PRR-008): this deletes the documents, vector-mapping, and keyword DBs,
+ * but it CANNOT delete the native EdgeVec HNSW blob for the prefix — that blob
+ * is stored as a VALUE keyed by `${prefix}-doc-qa-index` inside the shared
+ * `edgevec-db` database (see vite.config.ts IndexedDbBackend stub), not in a
+ * per-profile database. Clearing it requires deleting the key from
+ * `edgevec-db`'s data store (or deleting `edgevec-db` entirely, which would
+ * affect ALL profiles). PR-5's Clear Cache UI must handle the EdgeVec blob
+ * separately; deleting only these three DBs leaves the vector blob orphaned.
  */
 export async function deleteNamespace(prefix: string): Promise<void> {
   // Match the system-wide prefix constraint (see getProfilePrefix / DB_NAME

--- a/web_ui/src/lib/storage/profile.ts
+++ b/web_ui/src/lib/storage/profile.ts
@@ -1,0 +1,344 @@
+/**
+ * Stable profile-scoped storage namespace (F1).
+ *
+ * Replaces the per-session sessionStorage UUID scheme. The old scheme
+ * (`doc-qa-user-id` in sessionStorage) was cleared on every browser-session end
+ * and isolated per tab, so documents disappeared on restart and each tab saw an
+ * empty corpus. This module persists a single stable profile id in
+ * `localStorage`, derives all IndexedDB names from it, and offers a one-time
+ * best-effort migration of orphaned per-session databases.
+ *
+ * The prefix is constrained to lowercase-alphanumeric characters so the derived
+ * database names keep matching the historical `/^[a-z0-9-]{3,8}-doc-qa-…$/`
+ * shape (see document-store.test.ts).
+ */
+
+const PROFILE_KEY = 'doc-qa-profile-id';
+const MIGRATION_KEY = 'doc-qa-profile-migrated';
+const PREFIX_LENGTH = 8;
+
+export interface StorageDbNames {
+  /** IndexedDB name for the document metadata store. */
+  documents: string;
+  /** IndexedDB name for the vector-index idMapping store. */
+  vectorMapping: string;
+  /** EdgeVec native index name (key inside EdgeVec's own IndexedDB). */
+  vector: string;
+  /** IndexedDB name for the keyword-index store. */
+  keyword: string;
+}
+
+/**
+ * Mint a fresh lowercase-alphanumeric prefix of PREFIX_LENGTH chars.
+ * Uses crypto.randomUUID (hex) when available; falls back to a base36 random
+ * value filtered to lowercase alphanumerics. Never contains hyphens or
+ * uppercase, so it satisfies the DB_NAME regex char class.
+ */
+function mintPrefix(): string {
+  try {
+    if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+      // randomUUID is 0-9a-f with hyphens; strip non-alnum and take the first
+      // PREFIX_LENGTH chars.
+      const hex = crypto.randomUUID().replace(/[^a-z0-9]/g, '');
+      if (hex.length >= PREFIX_LENGTH) {
+        return hex.slice(0, PREFIX_LENGTH);
+      }
+    }
+  } catch {
+    /* crypto unavailable */
+  }
+  // Fallback: base36 of Date.now() + Math.random, filtered to lowercase alnum.
+  let raw = (Date.now().toString(36) + Math.random().toString(36).slice(2));
+  raw = raw.replace(/[^a-z0-9]/g, '');
+  if (raw.length < PREFIX_LENGTH) {
+    raw = raw.padEnd(PREFIX_LENGTH, '0');
+  }
+  return raw.slice(0, PREFIX_LENGTH);
+}
+
+/**
+ * Get the stable profile prefix, persisted in localStorage. Minted once on
+ * first access. SSR/private-mode safe.
+ */
+export function getProfilePrefix(): string {
+  // Prefer localStorage for cross-session persistence.
+  try {
+    if (typeof localStorage !== 'undefined') {
+      const existing = localStorage.getItem(PROFILE_KEY);
+      // m1: constrain to the same length window the DB_NAME shape regex
+      // requires (`/^[a-z0-9-]{3,8}-doc-qa-…$/`), so a corrupted stored value
+      // cannot produce an out-of-spec database name.
+      if (existing && /^[a-z0-9]{3,8}$/.test(existing)) {
+        return existing;
+      }
+      const fresh = mintPrefix();
+      localStorage.setItem(PROFILE_KEY, fresh);
+      return fresh;
+    }
+  } catch {
+    /* localStorage disabled (private mode) — fall through */
+  }
+  // Last-resort fallback when localStorage is unavailable: derive a per-origin
+  // stable value. This is NOT persistent across browser sessions, but it is the
+  // best available when localStorage is blocked. (Private mode is inherently
+  // ephemeral; nothing can persist there.)
+  return 'anon';
+}
+
+/**
+ * Derive all storage names for the current profile. Single source of truth —
+ * every store consumes this so the prefix can never desync across layers.
+ */
+export function getStorageDbNames(): StorageDbNames {
+  const prefix = getProfilePrefix();
+  return {
+    documents: `${prefix}-doc-qa-documents`,
+    vectorMapping: `${prefix}-doc-qa-indexes`,
+    vector: `${prefix}-doc-qa-index`,
+    keyword: `${prefix}-doc-qa-keywords`,
+  };
+}
+
+/** Pattern matching any legacy per-session namespace's databases. */
+const ORPHAN_DB_RE = /^([a-z0-9]{3,8})-doc-qa-(documents|indexes|keywords)$/;
+
+/**
+ * One-time, best-effort migration of orphaned per-session databases into the
+ * current stable profile namespace. Runs at most once per profile (guarded by
+ * a localStorage flag that is set ONLY after a successful attempt on a browser
+ * that supports the enumeration API).
+ *
+ * - Chrome/Edge: `indexedDB.databases()` is available; migration copies the
+ *   most-recently-written orphan document set + keyword index into the stable
+ *   namespace. The vector index is discarded with a re-index notice (its WASM
+ *   blob is not safely copyable across names).
+ * - Firefox/Safari: `indexedDB.databases()` is unavailable; migration is
+ *   skipped and the flag is NOT set, so a later session on an enumerating
+ *   browser can still migrate.
+ *
+ * Never throws — migration failures are logged and swallowed so the UI boots.
+ */
+export async function migrateOrphanedNamespaces(): Promise<void> {
+  // Already migrated for this profile.
+  try {
+    if (typeof localStorage !== 'undefined' && localStorage.getItem(MIGRATION_KEY) === '1') {
+      return;
+    }
+  } catch {
+    return;
+  }
+
+  if (typeof indexedDB === 'undefined') {
+    return;
+  }
+
+  // Feature-detect the enumeration API. Firefox/Safari lack it.
+  const idb = indexedDB as unknown as { databases?: () => Promise<Array<{ name?: string; version?: number }>> };
+  if (typeof idb.databases !== 'function') {
+    // Cannot enumerate — do NOT set the flag; a future enumerating browser can
+    // still migrate this profile's orphans.
+    return;
+  }
+
+  const currentPrefix = getProfilePrefix();
+  let dbs: Array<{ name?: string }>;
+  try {
+    dbs = await idb.databases();
+  } catch (error) {
+    console.warn('[profile] Could not enumerate IndexedDB databases for migration:', error);
+    return;
+  }
+
+  // Collect orphan prefixes (any profile prefix other than the current one).
+  const orphanPrefixes = new Set<string>();
+  for (const db of dbs) {
+    const name = db.name ?? '';
+    const match = name.match(ORPHAN_DB_RE);
+    if (match && match[1] !== currentPrefix) {
+      orphanPrefixes.add(match[1]);
+    }
+  }
+
+  if (orphanPrefixes.size === 0) {
+    // Nothing to migrate — mark complete so we don't re-enumerate every boot.
+    try {
+      if (typeof localStorage !== 'undefined') {
+        localStorage.setItem(MIGRATION_KEY, '1');
+      }
+    } catch {
+      /* ignore */
+    }
+    return;
+  }
+
+  // Best-effort copy of documents + keyword index from each orphan. We copy all
+  // orphans (merging), preferring the current profile's namespace as target.
+  // This is a read-all/write-all loop wrapped in try/catch; partial failures do
+  // not abort the rest and never surface to the UI.
+  for (const orphanPrefix of orphanPrefixes) {
+    try {
+      await copyDocumentStore(`${orphanPrefix}-doc-qa-documents`, `${currentPrefix}-doc-qa-documents`);
+      await copyKeywordIndex(`${orphanPrefix}-doc-qa-keywords`, `${currentPrefix}-doc-qa-keywords`);
+    } catch (error) {
+      console.warn(`[profile] Could not migrate orphan namespace ${orphanPrefix}:`, error);
+    }
+  }
+
+  // Migration attempt completed on an enumerating browser — mark complete.
+  try {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem(MIGRATION_KEY, '1');
+    }
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * Copy all documents from a source IndexedDB store into a target database's
+ * store, merging (by keyPath `id`). Opens each DB read-only/write-only; never
+ * deletes the source. Best-effort.
+ */
+async function copyDocumentStore(sourceDbName: string, targetDbName: string): Promise<void> {
+  const docs = await readAllFromStore<{ id: string }>(sourceDbName, 'documents');
+  if (docs.length === 0) {
+    return;
+  }
+  await mergeIntoStore(targetDbName, 'documents', 'id', docs);
+}
+
+/** Copy keyword-index entries from source to target (merge by keyPath `key`). */
+async function copyKeywordIndex(sourceDbName: string, targetDbName: string): Promise<void> {
+  const entries = await readAllFromStore<{ key: string }>(sourceDbName, 'keyword-index');
+  if (entries.length === 0) {
+    return;
+  }
+  await mergeIntoStore(targetDbName, 'keyword-index', 'key', entries);
+}
+
+/** Read all records from a given database/store. Returns [] if the DB/store is absent. */
+function readAllFromStore<T>(dbName: string, storeName: string): Promise<T[]> {
+  return new Promise((resolve) => {
+    const req = indexedDB.open(dbName);
+    req.onupgradeneeded = () => {
+      // Source DB may not have the store; resolve empty.
+    };
+    req.onsuccess = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(storeName)) {
+        db.close();
+        resolve([]);
+        return;
+      }
+      const tx = db.transaction(storeName, 'readonly');
+      const store = tx.objectStore(storeName);
+      const getAll = store.getAll();
+      getAll.onsuccess = () => {
+        db.close();
+        resolve((getAll.result as T[]) ?? []);
+      };
+      getAll.onerror = () => {
+        db.close();
+        resolve([]);
+      };
+    };
+    req.onerror = () => resolve([]);
+  });
+}
+
+/** Merge records into a target store by keyPath (put = upsert). Creates the DB/store if absent. */
+function mergeIntoStore<T>(dbName: string, storeName: string, keyPath: string, records: T[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(dbName, 1);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(storeName)) {
+        db.createObjectStore(storeName, { keyPath });
+      }
+    };
+    req.onsuccess = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(storeName)) {
+        // Version upgrade didn't run because the DB already existed at a higher
+        // version without this store — nothing to merge into safely.
+        db.close();
+        resolve();
+        return;
+      }
+      const tx = db.transaction(storeName, 'readwrite');
+      const store = tx.objectStore(storeName);
+      for (const rec of records) {
+        store.put(rec);
+      }
+      tx.oncomplete = () => {
+        db.close();
+        resolve();
+      };
+      tx.onerror = () => {
+        db.close();
+        reject(tx.error);
+      };
+    };
+    req.onerror = () => reject(req.error);
+  });
+}
+
+/**
+ * Enumerate stale (non-current) profile prefixes present in IndexedDB.
+ * Intended for the Settings "Clear Cache" UI (PR-5). Returns [] on browsers
+ * without `indexedDB.databases()`.
+ */
+export async function listStalePrefixes(): Promise<string[]> {
+  const currentPrefix = getProfilePrefix();
+  if (typeof indexedDB === 'undefined') {
+    return [];
+  }
+  const idb = indexedDB as unknown as { databases?: () => Promise<Array<{ name?: string }>> };
+  if (typeof idb.databases !== 'function') {
+    return [];
+  }
+  try {
+    const dbs = await idb.databases();
+    const prefixes = new Set<string>();
+    for (const db of dbs) {
+      const match = (db.name ?? '').match(ORPHAN_DB_RE);
+      if (match && match[1] !== currentPrefix) {
+        prefixes.add(match[1]);
+      }
+    }
+    return Array.from(prefixes);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Delete all IndexedDB databases for a given profile prefix.
+ * Intended for the Settings "Clear Cache" UI (PR-5). Best-effort.
+ */
+export async function deleteNamespace(prefix: string): Promise<void> {
+  // Match the system-wide prefix constraint (see getProfilePrefix / DB_NAME
+  // shape regex) so this only acts on real profile namespaces.
+  if (!/^[a-z0-9]{3,8}$/.test(prefix)) {
+    return;
+  }
+  if (typeof indexedDB === 'undefined') {
+    return;
+  }
+  const names = [
+    `${prefix}-doc-qa-documents`,
+    `${prefix}-doc-qa-indexes`,
+    `${prefix}-doc-qa-keywords`,
+  ];
+  await Promise.all(
+    names.map(
+      (name) =>
+        new Promise<void>((resolve) => {
+          const req = indexedDB.deleteDatabase(name);
+          req.onsuccess = () => resolve();
+          req.onerror = () => resolve();
+          req.onblocked = () => resolve();
+        })
+    )
+  );
+}

--- a/web_ui/src/pages/DocumentsPage.indexing.test.tsx
+++ b/web_ui/src/pages/DocumentsPage.indexing.test.tsx
@@ -13,6 +13,7 @@ const mockEmbeddingService = {
 // Mock the vector index
 const mockVectorIndex = {
   isReady: vi.fn(() => true),
+  initialize: vi.fn(async () => {}),
   addBatch: vi.fn(async (_entries: Array<{ docId: string; chunkIndex: number; vector: number[] }>) => {}),
   save: vi.fn(async () => {}),
   removeByDocId: vi.fn(async (_docId: string) => {}),
@@ -28,8 +29,21 @@ const mockKeywordIndex = {
 
 // Mock document store
 const mockLoadDocuments = vi.fn(async () => []);
-const mockSaveDocuments = vi.fn(async () => {});
+const mockSaveDocuments = vi.fn(async (_docs: Array<{ status: string; fileName: string; errorMessage?: string }>) => {});
 const mockDeleteDocumentFromStore = vi.fn(async () => {});
+
+// F2: mock the lazy embedding-service initializer so processFile's readiness
+// guard can be exercised without pulling in the real (heavy) service hook.
+const mockEnsureEmbeddingServiceReady = vi.fn(async () => true);
+
+// F1: migration is best-effort; stub it so the page mount doesn't touch IDB.
+vi.mock('../lib/storage/profile', () => ({
+  migrateOrphanedNamespaces: vi.fn(async () => {}),
+}));
+
+vi.mock('../hooks/useServiceInitialization', () => ({
+  ensureEmbeddingServiceReady: () => mockEnsureEmbeddingServiceReady(),
+}));
 
 // Mock the TextChunker
 vi.mock('../lib/processing/text-chunker', () => ({
@@ -92,6 +106,10 @@ describe('DocumentsPage search index integration', () => {
     mockLoadDocuments.mockClear();
     mockSaveDocuments.mockClear();
     mockDeleteDocumentFromStore.mockClear();
+    mockEnsureEmbeddingServiceReady.mockClear();
+    mockEnsureEmbeddingServiceReady.mockResolvedValue(true);
+    mockVectorIndex.initialize.mockClear();
+    mockVectorIndex.initialize.mockResolvedValue(undefined);
   });
 
   describe('processFile indexing flow', () => {
@@ -224,30 +242,135 @@ describe('DocumentsPage search index integration', () => {
     });
   });
 
-  describe('Error handling', () => {
-    test('9. Indexing continues even if embedding service is not ready', async () => {
-      // Reset mock to return false for isReady
-      mockEmbeddingService.isReady.mockReturnValueOnce(false);
-      mockVectorIndex.isReady.mockReturnValueOnce(false);
-      mockKeywordIndex.isReady.mockReturnValueOnce(false);
+  describe('Error handling (F2: embedding/vector init failures surface an error)', () => {
+    test('9. processFile sets status:error when ensureEmbeddingServiceReady() returns false (no silent skip-to-ready)', async () => {
+      // F2: a document uploaded when the embedding service cannot initialize
+      // must NOT be silently marked 'ready' with no vectors. processFile now
+      // awaits ensureEmbeddingServiceReady() and throws → status:'error'.
+      // This renders the real component and exercises the actual path.
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { render, waitFor, act } = await import('@testing-library/react');
+      const { DocumentsPage } = await import('./DocumentsPage');
 
-      const embeddingServiceReady = mockEmbeddingService.isReady();
-      const vectorIndexReady = mockVectorIndex.isReady();
-      const keywordIndexReady = mockKeywordIndex.isReady();
+      // ensureEmbeddingServiceReady resolves false → ingestion must error.
+      mockEnsureEmbeddingServiceReady.mockResolvedValue(false);
 
-      // When not ready, the indexing should be skipped but not throw
-      if (!embeddingServiceReady && !vectorIndexReady) {
-        // This is the expected behavior - skip vector indexing
+      const { unmount } = render(<DocumentsPage />);
+
+      // Wait for the initial load to finish, then drop a file.
+      await waitFor(() => expect(mockLoadDocuments).toHaveBeenCalled());
+
+      const file = new File(['hello world'], 'test.txt', { type: 'text/plain' });
+      // Trigger the drop via the DropZone input change handler.
+      const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+      expect(input).toBeTruthy();
+      await act(async () => {
+        Object.defineProperty(input, 'files', { value: [file], writable: false, configurable: true });
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+      });
+
+      // The document must reach status:'error', never 'ready'.
+      await waitFor(() => {
+        const saveCalls = mockSaveDocuments.mock.calls;
+        const lastSaved = saveCalls[saveCalls.length - 1]?.[0] as
+          | Array<{ status: string; fileName: string; errorMessage?: string }>
+          | undefined;
+        const doc = lastSaved?.find((d) => d.fileName === 'test.txt');
+        expect(doc?.status).toBe('error');
+        expect(doc?.errorMessage).toMatch(/embedding/i);
+      });
+
+      // And encodeBatch must NOT have been called (no silent indexing).
+      expect(mockEmbeddingService.encodeBatch).not.toHaveBeenCalled();
+
+      unmount();
+    });
+
+    test('F3: deleting a document while it is still processing waits for processing to settle before removing chunks (no orphan chunks)', async () => {
+      // Acceptance criterion #3: "Delete mid-processing leaves no orphan chunks
+      // (verified via index inspection)". The fix: handleDelete awaits the
+      // in-flight processFile promise before calling removeByDocId, so a late
+      // addBatch+save cannot leave orphaned vectors. This test renders the real
+      // component, blocks processFile mid-flight, triggers a delete, and asserts
+      // removeByDocId is called ONLY after processFile settles.
+      const { render, waitFor, act } = await import('@testing-library/react');
+      const { DocumentsPage } = await import('./DocumentsPage');
+
+      // Block processFile inside extractDocument on a deferred we control.
+      const mockExtract = extractDocument as unknown as { mockImplementation: (fn: () => Promise<unknown>) => void };
+      // Holder for the deferred resolver so the test can release the blocked
+      // extraction on demand. Typed as an array to dodge TS control-flow
+      // narrowing of closure-captured lets.
+      const releaseHolder: Array<() => void> = [];
+      const extractionBlocked = new Promise<void>((resolve) => {
+        releaseHolder.push(resolve);
+      });
+      mockExtract.mockImplementation(async () => {
+        await extractionBlocked;
+        return {
+          fullText: 'content for the in-flight document',
+          pages: [{ pageNumber: 1, text: 'content for the in-flight document' }],
+          metadata: {},
+        };
+      });
+
+      // embedding + vector index are ready so processFile proceeds to indexing
+      // once extraction resolves (then we'll have chunks to remove).
+      mockEnsureEmbeddingServiceReady.mockResolvedValue(true);
+      mockEmbeddingService.isReady.mockReturnValue(true);
+      mockVectorIndex.isReady.mockReturnValue(true);
+      mockEmbeddingService.encodeBatch.mockResolvedValue([new Array(384).fill(0)]);
+
+      const { unmount } = render(<DocumentsPage />);
+      await waitFor(() => expect(mockLoadDocuments).toHaveBeenCalled());
+
+      const file = new File(['in-flight content'], 'inflight.txt', { type: 'text/plain' });
+      const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+      await act(async () => {
+        Object.defineProperty(input, 'files', { value: [file], writable: false, configurable: true });
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+      });
+
+      // Wait until processFile has started (status flips to 'processing').
+      await waitFor(() => {
+        const calls = mockSaveDocuments.mock.calls;
+        const last = calls[calls.length - 1]?.[0];
+        return !!last?.some((d: { fileName: string; status: string }) => d.fileName === 'inflight.txt' && d.status === 'processing');
+      });
+
+      // Sanity: removeByDocId has NOT been called yet (no delete happened).
+      expect(mockVectorIndex.removeByDocId).not.toHaveBeenCalled();
+
+      // Trigger deletion of the still-processing document. handleDelete should
+      // await the in-flight processFile, so it stays pending while extraction
+      // is blocked. We don't await the delete here; we fire it and let it hang.
+      // Find the delete button for the row (aria-label="Delete <filename>").
+      await waitFor(() => {
+        const btns = document.querySelectorAll('button[aria-label^="Delete "]');
+        expect(btns.length).toBeGreaterThan(0);
+      });
+      const deleteButton = document.querySelector('button[aria-label^="Delete "]') as HTMLButtonElement;
+      await act(async () => {
+        deleteButton.click();
+      });
+
+      // The delete is now in flight and waiting on processFile. removeByDocId
+      // must still NOT have been called because processFile hasn't settled
+      // (extraction is blocked) — proving handleDelete awaits the in-flight work.
+      await new Promise((r) => setTimeout(r, 50));
+      expect(mockVectorIndex.removeByDocId).not.toHaveBeenCalled();
+
+      // Release the blocked extraction so processFile can complete. handleDelete
+      // (awaiting it) then proceeds to removeByDocId.
+      for (const release of releaseHolder) {
+        release();
       }
 
-      if (!keywordIndexReady) {
-        // Skip keyword indexing
-      }
+      await waitFor(() => {
+        expect(mockVectorIndex.removeByDocId).toHaveBeenCalled();
+      });
 
-      // No error should be thrown
-      expect(embeddingServiceReady).toBe(false);
-      expect(vectorIndexReady).toBe(false);
-      expect(keywordIndexReady).toBe(false);
+      unmount();
     });
 
     test('10. Deletion continues even if index removal fails', async () => {

--- a/web_ui/src/pages/DocumentsPage.indexing.test.tsx
+++ b/web_ui/src/pages/DocumentsPage.indexing.test.tsx
@@ -28,7 +28,7 @@ const mockKeywordIndex = {
 };
 
 // Mock document store
-const mockLoadDocuments = vi.fn(async () => []);
+const mockLoadDocuments = vi.fn(async (): Promise<Array<{ id: string; fileName: string; fileSize: number; fileType: string; status: string; progress: number; uploadedAt: number; errorMessage?: string; chunkCount?: number }>> => []);
 const mockSaveDocuments = vi.fn(async (_docs: Array<{ status: string; fileName: string; errorMessage?: string }>) => {});
 const mockDeleteDocumentFromStore = vi.fn(async () => {});
 
@@ -393,6 +393,112 @@ describe('DocumentsPage search index integration', () => {
       expect(mockVectorIndex.removeByDocId).toHaveBeenCalledWith(docId);
       // keywordIndex.removeByDocId should still be called (deletion continues)
       expect(mockKeywordIndex.removeByDocId).toHaveBeenCalledWith(docId);
+    });
+  });
+
+  describe('F4/F5/F13 behavioral coverage (PRR-004)', () => {
+    test('F5: a duplicate fileName+fileSize upload is skipped and surfaces a notice', async () => {
+      const { render, waitFor, act } = await import('@testing-library/react');
+      const { DocumentsPage } = await import('./DocumentsPage');
+
+      // Seed the document store with an existing document.
+      mockLoadDocuments.mockResolvedValueOnce([
+        { id: 'existing-1', fileName: 'dup.txt', fileSize: 100, fileType: '.txt', status: 'ready', progress: 100, uploadedAt: 1000 },
+      ]);
+      mockEnsureEmbeddingServiceReady.mockResolvedValue(true);
+      mockEmbeddingService.isReady.mockReturnValue(true);
+      mockVectorIndex.isReady.mockReturnValue(true);
+      mockEmbeddingService.encodeBatch.mockResolvedValue([new Array(384).fill(0)]);
+
+      const { unmount, container } = render(<DocumentsPage />);
+      await waitFor(() => expect(mockLoadDocuments).toHaveBeenCalled());
+
+      // Drop a file with the same name+size as the existing document.
+      const file = new File(['x'.repeat(100)], 'dup.txt', { type: 'text/plain' });
+      expect(file.size).toBe(100);
+      const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+      await act(async () => {
+        Object.defineProperty(input, 'files', { value: [file], writable: false, configurable: true });
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+      });
+
+      // A duplicate-skip notice must appear, and encodeBatch must NOT run for it.
+      await waitFor(() => {
+        expect(container.textContent).toMatch(/Skipped duplicate file: dup\.txt/);
+      });
+      expect(mockEmbeddingService.encodeBatch).not.toHaveBeenCalled();
+
+      unmount();
+    });
+
+    test('F13: a delete cancels an armed stale debounced save so it cannot resurrect the doc', async () => {
+      const { render, waitFor, act } = await import('@testing-library/react');
+      const { DocumentsPage } = await import('./DocumentsPage');
+
+      // Seed a ready document.
+      mockLoadDocuments.mockResolvedValueOnce([
+        { id: 'del-1', fileName: 'todelete.txt', fileSize: 50, fileType: '.txt', status: 'ready', progress: 100, uploadedAt: 1000 },
+      ]);
+      mockVectorIndex.isReady.mockReturnValue(true);
+      mockKeywordIndex.isReady.mockReturnValue(true);
+
+      const { unmount } = render(<DocumentsPage />);
+      await waitFor(() => expect(mockLoadDocuments).toHaveBeenCalled());
+
+      // Click delete on the ready document.
+      await waitFor(() => {
+        expect(document.querySelector('button[aria-label^="Delete "]')).toBeTruthy();
+      });
+      const saveCountBefore = mockSaveDocuments.mock.calls.length;
+      await act(async () => {
+        (document.querySelector('button[aria-label^="Delete "]') as HTMLButtonElement).click();
+      });
+
+      // After delete settles, the most recent save must NOT contain the deleted doc.
+      await waitFor(() => {
+        const calls = mockSaveDocuments.mock.calls;
+        expect(calls.length).toBeGreaterThan(saveCountBefore);
+      });
+      const lastSaved = mockSaveDocuments.mock.calls[mockSaveDocuments.mock.calls.length - 1]?.[0] as
+        Array<{ fileName: string }> | undefined;
+      expect(lastSaved?.some((d) => d.fileName === 'todelete.txt')).toBe(false);
+
+      unmount();
+    });
+
+    test('F4: unmount while a debounced save is pending flushes the latest documents', async () => {
+      const { render, waitFor, act } = await import('@testing-library/react');
+      const { DocumentsPage } = await import('./DocumentsPage');
+
+      // The component mounts, loadDocuments returns [], then we trigger an
+      // upload that mutates state within the 500ms debounce window, then
+      // immediately unmount — the pending save should flush.
+      mockEnsureEmbeddingServiceReady.mockResolvedValue(false); // error fast, no encode
+      const { unmount } = render(<DocumentsPage />);
+      await waitFor(() => expect(mockLoadDocuments).toHaveBeenCalled());
+
+      const file = new File(['flush-test'], 'flush.txt', { type: 'text/plain' });
+      const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+      await act(async () => {
+        Object.defineProperty(input, 'files', { value: [file], writable: false, configurable: true });
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+      });
+
+      // Unmount immediately (within the 500ms debounce). A flush save should fire.
+      const callsBeforeUnmount = mockSaveDocuments.mock.calls.length;
+      unmount();
+
+      // Allow the fire-and-forget flush promise to settle.
+      await waitFor(() => {
+        expect(mockSaveDocuments.mock.calls.length).toBeGreaterThan(callsBeforeUnmount);
+      });
+      // The flushed save should include the uploaded file's entry.
+      const flushedCalls = mockSaveDocuments.mock.calls.slice(callsBeforeUnmount);
+      const sawFlushEntry = flushedCalls.some((c) => {
+        const docs = c[0] as Array<{ fileName: string }> | undefined;
+        return docs?.some((d) => d.fileName === 'flush.txt');
+      });
+      expect(sawFlushEntry).toBe(true);
     });
   });
 

--- a/web_ui/src/pages/DocumentsPage.tsx
+++ b/web_ui/src/pages/DocumentsPage.tsx
@@ -72,7 +72,21 @@ export function DocumentsPage() {
         if (cancelled) return;
         const docs = await loadDocuments();
         if (cancelled) return;
-        setDocuments(docs);
+        // PRR-007: a browser/tab close during processing leaves documents
+        // persisted with a non-terminal status ('processing'/'uploading') and
+        // no in-flight promise to resume them. Reset any such stale documents
+        // to 'error' so they don't render stuck forever; the user can delete
+        // and re-add them.
+        const recovered = docs.map((doc) =>
+          doc.status === 'processing' || doc.status === 'uploading'
+            ? {
+                ...doc,
+                status: 'error' as const,
+                errorMessage: 'Processing was interrupted. Please delete and re-add this document.',
+              }
+            : doc
+        );
+        setDocuments(recovered);
       } catch (error) {
         console.error('Failed to load documents:', error);
       } finally {
@@ -306,9 +320,12 @@ export function DocumentsPage() {
       const skipped: string[] = [];
 
       for (const file of files) {
-        const isDuplicate = existing.some(
-          (doc) => doc.fileName === file.name && doc.fileSize === file.size
-        );
+        // F5/PRR-010: dedup against both the existing documents AND any entries
+        // already accepted in THIS batch, so two identical files dropped together
+        // don't both create independent chunk sets.
+        const isDuplicate =
+          existing.some((doc) => doc.fileName === file.name && doc.fileSize === file.size) ||
+          accepted.some((a) => a.entry.fileName === file.name && a.entry.fileSize === file.size);
         if (isDuplicate) {
           skipped.push(file.name);
           continue;

--- a/web_ui/src/pages/DocumentsPage.tsx
+++ b/web_ui/src/pages/DocumentsPage.tsx
@@ -9,7 +9,9 @@ import type { DocumentEntry } from '../types/document';
 import { extractDocument, SUPPORTED_EXTENSIONS } from '../lib/processing/extractor-factory';
 import { TextChunker } from '../lib/processing/text-chunker';
 import { loadDocuments, saveDocuments, deleteDocument as deleteDocumentFromStore } from '../lib/storage/document-store';
+import { migrateOrphanedNamespaces } from '../lib/storage/profile';
 import { getEmbeddingService } from '../lib/embeddings/embedding-service';
+import { ensureEmbeddingServiceReady } from '../hooks/useServiceInitialization';
 import { getVectorIndex } from '../lib/search/vector-index';
 import { getKeywordIndex } from '../lib/search/keyword-index';
 
@@ -24,7 +26,16 @@ export function DocumentsPage() {
   // F9: one-time banner when the embedding model was upgraded and the stored
   // vector index was discarded as incompatible (see VECTOR_INDEX_VERSION).
   const [showReindexNotice, setShowReindexNotice] = useState(false);
+  // F5: transient notice shown when a duplicate file upload is skipped.
+  const [duplicateNotice, setDuplicateNotice] = useState<string | null>(null);
   const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // F4/F13: latest documents mirror so the debounced save reads CURRENT state
+  // at fire-time (not the schedule-time snapshot) and the unmount flush can
+  // capture the newest state.
+  const latestDocumentsRef = useRef<DocumentEntry[]>([]);
+  // F3: in-flight processFile promises keyed by docId, so handleDelete can wait
+  // for processing to settle before removing chunks (avoids orphan chunks).
+  const processingPromisesRef = useRef<Map<string, Promise<void>>>(new Map());
 
   // F9: surface the re-index requirement once. The flag is set by VectorIndex
   // on version mismatch; cleared here on dismiss so the user sees it once.
@@ -49,22 +60,41 @@ export function DocumentsPage() {
     }
   }, []);
 
-  // Load documents from IndexedDB on mount
+  // Load documents from IndexedDB on mount.
+  // F1: run the one-time orphan-namespace migration before loading so any
+  // documents left in a legacy per-session namespace are folded into the
+  // current stable profile first. Migration is best-effort and never throws.
   useEffect(() => {
+    let cancelled = false;
     async function load() {
       try {
+        await migrateOrphanedNamespaces();
+        if (cancelled) return;
         const docs = await loadDocuments();
+        if (cancelled) return;
         setDocuments(docs);
       } catch (error) {
         console.error('Failed to load documents:', error);
       } finally {
-        setIsLoading(false);
+        if (!cancelled) setIsLoading(false);
       }
     }
     load();
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
-  // Save documents to IndexedDB when they change (debounced)
+  // Keep the latest-documents ref in sync so the debounced save and the unmount
+  // flush always read CURRENT state (F4/F13).
+  useEffect(() => {
+    latestDocumentsRef.current = documents;
+  }, [documents]);
+
+  // Save documents to IndexedDB when they change (debounced).
+  // F13: the save callback reads latestDocumentsRef.current at FIRE TIME rather
+  // than closing over the schedule-time `documents` snapshot, so a stale armed
+  // timer cannot resurrect a just-deleted document via clear-and-rewrite-all.
   useEffect(() => {
     if (isLoading) return;
 
@@ -74,7 +104,7 @@ export function DocumentsPage() {
 
     saveTimeoutRef.current = setTimeout(async () => {
       try {
-        await saveDocuments(documents);
+        await saveDocuments(latestDocumentsRef.current);
       } catch (error) {
         console.error('Failed to save documents:', error);
       }
@@ -87,9 +117,29 @@ export function DocumentsPage() {
     };
   }, [documents, isLoading]);
 
-  // Process a single file and update document state
+  // F4: flush the pending debounced save on unmount so navigating away within
+  // the 500ms debounce window does not lose the latest document-list change.
+  // This is best-effort: SPA navigation keeps the IndexedDB transaction alive,
+  // but a hard tab close / bfcache eviction may abort it (documented residual).
+  useEffect(() => {
+    return () => {
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current);
+        saveTimeoutRef.current = null;
+        void saveDocuments(latestDocumentsRef.current).catch((error) => {
+          console.error('Failed to flush documents on unmount:', error);
+        });
+      }
+    };
+  }, []);
+
+  // Process a single file and update document state.
+  // F3: the in-flight promise is registered in processingPromisesRef so
+  // handleDelete can await it (delete-while-processing would otherwise leave
+  // orphan chunks). Registered immediately and cleared in a finally.
   const processFile = useCallback(async (file: File, docId: string) => {
-    const chunker = new TextChunker();
+    const run = async () => {
+      const chunker = new TextChunker();
 
     try {
       // Update status to processing
@@ -127,33 +177,60 @@ export function DocumentsPage() {
         )
       );
 
-      // Compute embeddings and add to VectorIndex
-      const embeddingService = getEmbeddingService();
+      // F2: ensure BOTH the embedding service and the vector index are ready
+      // before deciding whether to vector-index. The embedding model is
+      // deferred to first use (useServiceInitialization), and the vector index
+      // initializes on boot — awaiting both resolves any boot/first-use race
+      // so a document uploaded before the first chat query is actually indexed
+      // (previously it was silently skipped and marked 'ready' with no vectors).
+      // Show a "loading model" progress stage so the UI isn't silent during the
+      // (one-time) model load.
+      setDocuments((prev) =>
+        prev.map((doc) =>
+          doc.id === docId
+            ? { ...doc, status: 'processing', progress: 78 }
+            : doc
+        )
+      );
+      const embeddingOk = await ensureEmbeddingServiceReady();
       const vectorIndex = getVectorIndex();
+      try {
+        await vectorIndex.initialize(); // idempotent
+      } catch (initError) {
+        console.error('Vector index initialization failed:', initError);
+      }
+      const embeddingService = getEmbeddingService();
       const keywordIndex = getKeywordIndex();
+
+      // F2: if the embedding model could not initialize, surface a clear error
+      // instead of silently marking the document ready (which left it invisible
+      // to semantic search forever).
+      if (!embeddingOk || !embeddingService.isReady() || !vectorIndex.isReady()) {
+        throw new Error(
+          'Could not initialize the embedding search model. The document was added but is not searchable by semantic search. Reload the page and try again.'
+        );
+      }
 
       // Vector index: embed and add. Pass the chunk's already-present text,
       // source (filename) and page so vector search results carry real text and
       // citation metadata (F1/F7). NOTE: this minimal metadata capture overlaps
       // with PR-4 (#23), which owns broader ingestion work.
-      if (embeddingService.isReady() && vectorIndex.isReady()) {
-        try {
-          const texts = chunks.map((c) => c.text);
-          const vectors = await embeddingService.encodeBatch(texts);
-          const entries = chunks.map((chunk, i) => ({
-            docId: chunk.docId!,
-            chunkIndex: chunk.chunkIndex,
-            vector: vectors[i],
-            text: chunk.text,     // F1: real chunk text for grounded context
-            source: chunk.source, // F7: filename for citations
-            page: chunk.page,     // F7: page number for citations
-          }));
-          await vectorIndex.addBatch(entries);
-          await vectorIndex.save();
-        } catch (indexError) {
-          console.error('Failed to add to vector index:', indexError);
-          // Continue so keyword indexing can proceed
-        }
+      try {
+        const texts = chunks.map((c) => c.text);
+        const vectors = await embeddingService.encodeBatch(texts);
+        const entries = chunks.map((chunk, i) => ({
+          docId: chunk.docId!,
+          chunkIndex: chunk.chunkIndex,
+          vector: vectors[i],
+          text: chunk.text,     // F1: real chunk text for grounded context
+          source: chunk.source, // F7: filename for citations
+          page: chunk.page,     // F7: page number for citations
+        }));
+        await vectorIndex.addBatch(entries);
+        await vectorIndex.save();
+      } catch (indexError) {
+        console.error('Failed to add to vector index:', indexError);
+        // Continue so keyword indexing can proceed
       }
 
       // Keyword index: add text chunks
@@ -203,43 +280,111 @@ export function DocumentsPage() {
         )
       );
     }
+    }; // end run()
+
+    const p = run();
+    processingPromisesRef.current.set(docId, p);
+    try {
+      await p;
+    } finally {
+      // Only delete our entry if it still points at this promise (a later call
+      // for the same docId may have replaced it).
+      if (processingPromisesRef.current.get(docId) === p) {
+        processingPromisesRef.current.delete(docId);
+      }
+    }
   }, []);
 
-  // Handle file selection from DropZone
+  // Handle file selection from DropZone.
+  // F5: skip files that duplicate an existing document by fileName + fileSize
+  // (re-uploading previously created a second independent set of chunks in both
+  // indexes). Skipped files surface a transient notice.
   const handleFilesSelected = useCallback(
     async (files: File[]) => {
-      const newEntries: DocumentEntry[] = files.map((file) => ({
-        id: generateId(),
-        fileName: file.name,
-        fileSize: file.size,
-        fileType: file.name.slice(file.name.lastIndexOf('.')).toLowerCase(),
-        status: 'uploading' as const,
-        progress: 0,
-        uploadedAt: Date.now(),
-      }));
+      const existing = latestDocumentsRef.current;
+      const accepted: { file: File; entry: DocumentEntry }[] = [];
+      const skipped: string[] = [];
+
+      for (const file of files) {
+        const isDuplicate = existing.some(
+          (doc) => doc.fileName === file.name && doc.fileSize === file.size
+        );
+        if (isDuplicate) {
+          skipped.push(file.name);
+          continue;
+        }
+        accepted.push({
+          file,
+          entry: {
+            id: generateId(),
+            fileName: file.name,
+            fileSize: file.size,
+            fileType: file.name.slice(file.name.lastIndexOf('.')).toLowerCase(),
+            status: 'uploading' as const,
+            progress: 0,
+            uploadedAt: Date.now(),
+          },
+        });
+      }
+
+      if (skipped.length > 0) {
+        setDuplicateNotice(
+          skipped.length === 1
+            ? `Skipped duplicate file: ${skipped[0]}`
+            : `Skipped ${skipped.length} duplicate files`
+        );
+      }
+
+      if (accepted.length === 0) {
+        return;
+      }
 
       // Add new entries to state
-      setDocuments((prev) => [...newEntries, ...prev]);
+      setDocuments((prev) => [...accepted.map((a) => a.entry), ...prev]);
 
-      // Process each file
-      for (let i = 0; i < newEntries.length; i++) {
-        const entry = newEntries[i];
-        const file = files[i];
-        if (file) {
-          await processFile(file, entry.id);
-        }
+      // Process each accepted file
+      for (const { file, entry } of accepted) {
+        await processFile(file, entry.id);
       }
     },
     [processFile]
   );
 
-  // Handle document deletion
+  // Auto-dismiss the duplicate notice after a few seconds.
+  useEffect(() => {
+    if (!duplicateNotice) return;
+    const t = setTimeout(() => setDuplicateNotice(null), 4000);
+    return () => clearTimeout(t);
+  }, [duplicateNotice]);
+
+  // Handle document deletion.
+  // F3: if the document is still being processed, await the in-flight
+  // processFile first so its addBatch/save either completes (and is then
+  // removed) or the delete sees the terminal state — preventing permanent
+  // orphan chunks from a delete-while-processing race. processFile never
+  // rejects (top-level try/catch), so this resolves even on extraction failure.
+  // F13: cancel any pending debounced save so a stale snapshot can't resurrect
+  // the deleted document; the state update below re-arms the debounce with the
+  // post-delete list (read from the ref at fire time).
   const handleDelete = useCallback(async (docId: string) => {
     setDeletingId(docId);
 
     try {
+      // F3: wait for in-flight processing to settle.
+      const inFlight = processingPromisesRef.current.get(docId);
+      if (inFlight) {
+        await inFlight;
+      }
+
       // Remove from IndexedDB
       await deleteDocumentFromStore(docId);
+
+      // F13: cancel any armed debounced save so it cannot fire with a stale
+      // snapshot that still includes this document.
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current);
+        saveTimeoutRef.current = null;
+      }
 
       // Remove from search indexes
       try {
@@ -387,6 +532,25 @@ export function DocumentsPage() {
           >
             ×
           </button>
+        </div>
+      )}
+
+      {/* F5: transient duplicate-upload notice. */}
+      {duplicateNotice && (
+        <div
+          role="status"
+          aria-live="polite"
+          style={{
+            padding: 'var(--spacing-xs) var(--spacing-sm)',
+            borderRadius: '8px',
+            backgroundColor: 'var(--color-bubble-system)',
+            color: 'var(--color-text-muted)',
+            fontSize: 'var(--font-size-small)',
+            fontFamily: 'var(--font-family)',
+            flexShrink: 0,
+          }}
+        >
+          {duplicateNotice}
         </div>
       )}
 

--- a/web_ui/src/types/document.ts
+++ b/web_ui/src/types/document.ts
@@ -63,4 +63,12 @@ export interface DocumentChunk {
   chunkIndex: number;
   docId?: string;
   sourcePath?: string;
+  /**
+   * Character offset of the start of this chunk into the cleaned full text
+   * (F8). Used for reliable PDF page attribution by mapping the offset against
+   * per-page text boundaries, instead of the unreliable prefix-string matching
+   * that preceded it. Consumed by RAG retrieval (issue #22) for citations.
+   * Optional so older callers and stored shapes remain valid.
+   */
+  charOffset?: number;
 }

--- a/web_ui/vite.config.ts
+++ b/web_ui/vite.config.ts
@@ -5,7 +5,19 @@ import path from 'path';
 /**
  * Vite plugin to handle edgevec WASM package internal imports.
  * edgevec's JS bundle imports from ./snippets/ which may not resolve
- * during Rollup production builds.
+ * during Rollup production builds (edgevec 0.6.0 ships without its snippets/
+ * directory), so we stub the storage backend it imports.
+ *
+ * Contract note (F17): the stub must match the real edgevec backend's miss
+ * behavior. The real IndexedDbBackend lives at the content-addressed snippet
+ * path `edgevec-98e271a617b3aceb` (the hash edgevec.js:1 imports). That exact
+ * directory is shipped in edgevec 0.9.0 on npm; its `read(name)` REJECTS with
+ * "File <name> not found" when there is no saved index, and resolves with the
+ * Uint8Array data on hit. The previous stub resolved `null` on miss, which the
+ * Rust `edgevec_load` deserializer treated as truncated/corrupt data and
+ * rejected with ERR_CORRUPTION on every fresh boot. Rejecting on miss makes
+ * `edgevec_load` reject cleanly, which VectorIndex.load() already catches as
+ * the "no index yet" path — no console error on a fresh boot.
  */
 function edgevecSnippetPlugin(): Plugin {
   const VIRTUAL_SNIPPET_ID = '\0edgevec-snippet';
@@ -28,7 +40,18 @@ export class IndexedDbBackend {
         const tx = req.result.transaction('data', 'readonly');
         const store = tx.objectStore('data');
         const getReq = store.get(dbName);
-        getReq.onsuccess = () => resolve(getReq.result || null);
+        getReq.onsuccess = () => {
+          if (getReq.result) {
+            resolve(getReq.result);
+          } else {
+            // Match the real edgevec backend contract (content-addressed
+            // snippet edgevec-98e271a617b3aceb, shipped in 0.9.0): reject on
+            // miss so the Rust edgevec_load surfaces a Promise rejection
+            // (clean "no index" path) rather than resolving null, which the
+            // WASM deserializer treats as corrupt data (ERR_CORRUPTION).
+            reject(new Error('EdgeVec index not found: ' + dbName));
+          }
+        };
         getReq.onerror = () => reject(getReq.error);
       };
       req.onerror = () => reject(req.error);


### PR DESCRIPTION
Closes #23

## Summary

PR-4/7 of the `web_ui/` audit: makes the document corpus reliable. Closes all 16 actionable findings in issue #23 (F10 — the UTF-16 mojibake claim — is an explicit skip, per the issue, as it was independently refuted). Rebased onto `master` (which now includes #20/#21/#22) and reconciled the overlapping memory-tiering work with #21's F4.

### Findings closed
- **F1 (CRITICAL):** Replaced the per-session `sessionStorage` UUID namespace (cleared on browser close, per-tab isolated) with a stable `localStorage`-backed profile id. New `lib/storage/profile.ts` is the single source of truth for the 3 stores (was copy-pasted 3×). One-time best-effort migration of orphaned per-session DBs (Chrome `indexedDB.databases()`; Firefox/Safari skip without setting the flag so a later Chrome session can migrate).
- **F2 (CRITICAL):** `processFile` now `await`s `ensureEmbeddingServiceReady()` + `vectorIndex.initialize()` before vector indexing, and surfaces a clear `status:'error'` on init failure (previously silently marked 'ready' with zero vectors → invisible to semantic search).
- **F3 (HIGH):** `handleDelete` now awaits the in-flight `processFile` for a doc before removing chunks, so a delete-while-processing can't leave permanent orphan vectors. In-flight promises tracked in a ref (cleaned in `finally`).
- **F4 (HIGH):** Unmount now flushes the pending debounced save instead of just clearing the timer.
- **F5 (MEDIUM):** Duplicate uploads (same fileName + fileSize) are skipped with a transient notice.
- **F6 (MEDIUM):** CJK/no-whitespace text is chunked by character count (`Intl.Segmenter`-aware heuristic) instead of collapsing into one mega-chunk.
- **F7 (MEDIUM):** Fixed the `chunkOverlap=1` off-by-zero (`slice(-Math.floor(1/2))` → entire chunk → infinite loop). Now guaranteed forward progress for all overlap values. **Acceptance criterion: `chunkOverlap:1` terminates (unit test).**
- **F8 (MEDIUM):** PDF page attribution re-derived from each chunk's char offset (post-processing forward-substring pass in normalized space), replacing the prefix-matching that only attributed chunk 0. Adds `charOffset` to `DocumentChunk` — **consumed by #22 (PR-3) for citations.**
- **F9 (LOW):** `splitSentences` now preserves abbreviation casing (`Dr.` not `dr.`) and protects `e.g.`/`i.e.`.
- **F11 (MEDIUM):** `VectorIndex.save` writes idMapping BEFORE the EdgeVec snapshot (partial failure leaves previous consistent state); `search()` skips unresolvable ids instead of fabricating `docId:'unknown'`.
- **F12 (MEDIUM):** Replaced the binary ≥8GB overhead cliff with a graduated taper; reconciled with #21 F4 (unknown deviceMemory → 8GB high-capacity).
- **F13 (MEDIUM):** Debounced save reads CURRENT state at fire-time (via ref), and `handleDelete` cancels any armed stale save — no resurrection.
- **F14 (LOW):** `encodeBatch` validates the returned tensor shape (`dims[0]` + `data.length`) before slicing.
- **F15 (LOW):** Loosened MIME validation (added `x-pdf`, `x-zip-compressed`, etc.); drag-drop now applies the same `accept` filter as the file picker.
- **F16 (INFO):** XLSX row numbers preserve their original spreadsheet index through the empty-row skip.
- **F17 (MEDIUM):** Fixed the edgevec snippet stub to **reject** on miss (matching the real backend — verified against npm-fetched edgevec@0.9.0's shipped snippet, content-addressed hash `edgevec-98e271a617b3aceb`) instead of resolving `null`, which the WASM deserializer treated as corrupt (ERR_CORRUPTION) on every fresh boot. Fresh boot now logs at info, not error.

## Invariant audit
- **Conventions:** `fix(web_ui): <desc> (Issue #N)` per repo history.
- **Scope:** only issue-#23-owned files touched (DocumentsPage, DropZone, processing/*, storage, search indexes, memory-aware, vite edgevec stub, types). No sibling-PR-owned concerns (drag-highlight→PR-6, contrast→PR-6, Clear Cache→PR-5, text-loss-on-search→PR-3).
- **Rebase reconciliation:** #21 F4 changed `getDeviceMemory()` unknown-fallback to 8GB; this PR's F12 graduated taper was reconciled to layer on top (unknown→8→normal, consistent with #21; known mid-range gets graduated overhead). Memory-aware tests updated to match the reconciled behavior.
- **No build artifacts staged** (`.zcode/` trace artifacts are gitignored and not committed).

## Test plan
All run against the rebased branch (master + #21/#22 + this PR):
- `npm run typecheck:all` → **clean** (`tsc --noEmit && tsc --noEmit -p tsconfig.test.json`)
- `npm run test` → **53 files, 866 passed, 1 skipped** (was 44 files / 804 passed on the pre-#21/#22 baseline; +34 tests from this PR's new/updated tests)
- `npm run build` → **✓ built in 9.32s**

### New/updated behavioral tests
- `profile.test.ts` (new, 12): stable prefix, migration flag correctness, no-throw on enumeration failure.
- `text-chunker.test.ts` (new, 12): overlap=1 termination + depth, CJK multi-chunk, page attribution, abbreviation case.
- `vector-index.test.ts`: F17 not-found (info not error) + corruption (error); F11 skip unmapped.
- `keyword-index.test.ts`: F11 skip unmapped; F1 stable-namespace.
- `memory-aware.test.ts`: F12 graduated taper for known mid-range + unknown-not-critical.
- `embedding-service.test.ts`: F14 shape-mismatch + too-small throws.
- `DocumentsPage.indexing.test.tsx`: **F2** real render asserting `status:'error'` on init failure; **F3** real render asserting delete-during-processing awaits the in-flight `processFile` (removeByDocId not called while blocked, called after release).

### Acceptance criteria
- [x] Documents survive browser close/reopen (F1)
- [x] Doc uploaded before first chat present in vector search (F2)
- [x] Delete mid-processing leaves no orphan chunks — verified by behavioral test (F3)
- [x] Rapid nav during pending save does not desync (F4)
- [x] Fresh boot no ERR_CORRUPTION console error (F17)
- [x] TextChunker with chunkOverlap:1 terminates (F7)

### Validation gates (swarm)
- Independent plan critic (GLM-5.2): NEEDS_REVISION → Rev 2 addressing 16 defects.
- Independent implementation reviewer (GLM-5.2): NEEDS_REVISION → added missing behavioral tests (F2 render, F17, keyword-F11) + minor fixes.
- Final critic (GLM-5.2): NEEDS_REVISION → added the F3 behavioral test the acceptance criteria require.

## Known caveats
- F4 unmount flush is best-effort: SPA navigation keeps the IDB transaction alive, but a hard tab-close / bfcache eviction may abort it (documented in-code).
- F1 migration is Chrome/Edge-only (`indexedDB.databases()`); Firefox/Safari skip and the flag is not set, so a later Chrome session can still migrate.
- `listStalePrefixes`/`deleteNamespace` are exported for PR-5's (Settings Clear Cache) consumption but not wired to any UI here.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/trainingapp/pull/30?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

