### PR TITLE
fix(web_ui): settings page rebuild — Clear Cache, engine-aware status, theme, a11y (Issue #24)

### DIFF
--- a/web_ui/src/lib/llm/readiness-gate.ts
+++ b/web_ui/src/lib/llm/readiness-gate.ts
@@ -34,8 +34,12 @@ const readinessGateInstance: { current: ModelReadinessGate | null } = { current:
  * truth so the readiness gate, the download flow, and the LLM services never
  * disagree on which model id an engine uses (a prior hardcoded id mismatch
  * made `isModelReady` unreachable for webllm — see issue #21 F3).
+ *
+ * Exported so SettingsPage can resolve the same model id when checking cache
+ * status for the selected engine (issue #24 F4) instead of re-deriving it
+ * inline and risking drift from this single source of truth.
  */
-function modelIdForEngine(engine: BrowserEngine): string {
+export function modelIdForEngine(engine: BrowserEngine): string {
   return engine === 'wllama' ? LLM_MODEL_DIR : WEBLLM_DEFAULT_MODEL_ID;
 }
 

--- a/web_ui/src/lib/theme/ThemeContext.test.tsx
+++ b/web_ui/src/lib/theme/ThemeContext.test.tsx
@@ -128,12 +128,17 @@ describe('ThemeContext — setTheme + system mode (issue #24 F5)', () => {
       setOsPreference(true);
     });
     expect(contextValue!.theme).toBe('dark');
+    // ADV-1: themePreference must STAY 'system' after an OS change (not flip
+    // to 'dark'), because no explicit preference was stored.
+    expect(contextValue!.themePreference).toBe('system');
+    expect(localStorage.getItem('theme-preference')).toBeNull();
 
     // OS switches back to light.
     act(() => {
       setOsPreference(false);
     });
     expect(contextValue!.theme).toBe('light');
+    expect(contextValue!.themePreference).toBe('system');
   });
 
   test('explicit preference overrides OS preference changes', () => {

--- a/web_ui/src/lib/theme/ThemeContext.test.tsx
+++ b/web_ui/src/lib/theme/ThemeContext.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * ThemeContext tests — issue #24 F5.
+ *
+ * Covers the new `setTheme(mode)` API and the 'system' mode behavior:
+ * - setTheme('light'/'dark') persists an explicit preference and applies it.
+ * - setTheme('system') CLEARS the stored preference so the media-query
+ *   listener follows OS changes (the bug: toggleTheme re-wrote the key).
+ * - The media-query listener updates theme when no explicit preference is
+ *   stored, and does NOT override an explicit preference.
+ */
+
+import React from 'react';
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { ThemeProvider, useTheme } from './ThemeContext';
+
+// A consumer that exposes the context value via a test handle.
+let contextValue: ReturnType<typeof useTheme> | null = null;
+function ContextProbe(): React.ReactElement {
+  contextValue = useTheme();
+  return <div data-testid="probe">{contextValue.theme}</div>;
+}
+
+function renderProvider(): ReturnType<typeof render> {
+  contextValue = null;
+  return render(
+    <ThemeProvider>
+      <ContextProbe />
+    </ThemeProvider>
+  );
+}
+
+describe('ThemeContext — setTheme + system mode (issue #24 F5)', () => {
+  let matchMediaListeners: ((e: MediaQueryListEvent) => void)[];
+  let matches: boolean;
+
+  beforeEach(() => {
+    matchMediaListeners = [];
+    matches = false; // OS preference = light by default
+    localStorage.clear();
+
+    // Provide a controllable matchMedia mock so tests can toggle the OS
+    // preference and dispatch change events.
+    window.matchMedia = ((query: string): MediaQueryList => ({
+      matches,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: (_event: string, listener: EventListener) => {
+        matchMediaListeners.push(listener as (e: MediaQueryListEvent) => void);
+      },
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    })) as typeof window.matchMedia;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    contextValue = null;
+  });
+
+  /** Simulate the OS color scheme changing. */
+  function setOsPreference(isDark: boolean) {
+    matches = isDark;
+    const event = { matches: isDark } as MediaQueryListEvent;
+    for (const listener of matchMediaListeners) {
+      listener(event);
+    }
+  }
+
+  test('setTheme("dark") persists and applies dark theme', () => {
+    renderProvider();
+    expect(contextValue!.theme).toBe('light');
+    expect(contextValue!.themePreference).toBe('system');
+
+    act(() => {
+      contextValue!.setTheme('dark');
+    });
+
+    expect(contextValue!.theme).toBe('dark');
+    expect(contextValue!.themePreference).toBe('dark');
+    expect(localStorage.getItem('theme-preference')).toBe('dark');
+  });
+
+  test('setTheme("light") persists and applies light theme', () => {
+    // Start with OS = dark so light is a real change.
+    matches = true;
+    renderProvider();
+    expect(contextValue!.theme).toBe('dark');
+
+    act(() => {
+      contextValue!.setTheme('light');
+    });
+
+    expect(contextValue!.theme).toBe('light');
+    expect(contextValue!.themePreference).toBe('light');
+    expect(localStorage.getItem('theme-preference')).toBe('light');
+  });
+
+  test('setTheme("system") clears the stored preference', () => {
+    renderProvider();
+    // Set an explicit preference first.
+    act(() => {
+      contextValue!.setTheme('dark');
+    });
+    expect(localStorage.getItem('theme-preference')).toBe('dark');
+
+    // Switch to system — must REMOVE the stored key.
+    act(() => {
+      contextValue!.setTheme('system');
+    });
+
+    expect(localStorage.getItem('theme-preference')).toBeNull();
+    expect(contextValue!.themePreference).toBe('system');
+  });
+
+  test('system mode follows OS preference changes', () => {
+    renderProvider();
+    // No explicit preference — should be in system mode.
+    expect(contextValue!.themePreference).toBe('system');
+    expect(contextValue!.theme).toBe('light'); // OS = light
+
+    // OS switches to dark — theme should follow.
+    act(() => {
+      setOsPreference(true);
+    });
+    expect(contextValue!.theme).toBe('dark');
+
+    // OS switches back to light.
+    act(() => {
+      setOsPreference(false);
+    });
+    expect(contextValue!.theme).toBe('light');
+  });
+
+  test('explicit preference overrides OS preference changes', () => {
+    renderProvider();
+    // Set explicit dark.
+    act(() => {
+      contextValue!.setTheme('dark');
+    });
+    expect(contextValue!.theme).toBe('dark');
+
+    // OS switches to light — theme must NOT follow (explicit preference stored).
+    act(() => {
+      setOsPreference(false);
+    });
+    expect(contextValue!.theme).toBe('dark');
+    expect(contextValue!.themePreference).toBe('dark');
+  });
+
+  test('initial load with no stored preference uses OS preference', () => {
+    matches = true; // OS = dark
+    renderProvider();
+    expect(contextValue!.theme).toBe('dark');
+    expect(contextValue!.themePreference).toBe('system');
+  });
+
+  test('initial load with a stored preference uses it over OS', () => {
+    localStorage.setItem('theme-preference', 'light');
+    matches = true; // OS = dark, but stored = light
+    renderProvider();
+    expect(contextValue!.theme).toBe('light');
+    expect(contextValue!.themePreference).toBe('light');
+  });
+
+  test('data-theme attribute reflects the applied theme', () => {
+    renderProvider();
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+
+    act(() => {
+      contextValue!.setTheme('dark');
+    });
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+  });
+
+  test('useTheme throws when used outside ThemeProvider', () => {
+    // Suppress the expected error output.
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => render(<ContextProbe />)).toThrow('useTheme must be used within a ThemeProvider');
+    spy.mockRestore();
+  });
+});

--- a/web_ui/src/lib/theme/ThemeContext.tsx
+++ b/web_ui/src/lib/theme/ThemeContext.tsx
@@ -2,9 +2,20 @@ import React, { createContext, useContext, useEffect, useState } from 'react';
 
 export type ThemeMode = 'light' | 'dark';
 
+/**
+ * The user's theme preference. `'system'` means "follow the OS preference" —
+ * no explicit value is persisted, so the media-query listener can react to
+ * OS-level changes. `'light'`/`'dark'` are explicit persisted preferences.
+ */
+export type ThemePreference = 'light' | 'dark' | 'system';
+
 interface ThemeContextValue {
+  /** The currently-applied theme (always a concrete 'light' or 'dark'). */
   theme: ThemeMode;
-  toggleTheme: () => void;
+  /** The user's preference: an explicit 'light'/'dark', or 'system' (follow OS). */
+  themePreference: ThemePreference;
+  /** Set an explicit theme preference. 'system' clears the stored preference. */
+  setTheme: (mode: ThemePreference) => void;
   isDark: boolean;
 }
 
@@ -33,7 +44,9 @@ interface ThemeProviderProps {
 }
 
 export function ThemeProvider({ children }: ThemeProviderProps) {
-  const [theme, setTheme] = useState<ThemeMode>(() => {
+  // NOTE: the internal state setter is named `setThemeState` (not `setTheme`)
+  // so the context-value function `setTheme` (below) does not shadow it.
+  const [theme, setThemeState] = useState<ThemeMode>(() => {
     const stored = getStoredPreference();
     return stored ?? getSystemPreference();
   });
@@ -45,30 +58,50 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
   useEffect(() => {
     const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
     const handleChange = (e: MediaQueryListEvent) => {
+      // Only follow OS changes when NO explicit preference is stored — an
+      // explicit 'light'/'dark' must override the OS setting. 'system' mode
+      // keeps localStorage empty so this listener stays active.
       const stored = getStoredPreference();
       if (stored === null) {
-        setTheme(e.matches ? 'dark' : 'light');
+        setThemeState(e.matches ? 'dark' : 'light');
       }
     };
     mediaQuery.addEventListener('change', handleChange);
     return () => mediaQuery.removeEventListener('change', handleChange);
   }, []);
 
-  const toggleTheme = () => {
-    setTheme((prev) => {
-      const next = prev === 'light' ? 'dark' : 'light';
+  // Derive the user's preference from the persisted value: an explicit
+  // 'light'/'dark' if stored, otherwise 'system'. Read fresh each render —
+  // cheap (one localStorage getItem), and keeps the context value in sync
+  // immediately after setTheme writes/removes the key.
+  const themePreference: ThemePreference = getStoredPreference() ?? 'system';
+
+  const setTheme = (mode: ThemePreference) => {
+    if (mode === 'system') {
+      // Clear the explicit preference so the media-query listener takes over
+      // and the app follows future OS-preference changes. Do NOT persist —
+      // a stored value here would defeat the entire point of 'system'.
       try {
-        localStorage.setItem(STORAGE_KEY, next);
+        localStorage.removeItem(STORAGE_KEY);
       } catch {
-        // localStorage unavailable; theme still toggles in memory
+        // localStorage unavailable; theme still updates in memory
       }
-      return next;
-    });
+      setThemeState(getSystemPreference());
+    } else {
+      // Explicit preference: persist and apply.
+      try {
+        localStorage.setItem(STORAGE_KEY, mode);
+      } catch {
+        // localStorage unavailable; theme still updates in memory
+      }
+      setThemeState(mode);
+    }
   };
 
   const value: ThemeContextValue = {
     theme,
-    toggleTheme,
+    themePreference,
+    setTheme,
     isDark: theme === 'dark',
   };
 

--- a/web_ui/src/lib/theme/index.ts
+++ b/web_ui/src/lib/theme/index.ts
@@ -1,2 +1,2 @@
 export { ThemeProvider, useTheme } from './ThemeContext';
-export type { ThemeMode } from './ThemeContext';
+export type { ThemeMode, ThemePreference } from './ThemeContext';

--- a/web_ui/src/pages/SettingsPage.clearCache.test.tsx
+++ b/web_ui/src/pages/SettingsPage.clearCache.test.tsx
@@ -1,15 +1,11 @@
 /**
- * F-CLEAR-CACHE-OPFS CI-enforced coverage (PR #28 review, closeout critic
- * pass): SettingsPage.tsx's Clear Cache handler (`handleClearCacheClick`)
- * now also deletes the WebLLM Cache Storage entries (`webllm/model`,
- * `webllm/config`, `webllm/wasm`) in addition to the pre-existing
- * IndexedDB/OPFS cleanup. `SettingsPage.test.tsx` — the file that would
- * naturally cover this — is in vitest.config.ts's pre-existing exclude list
- * (unrelated flaky/drifted assertions, see that file's exclusion comment),
- * so this new Cache Storage deletion behavior had zero CI-enforced
- * regression protection. This file is deliberately narrow: it only exists to
- * exercise the Clear Cache -> caches.delete(...) path, reusing the mock
- * setup from the (excluded, but still valid as reference) SettingsPage.test.tsx.
+ * Clear Cache tests — issue #24 F1.
+ *
+ * Originally (PR #28) this file only asserted the three WebLLM Cache Storage
+ * `caches.delete(...)` calls. Issue #24 F1 rebuilt Clear Cache to also delete
+ * the real user-prefixed IndexedDB databases via PR-4's `deleteNamespace` /
+ * `listStalePrefixes` (from `lib/storage/profile`) and the EdgeVec HNSW blob
+ * from the shared `edgevec-db`. These tests cover the full deletion path.
  */
 
 import React from 'react';
@@ -20,6 +16,10 @@ import '@testing-library/jest-dom';
 import * as inferenceModule from '../lib/inference';
 import * as themeModule from '../lib/theme';
 
+const deleteNamespaceMock = vi.fn((_prefix: string) => Promise.resolve());
+const listStalePrefixesMock = vi.fn(() => Promise.resolve([]));
+const getProfilePrefixMock = vi.fn(() => 'testprfx');
+
 vi.mock('../lib/inference', () => ({
   InferenceModeProvider: ({ children }: { children: React.ReactNode }) => children,
   useInferenceMode: vi.fn(),
@@ -27,6 +27,12 @@ vi.mock('../lib/inference', () => ({
 
 vi.mock('../lib/theme', () => ({
   useTheme: vi.fn(),
+}));
+
+vi.mock('../lib/storage/profile', () => ({
+  getProfilePrefix: () => getProfilePrefixMock(),
+  deleteNamespace: (prefix: string) => deleteNamespaceMock(prefix),
+  listStalePrefixes: () => listStalePrefixesMock(),
 }));
 
 const mockModelReadinessGateInstance = {
@@ -54,15 +60,33 @@ vi.mock('../components/ModelDownloadProgress', () => ({
 }));
 
 // IndexedDB mock — same shape as SettingsPage.test.tsx's, since
-// handleClearCacheClick also calls indexedDB.deleteDatabase(...).
+// handleClearCacheClick calls indexedDB.open(...) and deleteDatabase(...).
 const mockObjectStore = {
   get: vi.fn(),
   put: vi.fn(),
+  delete: vi.fn(),
 };
 
 const mockTransaction = {
   objectStore: vi.fn(() => mockObjectStore),
+  oncomplete: null as ((e: Event) => void) | null,
+  onerror: null as ((e: Event) => void) | null,
+  abort: vi.fn(),
 };
+
+/**
+ * Schedule the transaction's oncomplete to fire after a write operation
+ * (put/delete) is issued — mirrors real IDB where the transaction commits
+ * after all operations complete. Called from put/delete mock implementations
+ * in beforeEach.
+ */
+function scheduleOnComplete() {
+  setTimeout(() => {
+    if (mockTransaction.oncomplete) {
+      mockTransaction.oncomplete.call(mockTransaction, new Event('complete'));
+    }
+  }, 0);
+}
 
 const mockDB = {
   transaction: vi.fn(() => mockTransaction),
@@ -70,6 +94,7 @@ const mockDB = {
     contains: vi.fn(() => true),
   },
   createObjectStore: vi.fn(),
+  close: vi.fn(),
 };
 
 function createIDBRequest() {
@@ -89,15 +114,22 @@ global.indexedDB = {
       const onsuccess = (req as unknown as Record<string, (e: Event) => void>).onsuccess;
       if (onsuccess) onsuccess.call(req, new Event('success'));
     }, 0);
-    return req as unknown as IDBRequest;
+    return req as unknown as IDBOpenDBRequest;
   }),
-  deleteDatabase: vi.fn(() => ({ onsuccess: null, onerror: null })),
+  deleteDatabase: vi.fn(() => {
+    const req = createIDBRequest();
+    setTimeout(() => {
+      const onsuccess = (req as unknown as Record<string, (e: Event) => void>).onsuccess;
+      if (onsuccess) onsuccess.call(req, new Event('success'));
+    }, 0);
+    return req as unknown as IDBOpenDBRequest;
+  }),
 } as unknown as IDBDatabase & typeof globalThis.indexedDB;
 
 // Import after mocks, matching SettingsPage.test.tsx's convention.
 import { SettingsPage } from './SettingsPage';
 
-describe('SettingsPage — Clear Cache deletes WebLLM Cache Storage entries (F-CLEAR-CACHE-OPFS)', () => {
+describe('SettingsPage — Clear Cache (issue #24 F1)', () => {
   beforeEach(() => {
     vi.mocked(inferenceModule.useInferenceMode).mockClear();
     vi.mocked(themeModule.useTheme).mockClear();
@@ -105,6 +137,11 @@ describe('SettingsPage — Clear Cache deletes WebLLM Cache Storage entries (F-C
     mockModelReadinessGateInstance.checkModelCached.mockResolvedValue(false);
     mockObjectStore.get.mockClear();
     mockObjectStore.put.mockClear();
+    mockObjectStore.delete.mockClear();
+    deleteNamespaceMock.mockClear();
+    listStalePrefixesMock.mockClear();
+    getProfilePrefixMock.mockClear();
+    getProfilePrefixMock.mockReturnValue('testprfx');
 
     vi.mocked(inferenceModule.useInferenceMode).mockReturnValue({
       mode: 'browser-local',
@@ -124,9 +161,11 @@ describe('SettingsPage — Clear Cache deletes WebLLM Cache Storage entries (F-C
       setModelLoadingProgress: vi.fn(),
     });
 
+    // Updated mock shape (issue #24 F5): setTheme + themePreference, no toggleTheme.
     vi.mocked(themeModule.useTheme).mockReturnValue({
       theme: 'light',
-      toggleTheme: vi.fn(),
+      themePreference: 'system',
+      setTheme: vi.fn(),
       isDark: false,
     });
 
@@ -144,14 +183,23 @@ describe('SettingsPage — Clear Cache deletes WebLLM Cache Storage entries (F-C
         const onsuccess = (req as unknown as Record<string, (e: Event) => void>).onsuccess;
         if (onsuccess) onsuccess.call(req, new Event('success'));
       }, 0);
+      scheduleOnComplete();
+      return req as unknown as IDBRequest;
+    });
+    mockObjectStore.delete.mockImplementation((_key) => {
+      const req = createIDBRequest();
+      setTimeout(() => {
+        const onsuccess = (req as unknown as Record<string, (e: Event) => void>).onsuccess;
+        if (onsuccess) onsuccess.call(req, new Event('success'));
+      }, 0);
+      scheduleOnComplete();
       return req as unknown as IDBRequest;
     });
     mockTransaction.objectStore.mockReturnValue(mockObjectStore);
 
     // `caches` (Cache Storage API) isn't part of jsdom's global surface, so
     // without this stub `typeof caches !== 'undefined'` is false and the
-    // handler's caches.delete(...) calls are silently skipped — which is
-    // exactly how this behavior escaped CI coverage before.
+    // handler's caches.delete(...) calls are silently skipped.
     vi.stubGlobal('caches', { delete: vi.fn().mockResolvedValue(true) });
   });
 
@@ -159,7 +207,7 @@ describe('SettingsPage — Clear Cache deletes WebLLM Cache Storage entries (F-C
     vi.unstubAllGlobals();
   });
 
-  test('second Clear Cache click deletes all three WebLLM Cache Storage entries', async () => {
+  test('second Clear Cache click deletes the current profile namespace via deleteNamespace', async () => {
     render(<SettingsPage />);
 
     await waitFor(() => {
@@ -171,9 +219,46 @@ describe('SettingsPage — Clear Cache deletes WebLLM Cache Storage entries (F-C
     // First click — confirm state, no deletion yet.
     fireEvent.click(clearButton);
     expect(screen.getByText('Click Again to Confirm')).toBeInTheDocument();
-    expect(caches.delete).not.toHaveBeenCalled();
+    expect(deleteNamespaceMock).not.toHaveBeenCalled();
 
-    // Second click — actually clears, including Cache Storage.
+    // Second click — actually clears.
+    fireEvent.click(clearButton);
+
+    await waitFor(() => {
+      expect(deleteNamespaceMock).toHaveBeenCalledWith('testprfx');
+    });
+  });
+
+  test('Clear Cache deletes the EdgeVec blob key from edgevec-db (PRR-008)', async () => {
+    render(<SettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Storage')).toBeInTheDocument();
+    });
+
+    const clearButton = screen.getByRole('button', { name: /clear cache/i });
+    fireEvent.click(clearButton);
+    fireEvent.click(clearButton);
+
+    // The EdgeVec blob is stored as a key in the shared edgevec-db 'data'
+    // store. Verify deleteEdgeVecBlob issued store.delete with the correct
+    // profile-scoped key — this is the subtle PRR-008 fix that
+    // deleteNamespace cannot reach.
+    await waitFor(() => {
+      expect(mockObjectStore.delete).toHaveBeenCalledWith('testprfx-doc-qa-index');
+    });
+  });
+
+  test('second Clear Cache click deletes all three WebLLM Cache Storage entries', async () => {
+    render(<SettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Storage')).toBeInTheDocument();
+    });
+
+    const clearButton = screen.getByRole('button', { name: /clear cache/i });
+
+    fireEvent.click(clearButton);
     fireEvent.click(clearButton);
 
     await waitFor(() => {
@@ -182,6 +267,89 @@ describe('SettingsPage — Clear Cache deletes WebLLM Cache Storage entries (F-C
     expect(caches.delete).toHaveBeenCalledWith('webllm/model');
     expect(caches.delete).toHaveBeenCalledWith('webllm/config');
     expect(caches.delete).toHaveBeenCalledWith('webllm/wasm');
+  });
+
+  test('second Clear Cache click deletes the settings IndexedDB', async () => {
+    render(<SettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Storage')).toBeInTheDocument();
+    });
+
+    const clearButton = screen.getByRole('button', { name: /clear cache/i });
+    fireEvent.click(clearButton);
+    fireEvent.click(clearButton);
+
+    await waitFor(() => {
+      expect(indexedDB.deleteDatabase).toHaveBeenCalledWith('doc-qa-settings');
+    });
+  });
+
+  test('Clear Cache does NOT delete the bare (non-prefixed) doc-qa-documents name', async () => {
+    render(<SettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Storage')).toBeInTheDocument();
+    });
+
+    const clearButton = screen.getByRole('button', { name: /clear cache/i });
+    fireEvent.click(clearButton);
+    fireEvent.click(clearButton);
+
+    await waitFor(() => {
+      expect(deleteNamespaceMock).toHaveBeenCalled();
+    });
+
+    // The old bug deleted 'doc-qa-documents' (no prefix). Verify the bare name
+    // is never passed to deleteDatabase — only the profile-scoped deleteNamespace
+    // path and the settings DB are used.
+    const deleteCalls = (indexedDB.deleteDatabase as ReturnType<typeof vi.fn>).mock.calls.map(
+      (c: unknown[]) => c[0]
+    );
+    expect(deleteCalls).not.toContain('doc-qa-documents');
+  });
+
+  test('shows "Cache cleared" result feedback after clearing', async () => {
+    render(<SettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Storage')).toBeInTheDocument();
+    });
+
+    const clearButton = screen.getByRole('button', { name: /clear cache/i });
+    fireEvent.click(clearButton);
+    fireEvent.click(clearButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Cache cleared')).toBeInTheDocument();
+    });
+  });
+
+  test('confirmation text describes what will be deleted', async () => {
+    render(<SettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Storage')).toBeInTheDocument();
+    });
+
+    const clearButton = screen.getByRole('button', { name: /clear cache/i });
+    fireEvent.click(clearButton);
+
+    expect(
+      screen.getByText(/this will delete all documents, keyword\/vector indexes/i)
+    ).toBeInTheDocument();
+  });
+
+  test('returns to idle after clearing', async () => {
+    render(<SettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Storage')).toBeInTheDocument();
+    });
+
+    const clearButton = screen.getByRole('button', { name: /clear cache/i });
+    fireEvent.click(clearButton);
+    fireEvent.click(clearButton);
 
     await waitFor(() => {
       expect(screen.queryByText('Click Again to Confirm')).not.toBeInTheDocument();

--- a/web_ui/src/pages/SettingsPage.clearCache.test.tsx
+++ b/web_ui/src/pages/SettingsPage.clearCache.test.tsx
@@ -17,7 +17,7 @@ import * as inferenceModule from '../lib/inference';
 import * as themeModule from '../lib/theme';
 
 const deleteNamespaceMock = vi.fn((_prefix: string) => Promise.resolve());
-const listStalePrefixesMock = vi.fn(() => Promise.resolve([]));
+const listStalePrefixesMock = vi.fn((): Promise<string[]> => Promise.resolve([]));
 const getProfilePrefixMock = vi.fn(() => 'testprfx');
 
 vi.mock('../lib/inference', () => ({
@@ -335,8 +335,12 @@ describe('SettingsPage — Clear Cache (issue #24 F1)', () => {
     const clearButton = screen.getByRole('button', { name: /clear cache/i });
     fireEvent.click(clearButton);
 
+    // PRR-003: text now mentions orphan cleanup from previous sessions.
     expect(
       screen.getByText(/this will delete all documents, keyword\/vector indexes/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/orphaned data from previous sessions/i)
     ).toBeInTheDocument();
   });
 
@@ -353,6 +357,146 @@ describe('SettingsPage — Clear Cache (issue #24 F1)', () => {
 
     await waitFor(() => {
       expect(screen.queryByText('Click Again to Confirm')).not.toBeInTheDocument();
+    });
+  });
+
+  // F-001: deleteNamespace rejection → "Could not clear all data"
+  test('deleteNamespace rejection shows error feedback (F-001)', async () => {
+    deleteNamespaceMock.mockRejectedValueOnce(new Error('IndexedDB quota exceeded'));
+
+    render(<SettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Storage')).toBeInTheDocument();
+    });
+
+    const clearButton = screen.getByRole('button', { name: /clear cache/i });
+    fireEvent.click(clearButton);
+    fireEvent.click(clearButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Could not clear all data')).toBeInTheDocument();
+    });
+  });
+
+  // F-002: caches.delete rejection does not abort the clear
+  test('caches.delete rejection does not prevent the rest of clearing (F-002)', async () => {
+    // One cache rejects, the others resolve. The .catch(() => {}) suppression
+    // must swallow the rejection so clearing still completes.
+    const cachesDeleteSpy = vi.fn((name: string) =>
+      name === 'webllm/model'
+        ? Promise.reject(new Error('Cache Storage quota'))
+        : Promise.resolve(true)
+    );
+    vi.stubGlobal('caches', { delete: cachesDeleteSpy });
+
+    render(<SettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Storage')).toBeInTheDocument();
+    });
+
+    const clearButton = screen.getByRole('button', { name: /clear cache/i });
+    fireEvent.click(clearButton);
+    fireEvent.click(clearButton);
+
+    // Despite one rejection, the clear succeeds (catch swallows it).
+    await waitFor(() => {
+      expect(screen.getByText('Cache cleared')).toBeInTheDocument();
+    });
+    expect(cachesDeleteSpy).toHaveBeenCalledTimes(3);
+  });
+
+  // F-003/PRR-002: deleteEdgeVecBlob rejection surfaces as error feedback
+  test('EdgeVec blob deletion failure shows error feedback (F-003)', async () => {
+    // Make the EdgeVec transaction error: mockDB.transaction will return
+    // a transaction whose objectStore triggers an error. We simulate by
+    // making the objectStore delete trigger tx.onerror.
+    const errorTx = {
+      objectStore: vi.fn(() => {
+        // Schedule tx.onerror asynchronously (the store.delete call triggers it)
+        setTimeout(() => {
+          if (errorTx.onerror) errorTx.onerror.call(errorTx, new Event('error'));
+        }, 0);
+        return mockObjectStore;
+      }),
+      oncomplete: null as ((e: Event) => void) | null,
+      onerror: null as ((e: Event) => void) | null,
+      onabort: null as ((e: Event) => void) | null,
+    };
+
+    // Override mockDB.transaction to return the error tx for 'data' store
+    // (edgevec) requests, while keeping the normal tx for settings.
+    const originalTransaction = mockDB.transaction;
+    mockDB.transaction = vi.fn((storeName: string) => {
+      if (storeName === 'data') return errorTx;
+      return mockTransaction;
+    }) as typeof mockDB.transaction;
+
+    render(<SettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Storage')).toBeInTheDocument();
+    });
+
+    const clearButton = screen.getByRole('button', { name: /clear cache/i });
+    fireEvent.click(clearButton);
+    fireEvent.click(clearButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Could not clear all data')).toBeInTheDocument();
+    });
+
+    // Restore.
+    mockDB.transaction = originalTransaction;
+  });
+
+  // ADV-2: EdgeVec "data" store doesn't exist → clean resolve (not an error)
+  test('EdgeVec blob deletion when data store is absent resolves cleanly (ADV-2)', async () => {
+    // Temporarily make objectStoreNames.contains('data') return false so
+    // deleteEdgeVecBlob takes the "no store → nothing to delete" path.
+    const originalContains = mockDB.objectStoreNames.contains;
+    mockDB.objectStoreNames.contains = vi.fn((name: string) => {
+      // The settings DB does contain 'settings'; only 'data' is absent.
+      return name !== 'data';
+    }) as typeof mockDB.objectStoreNames.contains;
+
+    render(<SettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Storage')).toBeInTheDocument();
+    });
+
+    const clearButton = screen.getByRole('button', { name: /clear cache/i });
+    fireEvent.click(clearButton);
+    fireEvent.click(clearButton);
+
+    // Should still clear successfully (no EdgeVec store is not an error).
+    await waitFor(() => {
+      expect(screen.getByText('Cache cleared')).toBeInTheDocument();
+    });
+
+    mockDB.objectStoreNames.contains = originalContains;
+  });
+
+  // ADV-3: stale prefix cleanup path (listStalePrefixes returns non-empty)
+  test('Clear Cache deletes stale orphan namespaces (ADV-3)', async () => {
+    listStalePrefixesMock.mockResolvedValueOnce(['orphan1', 'orphan2']);
+
+    render(<SettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Storage')).toBeInTheDocument();
+    });
+
+    const clearButton = screen.getByRole('button', { name: /clear cache/i });
+    fireEvent.click(clearButton);
+    fireEvent.click(clearButton);
+
+    // deleteNamespace should be called for the current profile AND both orphans.
+    await waitFor(() => {
+      expect(deleteNamespaceMock).toHaveBeenCalledWith('orphan1');
+      expect(deleteNamespaceMock).toHaveBeenCalledWith('orphan2');
     });
   });
 });

--- a/web_ui/src/pages/SettingsPage.test.tsx
+++ b/web_ui/src/pages/SettingsPage.test.tsx
@@ -1,15 +1,31 @@
 /**
- * SettingsPage tests
+ * SettingsPage tests — issue #24.
+ *
+ * The component was substantially rebuilt:
+ * - The dead Model Selection section was deleted (preferredModel had no
+ *   runtime consumer).
+ * - Cache status is now engine-aware (passes browserEngine to
+ *   checkModelCached, not a webllm default).
+ * - Theme uses setTheme/themePreference from ThemeContext (no toggleTheme).
+ * - Server URL persists on blur (not onChange).
+ * - Radio cards use <label> + native input (no duplicate role="radio").
+ *
+ * Tests updated to match actual (correct) behavior. This file was previously
+ * in vitest.config.ts's exclude list (masked failing assertions); issue #24
+ * acceptance criterion requires it to pass, so it is un-excluded.
  */
 
 import React from 'react';
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
-// Import inference module to get mock
 import * as inferenceModule from '../lib/inference';
 import * as themeModule from '../lib/theme';
+
+const deleteNamespaceMock = vi.fn((_prefix: string) => Promise.resolve());
+const listStalePrefixesMock = vi.fn(() => Promise.resolve([]));
+const getProfilePrefixMock = vi.fn(() => 'testprfx');
 
 // Mock modules before importing component
 vi.mock('../lib/inference', () => ({
@@ -19,6 +35,12 @@ vi.mock('../lib/inference', () => ({
 
 vi.mock('../lib/theme', () => ({
   useTheme: vi.fn(),
+}));
+
+vi.mock('../lib/storage/profile', () => ({
+  getProfilePrefix: () => getProfilePrefixMock(),
+  deleteNamespace: (prefix: string) => deleteNamespaceMock(prefix),
+  listStalePrefixes: () => listStalePrefixesMock(),
 }));
 
 // Create a shared mock instance for ModelReadinessGate
@@ -50,11 +72,28 @@ vi.mock('../components/ModelDownloadProgress', () => ({
 const mockObjectStore = {
   get: vi.fn(),
   put: vi.fn(),
+  delete: vi.fn(),
 };
 
 const mockTransaction = {
   objectStore: vi.fn(() => mockObjectStore),
+  oncomplete: null as ((e: Event) => void) | null,
+  onerror: null as ((e: Event) => void) | null,
+  abort: vi.fn(),
 };
+
+/**
+ * Schedule the transaction's oncomplete to fire after a write operation
+ * (put/delete) is issued — mirrors real IDB where the transaction commits
+ * after all operations complete.
+ */
+function scheduleOnComplete() {
+  setTimeout(() => {
+    if (mockTransaction.oncomplete) {
+      mockTransaction.oncomplete.call(mockTransaction, new Event('complete'));
+    }
+  }, 0);
+}
 
 const mockDB = {
   transaction: vi.fn(() => mockTransaction),
@@ -62,6 +101,7 @@ const mockDB = {
     contains: vi.fn(() => true),
   },
   createObjectStore: vi.fn(),
+  close: vi.fn(),
 };
 
 // Factory for creating IDBRequest-like objects with proper event handling
@@ -79,14 +119,20 @@ global.indexedDB = {
   open: vi.fn((_name: string, _version: number) => {
     const req = createIDBRequest();
     (req as unknown as Record<string, unknown>).result = mockDB;
-    // Simulate successful open
     setTimeout(() => {
       const onsuccess = (req as unknown as Record<string, (e: Event) => void>).onsuccess;
       if (onsuccess) onsuccess.call(req, new Event('success'));
     }, 0);
-    return req as unknown as IDBRequest;
+    return req as unknown as IDBOpenDBRequest;
   }),
-  deleteDatabase: vi.fn(() => ({ onsuccess: null, onerror: null })),
+  deleteDatabase: vi.fn(() => {
+    const req = createIDBRequest();
+    setTimeout(() => {
+      const onsuccess = (req as unknown as Record<string, (e: Event) => void>).onsuccess;
+      if (onsuccess) onsuccess.call(req, new Event('success'));
+    }, 0);
+    return req as unknown as IDBOpenDBRequest;
+  }),
 } as unknown as IDBDatabase & typeof globalThis.indexedDB;
 
 // Import after mocks
@@ -94,6 +140,8 @@ import { SettingsPage } from './SettingsPage';
 
 describe('SettingsPage', () => {
   beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
     // Reset mock call history only, not implementations
     vi.mocked(inferenceModule.useInferenceMode).mockClear();
     vi.mocked(themeModule.useTheme).mockClear();
@@ -101,6 +149,11 @@ describe('SettingsPage', () => {
     mockModelReadinessGateInstance.checkModelCached.mockResolvedValue(false);
     mockObjectStore.get.mockClear();
     mockObjectStore.put.mockClear();
+    mockObjectStore.delete.mockClear();
+    deleteNamespaceMock.mockClear();
+    listStalePrefixesMock.mockClear();
+    getProfilePrefixMock.mockClear();
+    getProfilePrefixMock.mockReturnValue('testprfx');
 
     // Setup default mock returns
     vi.mocked(inferenceModule.useInferenceMode).mockReturnValue({
@@ -121,9 +174,11 @@ describe('SettingsPage', () => {
       setModelLoadingProgress: vi.fn(),
     });
 
+    // Updated mock shape (issue #24 F5): setTheme + themePreference, no toggleTheme.
     vi.mocked(themeModule.useTheme).mockReturnValue({
       theme: 'light',
-      toggleTheme: vi.fn(),
+      themePreference: 'system',
+      setTheme: vi.fn(),
       isDark: false,
     });
 
@@ -142,16 +197,30 @@ describe('SettingsPage', () => {
         const onsuccess = (req as unknown as Record<string, (e: Event) => void>).onsuccess;
         if (onsuccess) onsuccess.call(req, new Event('success'));
       }, 0);
+      scheduleOnComplete();
+      return req as unknown as IDBRequest;
+    });
+    mockObjectStore.delete.mockImplementation((_key) => {
+      const req = createIDBRequest();
+      setTimeout(() => {
+        const onsuccess = (req as unknown as Record<string, (e: Event) => void>).onsuccess;
+        if (onsuccess) onsuccess.call(req, new Event('success'));
+      }, 0);
+      scheduleOnComplete();
       return req as unknown as IDBRequest;
     });
     mockTransaction.objectStore.mockReturnValue(mockObjectStore);
+
+    // Cache Storage API stub (jsdom lacks `caches`).
+    vi.stubGlobal('caches', { delete: vi.fn().mockResolvedValue(true) });
   });
 
   afterEach(() => {
-    // Don't restoreAllMocks - it clears mock implementations
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
   });
 
-  test('renders the browser-engine selector and hardware-capability panel (Phase 3)', async () => {
+  test('renders the browser-engine selector and hardware-capability panel', async () => {
     render(<SettingsPage />);
 
     await waitFor(() => {
@@ -191,17 +260,21 @@ describe('SettingsPage', () => {
     expect(setBrowserEngine).toHaveBeenCalledWith('webllm');
   });
 
-  test('Renders all 6 sections', async () => {
+  test('renders the main sections (no dead Model Selection section)', async () => {
     render(<SettingsPage />);
 
     await waitFor(() => {
       expect(screen.getByText('Inference Mode')).toBeInTheDocument();
     });
 
-    expect(screen.getByText('Model Selection')).toBeInTheDocument();
+    expect(screen.getByText('Browser Engine')).toBeInTheDocument();
+    expect(screen.getByText('Response Quality')).toBeInTheDocument();
     expect(screen.getByText('Appearance')).toBeInTheDocument();
     expect(screen.getByText('Storage')).toBeInTheDocument();
     expect(screen.getByText('About')).toBeInTheDocument();
+
+    // The dead Model Selection section was deleted (issue #24 F2).
+    expect(screen.queryByText('Model Selection')).not.toBeInTheDocument();
   });
 
   test('Inference mode radio toggle changes mode', async () => {
@@ -241,7 +314,7 @@ describe('SettingsPage', () => {
     expect(setMode).toHaveBeenCalledWith('api');
   });
 
-  test('Server URL input updates on change', async () => {
+  test('Server URL input updates value on change but persists on blur (issue #24 F8)', async () => {
     const setServerUrl = vi.fn();
     vi.mocked(inferenceModule.useInferenceMode).mockReturnValue({
       mode: 'api',
@@ -269,67 +342,22 @@ describe('SettingsPage', () => {
 
     const serverUrlInput = screen.getByLabelText(/server url/i) as HTMLInputElement;
 
+    // Change updates the input value (local state) but does NOT persist.
     fireEvent.change(serverUrlInput, { target: { value: 'http://localhost:8080' } });
-
     expect(serverUrlInput.value).toBe('http://localhost:8080');
+    expect(setServerUrl).not.toHaveBeenCalled();
+
+    // Blur persists (the correct UX — issue #24 F8).
+    fireEvent.blur(serverUrlInput);
     expect(setServerUrl).toHaveBeenCalledWith('http://localhost:8080');
   });
 
-  test.skip('Test connection button triggers connectivity check', async () => {
-    // Skipping - async mock capture issue with useCallback
-    const checkServerConnectivity = vi.fn().mockResolvedValue(true);
-
-    vi.mocked(inferenceModule.useInferenceMode).mockReturnValue({
-      mode: 'api',
-      browserEngine: 'wllama',
-      ragPreset: 'balanced',
-      isServerConnected: false,
-      isModelReady: false,
-      modelLoadingProgress: 0,
-      modeError: null,
-      serverUrl: 'http://localhost:8080',
-      setMode: vi.fn(),
-      setBrowserEngine: vi.fn(),
-      setRagPreset: vi.fn(),
-      setServerUrl: vi.fn(),
-      checkServerConnectivity,
-      setModelReady: vi.fn(),
-      setModelLoadingProgress: vi.fn(),
-    });
-
-    render(<SettingsPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText('Server Configuration')).toBeInTheDocument();
-    });
-
-    const testButton = screen.getByRole('button', { name: /test connection/i });
-
-    fireEvent.click(testButton);
-
-    // Wait for async operation to complete
-    await waitFor(() => {
-      expect(checkServerConnectivity).toHaveBeenCalled();
-    });
-  });
-
-  test('Model selection dropdown updates', async () => {
-    render(<SettingsPage />);
-
-    await waitFor(() => {
-      expect(screen.getByLabelText(/ai model/i)).toBeInTheDocument();
-    });
-
-    const modelSelect = screen.getByLabelText(/ai model/i) as HTMLSelectElement;
-
-    expect(modelSelect.value).toBe('Llama-3.2-3B-Instruct-q4f16_1-MLC');
-  });
-
-  test('Theme toggle changes theme', async () => {
-    const toggleTheme = vi.fn();
+  test('Theme selection calls setTheme (not toggleTheme) (issue #24 F5)', async () => {
+    const setTheme = vi.fn();
     vi.mocked(themeModule.useTheme).mockReturnValue({
       theme: 'light',
-      toggleTheme,
+      themePreference: 'system',
+      setTheme,
       isDark: false,
     });
 
@@ -340,10 +368,27 @@ describe('SettingsPage', () => {
     });
 
     const darkOption = screen.getByRole('radio', { name: /dark/i });
-
     fireEvent.click(darkOption);
 
-    expect(toggleTheme).toHaveBeenCalled();
+    expect(setTheme).toHaveBeenCalledWith('dark');
+  });
+
+  test('System theme radio is selected when themePreference is system', async () => {
+    vi.mocked(themeModule.useTheme).mockReturnValue({
+      theme: 'light',
+      themePreference: 'system',
+      setTheme: vi.fn(),
+      isDark: false,
+    });
+
+    render(<SettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Appearance')).toBeInTheDocument();
+    });
+
+    const systemRadio = screen.getByRole('radio', { name: /system/i });
+    expect(systemRadio).toBeChecked();
   });
 
   test('Clear cache requires two clicks (confirm)', async () => {
@@ -357,7 +402,6 @@ describe('SettingsPage', () => {
 
     // First click - should show confirm state
     fireEvent.click(clearButton);
-
     expect(screen.getByText('Click Again to Confirm')).toBeInTheDocument();
 
     // Second click - should actually clear
@@ -369,7 +413,23 @@ describe('SettingsPage', () => {
     });
   });
 
-  test('Settings persist to IndexedDB via SettingsStore', async () => {
+  test('Clear cache deletes the profile namespace via deleteNamespace (issue #24 F1)', async () => {
+    render(<SettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Storage')).toBeInTheDocument();
+    });
+
+    const clearButton = screen.getByRole('button', { name: /clear cache/i });
+    fireEvent.click(clearButton);
+    fireEvent.click(clearButton);
+
+    await waitFor(() => {
+      expect(deleteNamespaceMock).toHaveBeenCalledWith('testprfx');
+    });
+  });
+
+  test('Settings persist to IndexedDB via SettingsStore (serverUrl on blur)', async () => {
     const savedData: unknown[] = [];
 
     mockObjectStore.put.mockImplementation((data) => {
@@ -382,49 +442,48 @@ describe('SettingsPage', () => {
       return req as unknown as IDBRequest;
     });
 
+    vi.mocked(inferenceModule.useInferenceMode).mockReturnValue({
+      mode: 'api',
+      browserEngine: 'wllama',
+      ragPreset: 'balanced',
+      isServerConnected: false,
+      isModelReady: false,
+      modelLoadingProgress: 0,
+      modeError: null,
+      serverUrl: '',
+      setMode: vi.fn(),
+      setBrowserEngine: vi.fn(),
+      setRagPreset: vi.fn(),
+      setServerUrl: vi.fn(),
+      checkServerConnectivity: vi.fn(() => Promise.resolve(false)),
+      setModelReady: vi.fn(),
+      setModelLoadingProgress: vi.fn(),
+    });
+
     render(<SettingsPage />);
 
     await waitFor(() => {
-      expect(screen.getByText('Inference Mode')).toBeInTheDocument();
+      expect(screen.getByLabelText(/server url/i)).toBeInTheDocument();
     });
 
-    // Trigger a settings change by clicking the dark theme
-    const darkOption = screen.getByRole('radio', { name: /dark/i });
-    fireEvent.click(darkOption);
+    // Trigger a settings persist by typing + blurring the server URL.
+    const serverUrlInput = screen.getByLabelText(/server url/i) as HTMLInputElement;
+    fireEvent.change(serverUrlInput, { target: { value: 'http://localhost:8080' } });
+    fireEvent.blur(serverUrlInput);
 
     await waitFor(() => {
       expect(savedData.length).toBeGreaterThan(0);
     });
 
-    // Verify the saved data structure
+    // Verify the saved data structure — theme and preferredModel are no longer
+    // part of the persisted shape (issue #24 F2/F5).
     const savedSettings = savedData[savedData.length - 1] as Record<string, unknown>;
     expect(savedSettings).toMatchObject({
       key: 'user-preferences',
+      serverUrl: 'http://localhost:8080',
     });
-    expect(['light', 'dark', 'system']).toContain(savedSettings.theme);
-  });
-
-  test.skip('Loading settings displays loading state then renders content', async () => {
-    // Skipping - IndexedDB mock timing issues
-    // Make get return a pending request (no success callback)
-    mockObjectStore.get.mockImplementation(() => {
-      return createIDBRequest() as unknown as IDBRequest;
-    });
-
-    render(<SettingsPage />);
-
-    // Should show loading state initially
-    expect(screen.getByText('Loading settings...')).toBeInTheDocument();
-
-    // After settings load, should show sections
-    await waitFor(
-      () => {
-        expect(screen.queryByText('Loading settings...')).not.toBeInTheDocument();
-      },
-      { timeout: 3000 }
-    );
-
-    expect(screen.getByText('Inference Mode')).toBeInTheDocument();
+    expect(savedSettings).not.toHaveProperty('theme');
+    expect(savedSettings).not.toHaveProperty('preferredModel');
   });
 
   test('Server Configuration section is hidden in browser-local mode', async () => {
@@ -434,28 +493,36 @@ describe('SettingsPage', () => {
       expect(screen.getByText('Inference Mode')).toBeInTheDocument();
     });
 
-    // Server Configuration should not be visible in browser-local mode
     expect(screen.queryByText('Server Configuration')).not.toBeInTheDocument();
   });
 
-  test.skip('Shows error status when connection test fails', async () => {
-    // Skipping - async mock capture issue with useCallback
-    const checkServerConnectivity = vi.fn().mockResolvedValue(false);
+  test('wllama engine shows "no download needed" and no download button (issue #24 F3)', async () => {
+    render(<SettingsPage />);
 
+    await waitFor(() => {
+      expect(screen.getByText('Browser Engine')).toBeInTheDocument();
+    });
+
+    // wllama is the default engine — weights are bundled, no download button.
+    expect(screen.getByText(/weights are bundled with this build/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /download model/i })).not.toBeInTheDocument();
+  });
+
+  test('webllm engine shows download button when model not cached (issue #24 F3)', async () => {
     vi.mocked(inferenceModule.useInferenceMode).mockReturnValue({
-      mode: 'api',
-      browserEngine: 'wllama',
+      mode: 'browser-local',
+      browserEngine: 'webllm',
       ragPreset: 'balanced',
       isServerConnected: false,
       isModelReady: false,
       modelLoadingProgress: 0,
       modeError: null,
-      serverUrl: 'http://localhost:8080',
+      serverUrl: '',
       setMode: vi.fn(),
       setBrowserEngine: vi.fn(),
       setRagPreset: vi.fn(),
       setServerUrl: vi.fn(),
-      checkServerConnectivity,
+      checkServerConnectivity: vi.fn(() => Promise.resolve(false)),
       setModelReady: vi.fn(),
       setModelLoadingProgress: vi.fn(),
     });
@@ -463,29 +530,99 @@ describe('SettingsPage', () => {
     render(<SettingsPage />);
 
     await waitFor(() => {
-      expect(screen.getByText('Server Configuration')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /download model/i })).toBeInTheDocument();
     });
 
-    const testButton = screen.getByRole('button', { name: /test connection/i });
-    fireEvent.click(testButton);
-
-    // Wait for the error status to appear
-    await waitFor(
-      () => {
-        expect(screen.getByText(/connection failed/i)).toBeInTheDocument();
-      },
-      { timeout: 3000 }
-    );
+    // The "requires internet" warning must be shown.
+    expect(screen.getByText(/requires internet access/i)).toBeInTheDocument();
   });
 
-  test('Model not cached shows download button', async () => {
+  test('cache status checks the selected engine, not a hardcoded default (issue #24 F4)', async () => {
+    // Default mock: browserEngine = 'wllama'. The cache check should pass
+    // the wllama engine + the wllama model id (LLM_MODEL_DIR), not the
+    // webllm default.
     render(<SettingsPage />);
 
     await waitFor(() => {
-      expect(screen.getByText('Model Selection')).toBeInTheDocument();
+      expect(mockModelReadinessGateInstance.checkModelCached).toHaveBeenCalled();
     });
 
-    expect(screen.getByText('Not cached')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /download model/i })).toBeInTheDocument();
+    const call = mockModelReadinessGateInstance.checkModelCached.mock.calls[0] as unknown as [string, string];
+    // Second arg must be the browserEngine ('wllama'), not the old 'webllm' default.
+    expect(call[1]).toBe('wllama');
+    // First arg is the model id — for wllama it's LLM_MODEL_DIR ('lfm2-vl-1.6b').
+    expect(call[0]).toBe('lfm2-vl-1.6b');
+  });
+
+  test('clicking a radio circle changes selection exactly once (no double-fire) (issue #24 F9)', async () => {
+    const setRagPreset = vi.fn();
+    vi.mocked(inferenceModule.useInferenceMode).mockReturnValue({
+      mode: 'browser-local',
+      browserEngine: 'wllama',
+      ragPreset: 'fast',
+      isServerConnected: false,
+      isModelReady: false,
+      modelLoadingProgress: 0,
+      modeError: null,
+      serverUrl: '',
+      setMode: vi.fn(),
+      setBrowserEngine: vi.fn(),
+      setRagPreset,
+      setServerUrl: vi.fn(),
+      checkServerConnectivity: vi.fn(() => Promise.resolve(false)),
+      setModelReady: vi.fn(),
+      setModelLoadingProgress: vi.fn(),
+    });
+
+    render(<SettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Response Quality')).toBeInTheDocument();
+    });
+
+    // Click directly on the radio input (the circle). With the <label> pattern,
+    // the native input's onChange is the sole handler — no div onClick to
+    // double-fire.
+    const balancedRadio = screen.getByRole('radio', { name: /balanced/i });
+    fireEvent.click(balancedRadio);
+
+    // Should fire exactly once, not twice.
+    expect(setRagPreset).toHaveBeenCalledTimes(1);
+    expect(setRagPreset).toHaveBeenCalledWith('balanced');
+  });
+
+  test('memory pressure refreshes on an interval (issue #24 F7)', async () => {
+    const { getMemoryPressureStatus } = await import('../lib/embeddings/memory-aware');
+    render(<SettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Storage')).toBeInTheDocument();
+    });
+
+    // Initial call on mount.
+    const initialCalls = (getMemoryPressureStatus as ReturnType<typeof vi.fn>).mock.calls.length;
+    expect(initialCalls).toBeGreaterThanOrEqual(1);
+
+    // Advance past the 5s interval — should refresh.
+    vi.advanceTimersByTime(5000);
+    await vi.waitFor(() => {
+      expect((getMemoryPressureStatus as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(initialCalls);
+    });
+  });
+
+  test('radio groups use native input as the sole radio (no duplicate role) (issue #24 F9)', async () => {
+    render(<SettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Inference Mode')).toBeInTheDocument();
+    });
+
+    // Every radio found by role should be a native <input> (the wrapping
+    // element is a <label>, which has no implicit role="radio").
+    const radios = screen.getAllByRole('radio');
+    expect(radios.length).toBeGreaterThanOrEqual(4);
+    for (const radio of radios) {
+      expect(radio.tagName).toBe('INPUT');
+    }
   });
 });

--- a/web_ui/src/pages/SettingsPage.test.tsx
+++ b/web_ui/src/pages/SettingsPage.test.tsx
@@ -64,6 +64,21 @@ vi.mock('../lib/embeddings/memory-aware', () => ({
   getMemoryPressureStatus: vi.fn(() => 'normal'),
 }));
 
+// PRR-005: mock checkPackagedModels so the PackagedModelReadiness component
+// mounts with controlled data (real HEAD probes fail in jsdom). Default
+// returns null so existing tests that don't care about readiness still pass.
+import type { PackagedModelsReport } from '../lib/models/model-manifest';
+const checkPackagedModelsMock = vi.fn((): Promise<PackagedModelsReport | null> => Promise.resolve(null));
+vi.mock('../lib/models/model-manifest', () => ({
+  checkPackagedModels: (..._args: unknown[]) => checkPackagedModelsMock(),
+  LLM_MODEL_DIR: 'lfm2-vl-1.6b',
+}));
+
+// Mock detectEngineCapability so it doesn't do real WebGPU probes in jsdom.
+vi.mock('../lib/llm/engine-capability', () => ({
+  detectEngineCapability: vi.fn(() => Promise.resolve(null)),
+}));
+
 vi.mock('../components/ModelDownloadProgress', () => ({
   ModelDownloadProgress: () => null,
 }));
@@ -154,6 +169,9 @@ describe('SettingsPage', () => {
     listStalePrefixesMock.mockClear();
     getProfilePrefixMock.mockClear();
     getProfilePrefixMock.mockReturnValue('testprfx');
+    // Reset checkPackagedModels to default (null = no panel rendered).
+    checkPackagedModelsMock.mockClear();
+    checkPackagedModelsMock.mockResolvedValue(null);
 
     // Setup default mock returns
     vi.mocked(inferenceModule.useInferenceMode).mockReturnValue({
@@ -550,7 +568,11 @@ describe('SettingsPage', () => {
     const call = mockModelReadinessGateInstance.checkModelCached.mock.calls[0] as unknown as [string, string];
     // Second arg must be the browserEngine ('wllama'), not the old 'webllm' default.
     expect(call[1]).toBe('wllama');
-    // First arg is the model id — for wllama it's LLM_MODEL_DIR ('lfm2-vl-1.6b').
+    // First arg is the model id — for wllama it's LLM_MODEL_DIR. We use the
+    // explicit literal here because model-manifest is mocked in this test file,
+    // so importing LLM_MODEL_DIR would read the mock (tautological). The real
+    // value is 'lfm2-vl-1.6b' (model-manifest.ts LLM_MODEL_DIR). If that
+    // constant changes, update this literal AND the mock factory's LLM_MODEL_DIR.
     expect(call[0]).toBe('lfm2-vl-1.6b');
   });
 
@@ -593,21 +615,32 @@ describe('SettingsPage', () => {
 
   test('memory pressure refreshes on an interval (issue #24 F7)', async () => {
     const { getMemoryPressureStatus } = await import('../lib/embeddings/memory-aware');
-    render(<SettingsPage />);
+    const { unmount } = render(<SettingsPage />);
 
+    // Wait for settings to load (the memory effect is gated on settingsLoaded).
     await waitFor(() => {
-      expect(screen.getByText('Storage')).toBeInTheDocument();
+      expect(screen.getByText('Inference Mode')).toBeInTheDocument();
     });
 
-    // Initial call on mount.
-    const initialCalls = (getMemoryPressureStatus as ReturnType<typeof vi.fn>).mock.calls.length;
-    expect(initialCalls).toBeGreaterThanOrEqual(1);
+    // ADV-4: exact call count, not just "> initial". After settings load the
+    // memory effect fires once (the initial updateMemoryStatus).
+    await waitFor(() => {
+      expect((getMemoryPressureStatus as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThanOrEqual(1);
+    });
+    const callsAfterMount = (getMemoryPressureStatus as ReturnType<typeof vi.fn>).mock.calls.length;
 
-    // Advance past the 5s interval — should refresh.
+    // One 5s interval tick → exactly one more call.
     vi.advanceTimersByTime(5000);
-    await vi.waitFor(() => {
-      expect((getMemoryPressureStatus as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(initialCalls);
-    });
+    expect((getMemoryPressureStatus as ReturnType<typeof vi.fn>).mock.calls.length).toBe(callsAfterMount + 1);
+
+    // Another tick → +1 more.
+    vi.advanceTimersByTime(5000);
+    expect((getMemoryPressureStatus as ReturnType<typeof vi.fn>).mock.calls.length).toBe(callsAfterMount + 2);
+
+    // Unmount → interval cleared, no further calls.
+    unmount();
+    vi.advanceTimersByTime(15000);
+    expect((getMemoryPressureStatus as ReturnType<typeof vi.fn>).mock.calls.length).toBe(callsAfterMount + 2);
   });
 
   test('radio groups use native input as the sole radio (no duplicate role) (issue #24 F9)', async () => {
@@ -624,5 +657,94 @@ describe('SettingsPage', () => {
     for (const radio of radios) {
       expect(radio.tagName).toBe('INPUT');
     }
+  });
+
+  // PRR-005: PackagedModelReadiness component tests. The component renders
+  // per-kind readiness from the PackagedModelsReport. These tests mock
+  // checkPackagedModels/detectEngineCapability so the component mounts with
+  // controlled data.
+
+  test('PackagedModelReadiness renders per-kind status badges (PRR-005, issue #24 F6)', async () => {
+    // Override checkPackagedModels to return a report with known kinds.
+    checkPackagedModelsMock.mockResolvedValue({
+      allReady: false,
+      models: [
+        { id: 'emb1', label: 'Embeddings', kind: 'embedding', group: 'core', ready: true, excluded: false, files: [] },
+        { id: 'rt1', label: 'ONNX Runtime', kind: 'runtime', group: 'core', ready: true, excluded: false, files: [] },
+        { id: 'rr1', label: 'Reranker', kind: 'reranker', group: 'optional', ready: false, excluded: false, files: [{ path: '/x.onnx', required: true, present: false }] },
+        { id: 'llm1', label: 'Browser LLM', kind: 'llm', group: 'llm', ready: true, excluded: false, files: [] },
+      ],
+      missing: ['/x.onnx'],
+    });
+
+    render(<SettingsPage />);
+
+    // Wait for the readiness panel to render.
+    await waitFor(() => {
+      expect(screen.getByText('Embeddings')).toBeInTheDocument();
+    });
+
+    // Per-kind labels rendered.
+    expect(screen.getByText('ONNX Runtime')).toBeInTheDocument();
+    expect(screen.getByText('Reranker')).toBeInTheDocument();
+
+    // Overall aggregate shows the missing-files message (reranker not ready).
+    expect(screen.getByText(/required model file/i)).toBeInTheDocument();
+  });
+
+  test('PackagedModelReadiness suppresses llm row for webllm engine (PRR-005, issue #24 F6)', async () => {
+    vi.mocked(inferenceModule.useInferenceMode).mockReturnValue({
+      mode: 'browser-local',
+      browserEngine: 'webllm',
+      ragPreset: 'balanced',
+      isServerConnected: false,
+      isModelReady: false,
+      modelLoadingProgress: 0,
+      modeError: null,
+      serverUrl: '',
+      setMode: vi.fn(),
+      setBrowserEngine: vi.fn(),
+      setRagPreset: vi.fn(),
+      setServerUrl: vi.fn(),
+      checkServerConnectivity: vi.fn(() => Promise.resolve(false)),
+      setModelReady: vi.fn(),
+      setModelLoadingProgress: vi.fn(),
+    });
+
+    checkPackagedModelsMock.mockResolvedValue({
+      allReady: true,
+      models: [
+        { id: 'emb1', label: 'Embeddings', kind: 'embedding', group: 'core', ready: true, excluded: false, files: [] },
+        { id: 'llm1', label: 'Browser LLM', kind: 'llm', group: 'llm', ready: true, excluded: false, files: [] },
+      ],
+      missing: [],
+    });
+
+    render(<SettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Embeddings')).toBeInTheDocument();
+    });
+
+    // The webllm-suppression note must be shown instead of the llm "Ready" row.
+    expect(screen.getByText(/webllm weights are not packaged/i)).toBeInTheDocument();
+  });
+
+  test('PackagedModelReadiness shows "Excluded from build" for excluded groups (PRR-005)', async () => {
+    checkPackagedModelsMock.mockResolvedValue({
+      allReady: true,
+      models: [
+        { id: 'emb1', label: 'Embeddings', kind: 'embedding', group: 'core', ready: true, excluded: false, files: [] },
+        { id: 'llm1', label: 'Browser LLM', kind: 'llm', group: 'llm', ready: true, excluded: true, files: [] },
+      ],
+      missing: [],
+    });
+
+    render(<SettingsPage />);
+
+    // wllama engine (default) → llm row shows, but it's excluded.
+    await waitFor(() => {
+      expect(screen.getByText('Excluded from build')).toBeInTheDocument();
+    });
   });
 });

--- a/web_ui/src/pages/SettingsPage.tsx
+++ b/web_ui/src/pages/SettingsPage.tsx
@@ -1,21 +1,41 @@
 /**
- * Settings page — inference mode, server configuration, model selection,
- * appearance, storage management, and about info.
+ * Settings page — inference mode, server configuration, browser engine &
+ * model cache status, appearance, storage management, and about info.
+ *
+ * Issue #24 rebuild: the page was almost entirely useless — Clear Cache was a
+ * no-op (deleted a nonexistent DB), the Model Selection dropdown was dead
+ * (persisted but never read by runtime), cache status checked the wrong
+ * engine, "System" theme sabotaged itself, readiness showed green while the
+ * LLM was missing, memory pressure was static, and radio cards had duplicate
+ * a11y semantics. All nine findings are addressed here.
  */
 
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { useInferenceMode } from '../lib/inference';
-import { useTheme } from '../lib/theme';
+import { useTheme, type ThemePreference } from '../lib/theme';
 import { ModelDownloadManager, type DownloadProgress } from '../lib/llm/model-download';
 import { ModelReadinessGate } from '../lib/llm/model-readiness';
 import { WEBLLM_DEFAULT_MODEL_ID } from '../lib/llm/web-llm-service';
-import { resetReadinessCache, ensureReadinessGateChecked } from '../lib/llm/readiness-gate';
+import {
+  resetReadinessCache,
+  ensureReadinessGateChecked,
+  modelIdForEngine,
+} from '../lib/llm/readiness-gate';
 import { detectEngineCapability, type EngineCapability } from '../lib/llm/engine-capability';
-import { checkPackagedModels, type PackagedModelsReport } from '../lib/models/model-manifest';
+import {
+  checkPackagedModels,
+  type PackagedModelsReport,
+  type PackagedModelKind,
+} from '../lib/models/model-manifest';
 import { RAG_PRESET_LABELS } from '../lib/rag/rag-presets';
 import { getMemoryBudget, getMemoryPressureStatus } from '../lib/embeddings/memory-aware';
 import { ModelDownloadProgress } from '../components/ModelDownloadProgress';
 import { ProgressBar, StatusBadge, SectionCard } from '../components/SettingsMetrics';
+import {
+  getProfilePrefix,
+  deleteNamespace,
+  listStalePrefixes,
+} from '../lib/storage/profile';
 
 // ============================================================================
 // Settings Store (IndexedDB)
@@ -25,9 +45,16 @@ const SETTINGS_DB_NAME = 'doc-qa-settings';
 const SETTINGS_STORE_NAME = 'settings';
 const SETTINGS_KEY = 'user-preferences';
 
+/**
+ * Persisted user preferences.
+ *
+ * Note (issue #24 F5): `theme` and `preferredModel` were removed — theme now
+ * lives solely in `localStorage['theme-preference']` (owned by ThemeContext),
+ * and `preferredModel` was dead (read by no runtime code; the readiness gate
+ * resolves the model id per-engine via `modelIdForEngine`). Old IndexedDB
+ * records may still carry these stale fields; they are simply ignored on load.
+ */
 interface UserPreferences {
-  theme: 'light' | 'dark' | 'system';
-  preferredModel: string;
   serverUrl: string;
 }
 
@@ -66,8 +93,6 @@ async function openSettingsDatabase(): Promise<IDBDatabase> {
 
 async function loadSettings(): Promise<UserPreferences> {
   const defaults: UserPreferences = {
-    theme: 'system',
-    preferredModel: WEBLLM_DEFAULT_MODEL_ID,
     serverUrl: '',
   };
 
@@ -87,8 +112,6 @@ async function loadSettings(): Promise<UserPreferences> {
         const result = request.result as StoredSettings | undefined;
         if (result && result.key === SETTINGS_KEY) {
           resolve({
-            theme: result.theme ?? defaults.theme,
-            preferredModel: result.preferredModel ?? defaults.preferredModel,
             serverUrl: result.serverUrl ?? defaults.serverUrl,
           });
         } else {
@@ -126,24 +149,72 @@ async function saveSettings(settings: UserPreferences): Promise<void> {
 }
 
 // ============================================================================
-// Available models
+// EdgeVec blob deletion (Clear Cache — issue #24 F1, resolves PRR-008)
 // ============================================================================
 
-interface ModelOption {
-  id: string;
-  label: string;
-  description: string;
-  sizeEstimate: string;
+/**
+ * Delete this profile's HNSW vector blob from the shared `edgevec-db`.
+ *
+ * The blob is stored as a VALUE keyed by `${prefix}-doc-qa-index`
+ * (`getStorageDbNames().vector`) in the `'data'` object store of `edgevec-db`
+ * (see vite.config.ts `IndexedDbBackend` + vector-index.ts `INDEX_NAME`).
+ * Deleting only this key preserves other profiles' blobs — deleting the whole
+ * `edgevec-db` would affect ALL profiles. Best-effort: never throws.
+ */
+function deleteEdgeVecBlob(prefix: string): Promise<void> {
+  return new Promise((resolve) => {
+    if (typeof indexedDB === 'undefined') {
+      resolve();
+      return;
+    }
+    const vectorKey = `${prefix}-doc-qa-index`;
+    let settled = false;
+    const finish = () => {
+      if (!settled) {
+        settled = true;
+        resolve();
+      }
+    };
+    try {
+      const req = indexedDB.open('edgevec-db', 1);
+      req.onupgradeneeded = () => {
+        // The DB may not exist yet in this session; ensure the 'data' store.
+        const db = req.result;
+        if (!db.objectStoreNames.contains('data')) {
+          db.createObjectStore('data');
+        }
+      };
+      req.onsuccess = () => {
+        const db = req.result;
+        if (!db.objectStoreNames.contains('data')) {
+          // No store → no blob to delete.
+          db.close();
+          finish();
+          return;
+        }
+        try {
+          const tx = db.transaction('data', 'readwrite');
+          const store = tx.objectStore('data');
+          store.delete(vectorKey);
+          tx.oncomplete = () => {
+            db.close();
+            finish();
+          };
+          tx.onerror = () => {
+            db.close();
+            finish();
+          };
+        } catch {
+          db.close();
+          finish();
+        }
+      };
+      req.onerror = () => finish();
+    } catch {
+      finish();
+    }
+  });
 }
-
-const AVAILABLE_MODELS: ModelOption[] = [
-  {
-    id: WEBLLM_DEFAULT_MODEL_ID,
-    label: WEBLLM_DEFAULT_MODEL_ID,
-    description: 'Fast, efficient model optimized for local inference',
-    sizeEstimate: '~1.9 GB',
-  },
-];
 
 // ============================================================================
 // App version
@@ -252,6 +323,7 @@ const radioInputStyle: React.CSSProperties = {
   height: '16px',
   accentColor: 'var(--color-primary)',
   cursor: 'pointer',
+  flexShrink: 0,
 };
 
 const radioLabelStyle: React.CSSProperties = {
@@ -271,19 +343,6 @@ const inputStyle: React.CSSProperties = {
   fontFamily: 'var(--font-family)',
   color: 'var(--color-text-on-bubble-assistant)',
   boxSizing: 'border-box',
-};
-
-// SVG data URLs cannot reference CSS variables, so we use the literal hex value
-// of --color-text-muted (#64748b in light mode). This is intentional.
-const SELECT_DROPDOWN_ARROW_COLOR = '#64748b';
-const selectStyle: React.CSSProperties = {
-  ...inputStyle,
-  cursor: 'pointer',
-  appearance: 'none',
-  backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23${SELECT_DROPDOWN_ARROW_COLOR.slice(1)}' d='M6 8L1 3h10z'/%3E%3C/svg%3E")`,
-  backgroundRepeat: 'no-repeat',
-  backgroundPosition: 'right 12px center',
-  paddingRight: '36px',
 };
 
 const buttonRowStyle: React.CSSProperties = {
@@ -328,8 +387,6 @@ const dangerButtonStyle: React.CSSProperties = {
   cursor: 'pointer',
   transition: 'background-color 0.15s ease',
 };
-
-
 
 const storageInfoStyle: React.CSSProperties = {
   display: 'flex',
@@ -380,12 +437,10 @@ function SettingsPageInner(): React.ReactElement {
     checkServerConnectivity,
   } = useInferenceMode();
 
-  const { theme, toggleTheme } = useTheme();
+  const { themePreference, setTheme } = useTheme();
 
   // Settings state
-  const [preferredModel, setPreferredModel] = useState<string>(WEBLLM_DEFAULT_MODEL_ID);
   const [localServerUrl, setLocalServerUrl] = useState<string>(serverUrl);
-  const [themePreference, setThemePreference] = useState<'light' | 'dark' | 'system'>('system');
 
   // Download state
   const [downloadProgress, setDownloadProgress] = useState<DownloadProgress | null>(null);
@@ -402,8 +457,9 @@ function SettingsPageInner(): React.ReactElement {
   const [memoryAvailable, setMemoryAvailable] = useState<number>(0);
   const [memoryTotal, setMemoryTotal] = useState<number>(0);
 
-  // Clear cache confirm state
+  // Clear cache confirm + result state (issue #24 F1)
   const [clearCacheState, setClearCacheState] = useState<'idle' | 'confirming'>('idle');
+  const [clearCacheResult, setClearCacheResult] = useState<'idle' | 'clearing' | 'cleared' | 'error'>('idle');
   const clearTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Connection test state
@@ -422,15 +478,7 @@ function SettingsPageInner(): React.ReactElement {
   // Load settings on mount
   useEffect(() => {
     loadSettings().then((settings) => {
-      setPreferredModel(settings.preferredModel);
       setLocalServerUrl(settings.serverUrl);
-      setThemePreference(settings.theme);
-      // Apply theme preference
-      if (settings.theme === 'system') {
-        // System default — no explicit toggle needed
-      } else if (settings.theme !== theme) {
-        toggleTheme();
-      }
       setSettingsLoaded(true);
     });
 
@@ -455,14 +503,19 @@ function SettingsPageInner(): React.ReactElement {
     setLocalServerUrl(serverUrl);
   }, [serverUrl]);
 
-  // Check model cache status when model changes
+  // Check model cache status — engine-aware (issue #24 F4).
+  // Previously this called checkModelCached(preferredModel) which defaulted
+  // engine='webllm', so a wllama user saw "Not cached" for their packaged GGUF.
+  // Now resolve the model id per-engine via modelIdForEngine and pass the
+  // actually-selected browserEngine.
   useEffect(() => {
     if (!settingsLoaded) return;
 
-    readinessGate.checkModelCached(preferredModel).then((cached) => {
-      setModelCached(cached);
+    const modelId = modelIdForEngine(browserEngine);
+    readinessGate.checkModelCached(modelId, browserEngine).then((cached) => {
+      if (isMountedRef.current) setModelCached(cached);
     });
-  }, [preferredModel, readinessGate, settingsLoaded]);
+  }, [browserEngine, readinessGate, settingsLoaded]);
 
   // Detect hardware capability + packaged-model readiness once on mount.
   useEffect(() => {
@@ -478,7 +531,8 @@ function SettingsPageInner(): React.ReactElement {
     };
   }, []);
 
-  // Update memory pressure periodically
+  // Update memory pressure periodically (issue #24 F7).
+  // Previously ran exactly once; now refreshes every 5s while Settings is open.
   useEffect(() => {
     if (!settingsLoaded) return;
 
@@ -491,51 +545,30 @@ function SettingsPageInner(): React.ReactElement {
     };
 
     updateMemoryStatus();
+    const intervalId = setInterval(updateMemoryStatus, 5000);
+    return () => clearInterval(intervalId);
   }, [settingsLoaded]);
 
   // Persist settings when they change
   const persistSettings = useCallback(
     (updates: Partial<UserPreferences>) => {
       saveSettings({
-        theme: themePreference,
-        preferredModel,
         serverUrl: localServerUrl,
         ...updates,
       });
     },
-    [themePreference, preferredModel, localServerUrl]
+    [localServerUrl]
   );
 
-  // Handle theme preference change
+  // Handle theme preference change (issue #24 F5).
+  // Delegates entirely to ThemeContext.setTheme, which persists/clears
+  // localStorage['theme-preference'] and applies the theme. 'system' clears
+  // the stored preference so the OS media-query listener follows changes.
   const handleThemeChange = useCallback(
-    (newTheme: 'light' | 'dark' | 'system') => {
-      setThemePreference(newTheme);
-      persistSettings({ theme: newTheme });
-
-      if (newTheme === 'system') {
-        // Clear stored preference so ThemeProvider's media query listener takes over
-        localStorage.removeItem('theme-preference');
-        // If OS preference differs from current theme, toggle to align
-        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-        if (prefersDark && theme === 'light') {
-          toggleTheme();
-        } else if (!prefersDark && theme === 'dark') {
-          toggleTheme();
-        }
-      } else if (newTheme !== theme) {
-        toggleTheme();
-      }
+    (newTheme: ThemePreference) => {
+      setTheme(newTheme);
     },
-    [theme, toggleTheme, persistSettings]
-  );
-
-  // Handle model change
-  const handleModelChange = useCallback(
-    (newModel: string) => {
-      setPreferredModel(newModel);
-      persistSettings({ preferredModel: newModel });
-    },
-    [persistSettings]
+    [setTheme]
   );
 
   // Handle server URL change
@@ -581,7 +614,9 @@ function SettingsPageInner(): React.ReactElement {
     setConnectionResult(connected ? 'success' : 'error');
   }, [checkServerConnectivity, localServerUrl, setServerUrl]);
 
-  // Download model
+  // Download model (issue #24 F3).
+  // webllm-only: downloads weights from the WebLLM CDN into Cache Storage.
+  // wllama weights are packaged same-origin and need no download.
   const handleDownloadModel = useCallback(async () => {
     if (!downloadManagerRef.current) {
       downloadManagerRef.current = new ModelDownloadManager();
@@ -592,7 +627,7 @@ function SettingsPageInner(): React.ReactElement {
     setDownloadProgress(null);
 
     try {
-      await downloadManagerRef.current.downloadModel(preferredModel, (progress) => {
+      await downloadManagerRef.current.downloadModel(WEBLLM_DEFAULT_MODEL_ID, (progress) => {
         if (!isMountedRef.current) return;
         setDownloadProgress(progress);
         if (progress.status === 'complete') {
@@ -621,7 +656,7 @@ function SettingsPageInner(): React.ReactElement {
       }
       setIsDownloading(false);
     }
-  }, [preferredModel]);
+  }, []);
 
   // Cancel download
   const handleCancelDownload = useCallback(() => {
@@ -629,7 +664,12 @@ function SettingsPageInner(): React.ReactElement {
     setIsDownloading(false);
   }, []);
 
-  // Clear cache (two-click confirm)
+  // Clear cache (two-click confirm) — issue #24 F1.
+  // Previously deleted a nonexistent bare 'doc-qa-documents' DB (no profile
+  // prefix) and an OPFS dir no engine uses — a near-total no-op. Now reuses
+  // PR-4's profile-scoped namespace utilities to delete the real user-prefixed
+  // document/keyword/vector-mapping DBs, the EdgeVec HNSW blob, stale orphan
+  // namespaces, the settings DB, and the webllm Cache Storage entries.
   const handleClearCacheClick = useCallback(async () => {
     if (clearCacheState === 'idle') {
       setClearCacheState('confirming');
@@ -644,35 +684,58 @@ function SettingsPageInner(): React.ReactElement {
         clearTimeoutRef.current = null;
       }
       setClearCacheState('idle');
+      setClearCacheResult('clearing');
 
-        // Clear IndexedDB and OPFS
-        try {
-          const deleteReq = indexedDB.deleteDatabase('doc-qa-documents');
-          deleteReq.onsuccess = () => {
-            console.info('Documents IndexedDB cleared');
-          };
+      try {
+        // 1. Current profile's document/keyword/vector-mapping IndexedDBs.
+        const prefix = getProfilePrefix();
+        await deleteNamespace(prefix);
+
+        // 2. EdgeVec HNSW blob (key in shared edgevec-db, store 'data').
+        //    Resolves PRR-008: deleteNamespace cannot reach this shared DB.
+        await deleteEdgeVecBlob(prefix);
+
+        // 3. Stale/orphan namespaces from prior sessions/profiles.
+        const stale = await listStalePrefixes();
+        if (stale.length > 0) {
+          await Promise.all(stale.map((p) => deleteNamespace(p)));
+        }
+
+        // 4. Settings IndexedDB (non-prefixed).
+        await new Promise<void>((resolve) => {
           const settingsDeleteReq = indexedDB.deleteDatabase(SETTINGS_DB_NAME);
           settingsDeleteReq.onsuccess = () => {
             settingsDbInstance = null;
-            console.info('Settings IndexedDB cleared');
+            resolve();
           };
-          // Clear OPFS (legacy/other cached data, if any)
-          await navigator.storage?.getDirectory()?.then(dir => dir.removeEntry('webllm', { recursive: true }).catch(() => {}));
-          // Clear Cache Storage (webllm's actual model weight storage — see
-          // model-readiness.ts / web-llm-service.ts. web-llm scopes its
-          // artifacts across three named caches: model weights, model config,
-          // and the wasm runtime).
-          if (typeof caches !== 'undefined' && typeof caches.delete === 'function') {
-            await Promise.all(
-              ['webllm/model', 'webllm/config', 'webllm/wasm'].map((cacheName) =>
-                caches.delete(cacheName).catch(() => {})
-              )
-            );
-          }
-          console.info('Cache clear completed — documents and models cleared');
-        } catch (err) {
-          console.error('Error clearing cache:', err);
+          settingsDeleteReq.onerror = () => resolve();
+          settingsDeleteReq.onblocked = () => resolve();
+        });
+
+        // 5. WebLLM Cache Storage (web-llm scopes artifacts across three
+        //    named caches: model weights, model config, and the wasm runtime).
+        if (typeof caches !== 'undefined' && typeof caches.delete === 'function') {
+          await Promise.all(
+            ['webllm/model', 'webllm/config', 'webllm/wasm'].map((cacheName) =>
+              caches.delete(cacheName).catch(() => {})
+            )
+          );
         }
+
+        setClearCacheResult('cleared');
+      } catch (err) {
+        console.error('Error clearing cache:', err);
+        setClearCacheResult('error');
+      }
+
+      // Clear the result status after a few seconds so it doesn't linger.
+      if (clearTimeoutRef.current) {
+        clearTimeout(clearTimeoutRef.current);
+      }
+      clearTimeoutRef.current = setTimeout(() => {
+        setClearCacheResult('idle');
+        clearTimeoutRef.current = null;
+      }, 3000);
     }
   }, [clearCacheState]);
 
@@ -683,9 +746,6 @@ function SettingsPageInner(): React.ReactElement {
     }
     return `${mb} MB`;
   };
-
-  // Get model info for selected model
-  const selectedModelInfo = AVAILABLE_MODELS.find((m) => m.id === preferredModel);
 
   if (!settingsLoaded) {
     return (
@@ -719,18 +779,12 @@ function SettingsPageInner(): React.ReactElement {
               <legend style={{ position: 'absolute', width: 1, height: 1, padding: 0, margin: -1, overflow: 'hidden', clip: 'rect(0,0,0,0)', whiteSpace: 'nowrap', border: 0 }}>Select inference mode</legend>
               <div style={radioGroupStyle}>
                 {/* Browser-local option */}
-                <div
+                {/* Radio a11y (issue #24 F9): the wrapping <label> is presentational
+                    (no role="radio"); the native <input type="radio"> is the sole
+                    AT-facing radio. Clicking the card checks the input via native
+                    label behavior — no duplicate onClick, no double-fire. */}
+                <label
                   style={mode === 'browser-local' ? radioOptionSelectedStyle : radioOptionStyle}
-                  onClick={() => setMode('browser-local')}
-                  role="radio"
-                  aria-checked={mode === 'browser-local'}
-                  tabIndex={0}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault();
-                      setMode('browser-local');
-                    }
-                  }}
                 >
                   <input
                     type="radio"
@@ -747,21 +801,11 @@ function SettingsPageInner(): React.ReactElement {
                       Run the AI model directly in your browser (CPU via wllama, or WebGPU via WebLLM — choose below)
                     </p>
                   </div>
-                </div>
+                </label>
 
                 {/* API server option */}
-                <div
+                <label
                   style={mode === 'api' ? radioOptionSelectedStyle : radioOptionStyle}
-                  onClick={() => setMode('api')}
-                  role="radio"
-                  aria-checked={mode === 'api'}
-                  tabIndex={0}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault();
-                      setMode('api');
-                    }
-                  }}
                 >
                   <input
                     type="radio"
@@ -778,7 +822,7 @@ function SettingsPageInner(): React.ReactElement {
                       Connect to a remote inference server
                     </p>
                   </div>
-                </div>
+                </label>
               </div>
             </fieldset>
           </div>
@@ -812,7 +856,7 @@ function SettingsPageInner(): React.ReactElement {
                 />
               </div>
 
-              <div style={buttonRowStyle}>
+              <div style={buttonRowStyle} role="status" aria-live="polite">
                 <button
                   type="button"
                   onClick={handleTestConnection}
@@ -843,88 +887,7 @@ function SettingsPageInner(): React.ReactElement {
         )}
 
         {/* ================================================================== */}
-        {/* 3. Model Selection */}
-        {/* ================================================================== */}
-        <section style={sectionStyle} aria-labelledby="model-selection-heading">
-          <h2 id="model-selection-heading" style={sectionTitleStyle}>
-            Model Selection
-          </h2>
-          <div style={fieldGroupStyle}>
-            <div>
-              <label htmlFor="model-select" style={labelStyle}>
-                AI Model
-              </label>
-              <p id="model-select-desc" style={descriptionStyle}>
-                Choose the AI model for browser-local inference
-              </p>
-              <select
-                id="model-select"
-                value={preferredModel}
-                onChange={(e) => handleModelChange(e.target.value)}
-                style={selectStyle}
-                aria-describedby="model-select-desc"
-                disabled={mode === 'api'}
-              >
-                {AVAILABLE_MODELS.map((model) => (
-                  <option key={model.id} value={model.id}>
-                    {model.label} ({model.sizeEstimate})
-                  </option>
-                ))}
-              </select>
-            </div>
-
-            {selectedModelInfo && (
-              <p style={descriptionStyle}>{selectedModelInfo.description}</p>
-            )}
-
-            {/* Cache status */}
-            <div style={buttonRowStyle}>
-              <span style={{ ...labelStyle, display: 'flex', alignItems: 'center', gap: 'var(--spacing-sm)' }}>
-                Status:
-                {modelCached ? (
-                  <StatusBadge status="ready" label="Cached" />
-                ) : (
-                  <StatusBadge status="not-ready" label="Not cached" />
-                )}
-              </span>
-            </div>
-
-            {/* Download progress */}
-            {isDownloading && (
-              <ModelDownloadProgress
-                progress={downloadProgress}
-                onCancel={handleCancelDownload}
-                isQuotaError={isQuotaError}
-              />
-            )}
-
-            {/* Download button */}
-            {mode === 'browser-local' && !modelCached && !isDownloading && (
-              <button
-                type="button"
-                onClick={handleDownloadModel}
-                style={primaryButtonStyle}
-              >
-                Download Model
-              </button>
-            )}
-
-            {mode === 'browser-local' && modelCached && !isDownloading && (
-              <span style={{ ...labelStyle, color: 'var(--color-primary)' }}>
-                Model ready to use
-              </span>
-            )}
-
-            {mode === 'api' && (
-              <p style={descriptionStyle}>
-                Model downloads are only available in browser-local mode
-              </p>
-            )}
-          </div>
-        </section>
-
-        {/* ================================================================== */}
-        {/* 3b. Browser Engine (browser-local only) */}
+        {/* 3. Browser Engine (browser-local only) + model cache status */}
         {/* ================================================================== */}
         <section style={sectionStyle} aria-labelledby="browser-engine-heading">
           <h2 id="browser-engine-heading" style={sectionTitleStyle}>
@@ -955,19 +918,9 @@ function SettingsPageInner(): React.ReactElement {
                     desc: 'Fastest when WebGPU is available; text only. Requires a GPU-capable browser.',
                   },
                 ]).map((opt) => (
-                  <div
+                  <label
                     key={opt.id}
                     style={browserEngine === opt.id ? radioOptionSelectedStyle : radioOptionStyle}
-                    onClick={() => setBrowserEngine(opt.id)}
-                    role="radio"
-                    aria-checked={browserEngine === opt.id}
-                    tabIndex={0}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault();
-                        setBrowserEngine(opt.id);
-                      }
-                    }}
                   >
                     <input
                       type="radio"
@@ -975,9 +928,6 @@ function SettingsPageInner(): React.ReactElement {
                       value={opt.id}
                       checked={browserEngine === opt.id}
                       onChange={() => setBrowserEngine(opt.id)}
-                      // Stop the native input click from bubbling to the row's
-                      // onClick, which would call setBrowserEngine a second time.
-                      onClick={(e) => e.stopPropagation()}
                       style={radioInputStyle}
                       aria-describedby={`${opt.id}-desc`}
                     />
@@ -985,7 +935,7 @@ function SettingsPageInner(): React.ReactElement {
                       <span style={radioLabelStyle}>{opt.label}</span>
                       <p id={`${opt.id}-desc`} style={descriptionStyle}>{opt.desc}</p>
                     </div>
-                  </div>
+                  </label>
                 ))}
               </div>
             </fieldset>
@@ -994,11 +944,67 @@ function SettingsPageInner(): React.ReactElement {
                 WebGPU was not detected — WebLLM will not run on this device. Switch to wllama or use server mode.
               </p>
             )}
+
+            {/* Model cache status + download — engine-aware (issue #24 F2/F3/F4).
+                Moved here from the deleted Model Selection section. The status
+                reflects the actually-selected engine, and the Download button
+                only shows for webllm (the only engine with a download step). */}
+            {mode === 'browser-local' && (
+              <div style={fieldGroupStyle} role="status" aria-live="polite">
+                <div style={buttonRowStyle}>
+                  <span style={{ ...labelStyle, display: 'flex', alignItems: 'center', gap: 'var(--spacing-sm)' }}>
+                    Status:
+                    {modelCached ? (
+                      <StatusBadge status="ready" label="Cached" />
+                    ) : (
+                      <StatusBadge status="not-ready" label="Not cached" />
+                    )}
+                  </span>
+                </div>
+
+                {/* Download progress */}
+                {isDownloading && (
+                  <ModelDownloadProgress
+                    progress={downloadProgress}
+                    onCancel={handleCancelDownload}
+                    isQuotaError={isQuotaError}
+                  />
+                )}
+
+                {/* Download button — webllm only (issue #24 F3) */}
+                {browserEngine === 'webllm' && !modelCached && !isDownloading && (
+                  <>
+                    <button
+                      type="button"
+                      onClick={handleDownloadModel}
+                      style={primaryButtonStyle}
+                    >
+                      Download Model
+                    </button>
+                    <p style={{ ...descriptionStyle, color: 'var(--color-warning)' }}>
+                      Requires internet access (~1.9 GB) — downloads weights from the WebLLM CDN.
+                    </p>
+                  </>
+                )}
+
+                {browserEngine === 'webllm' && modelCached && !isDownloading && (
+                  <span style={{ ...labelStyle, color: 'var(--color-primary)' }}>
+                    Model ready to use
+                  </span>
+                )}
+
+                {browserEngine === 'wllama' && (
+                  <p style={descriptionStyle}>
+                    Weights are bundled with this build — no download needed. The model loads automatically on first use.
+                  </p>
+                )}
+              </div>
+            )}
           </div>
         </section>
 
         {/* ================================================================== */}
-        {/* 3c. Response Quality (RAG preset) */}
+        {/* 4. Response Quality (RAG preset) */}
         {/* ================================================================== */}
         <section style={sectionStyle} aria-labelledby="rag-preset-heading">
           <h2 id="rag-preset-heading" style={sectionTitleStyle}>
@@ -1013,19 +1019,9 @@ function SettingsPageInner(): React.ReactElement {
               <legend style={{ position: 'absolute', width: 1, height: 1, padding: 0, margin: -1, overflow: 'hidden', clip: 'rect(0,0,0,0)', whiteSpace: 'nowrap', border: 0 }}>Select response quality preset</legend>
               <div style={radioGroupStyle}>
                 {(['fast', 'balanced', 'quality'] as const).map((preset) => (
-                  <div
+                  <label
                     key={preset}
                     style={ragPreset === preset ? radioOptionSelectedStyle : radioOptionStyle}
-                    onClick={() => setRagPreset(preset)}
-                    role="radio"
-                    aria-checked={ragPreset === preset}
-                    tabIndex={0}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault();
-                        setRagPreset(preset);
-                      }
-                    }}
                   >
                     <input
                       type="radio"
@@ -1033,9 +1029,6 @@ function SettingsPageInner(): React.ReactElement {
                       value={preset}
                       checked={ragPreset === preset}
                       onChange={() => setRagPreset(preset)}
-                      // Stop the native input click from bubbling to the row's
-                      // onClick, which would call setRagPreset a second time.
-                      onClick={(e) => e.stopPropagation()}
                       style={radioInputStyle}
                       aria-describedby={`rag-${preset}-desc`}
                     />
@@ -1045,7 +1038,7 @@ function SettingsPageInner(): React.ReactElement {
                         {RAG_PRESET_LABELS[preset].description}
                       </p>
                     </div>
-                  </div>
+                  </label>
                 ))}
               </div>
             </fieldset>
@@ -1053,7 +1046,7 @@ function SettingsPageInner(): React.ReactElement {
         </section>
 
         {/* ================================================================== */}
-        {/* 4. Appearance */}
+        {/* 5. Appearance */}
         {/* ================================================================== */}
         <section style={sectionStyle} aria-labelledby="appearance-heading">
           <h2 id="appearance-heading" style={sectionTitleStyle}>
@@ -1066,23 +1059,13 @@ function SettingsPageInner(): React.ReactElement {
               </legend>
               <div style={{ display: 'flex', gap: 'var(--spacing-md)', flexWrap: 'wrap' }}>
                 {(['light', 'dark', 'system'] as const).map((option) => (
-                  <div
+                  <label
                     key={option}
                     style={
                       themePreference === option
                         ? radioOptionSelectedStyle
                         : radioOptionStyle
                     }
-                    onClick={() => handleThemeChange(option)}
-                    role="radio"
-                    aria-checked={themePreference === option}
-                    tabIndex={0}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault();
-                        handleThemeChange(option);
-                      }
-                    }}
                   >
                     <input
                       type="radio"
@@ -1095,36 +1078,41 @@ function SettingsPageInner(): React.ReactElement {
                     <span style={radioLabelStyle}>
                       {option.charAt(0).toUpperCase() + option.slice(1)}
                     </span>
-                  </div>
+                  </label>
                 ))}
               </div>
+              <p style={descriptionStyle}>
+                System follows your OS color scheme and updates automatically when it changes.
+              </p>
             </fieldset>
           </div>
         </section>
 
         {/* ================================================================== */}
-        {/* 5. Storage */}
+        {/* 6. Storage */}
         {/* ================================================================== */}
         <SectionCard
           title="Storage"
           id="storage-heading"
           description="Browser storage status and cache management"
         >
+          {/* Per-kind packaged-model readiness (issue #24 F6).
+              Previously only the aggregate `allReady` was shown, which reported
+              green even when the browser LLM was absent (excluded group). Now
+              each kind is reported individually, scoped to the selected engine. */}
           {packagesReady && (
             <div
               style={{
                 ...storageInfoStyle,
                 borderLeft: `4px solid ${packagesReady.allReady ? 'var(--color-success)' : 'var(--color-danger)'}`,
               }}
+              aria-live="polite"
             >
-              <div style={storageRowStyle}>
-                <span style={storageLabelStyle}>Packaged Models</span>
-                <span style={{ fontWeight: 500, color: packagesReady.allReady ? 'var(--color-success)' : 'var(--color-danger)' }}>
-                  <span aria-hidden="true">{packagesReady.allReady ? '✓ ' : '✗ '}</span>
-                  {packagesReady.allReady ? 'Ready' : 'Missing'}
-                </span>
-              </div>
-              {!packagesReady.allReady && (
+              <PackagedModelReadiness
+                report={packagesReady}
+                browserEngine={browserEngine}
+              />
+              {!packagesReady.allReady && packagesReady.missing.length > 0 && (
                 <p style={descriptionStyle}>
                   {packagesReady.missing.length} required model file(s) not found in this build.
                   See the packaging guide (PACKAGING.md) to bundle models for offline use.
@@ -1151,16 +1139,32 @@ function SettingsPageInner(): React.ReactElement {
             >
               {clearCacheState === 'confirming' ? 'Click Again to Confirm' : 'Clear Cache'}
             </button>
-            <span id="clear-cache-desc" style={descriptionStyle}>
+            <span id="clear-cache-desc" style={descriptionStyle} aria-live="polite">
               {clearCacheState === 'confirming'
-                ? 'Are you sure? Click again to clear all cached data.'
-                : 'Clear cached models and stored documents from browser storage.'}
+                ? 'This will delete all documents, keyword/vector indexes, cached model weights, and settings for this profile. This cannot be undone.'
+                : 'Clear cached documents, indexes, model weights, and settings from browser storage.'}
             </span>
+            {/* Result feedback (issue #24 F1) — announced to screen readers */}
+            {clearCacheResult === 'clearing' && (
+              <span role="status" aria-live="polite" style={descriptionStyle}>
+                Clearing…
+              </span>
+            )}
+            {clearCacheResult === 'cleared' && (
+              <span role="status" aria-live="polite" style={{ ...descriptionStyle, color: 'var(--color-success)' }}>
+                Cache cleared
+              </span>
+            )}
+            {clearCacheResult === 'error' && (
+              <span role="status" aria-live="polite" style={{ ...descriptionStyle, color: 'var(--color-danger)' }}>
+                Could not clear all data
+              </span>
+            )}
           </div>
         </SectionCard>
 
         {/* ================================================================== */}
-        {/* 5b. Hardware Capability (diagnostic) */}
+        {/* 7. Hardware Capability (diagnostic) */}
         {/* ================================================================== */}
         <SectionCard
           title="Hardware Capability"
@@ -1205,7 +1209,7 @@ function SettingsPageInner(): React.ReactElement {
         </SectionCard>
 
         {/* ================================================================== */}
-        {/* 6. About */}
+        {/* 8. About */}
         {/* ================================================================== */}
         <section style={sectionStyle} aria-labelledby="about-heading">
           <h2 id="about-heading" style={sectionTitleStyle}>
@@ -1213,7 +1217,7 @@ function SettingsPageInner(): React.ReactElement {
           </h2>
           <div style={aboutSectionStyle}>
             <p>
-              <strong>Document Q&A</strong>
+              <strong>Document Q&amp;A</strong>
             </p>
             <p>Version: {APP_VERSION}</p>
             <p>
@@ -1227,6 +1231,98 @@ function SettingsPageInner(): React.ReactElement {
         </section>
       </div>
     </div>
+  );
+}
+
+// ============================================================================
+// PackagedModelReadiness — per-kind readiness display (issue #24 F6)
+// ============================================================================
+
+const KIND_LABELS: Record<PackagedModelKind, string> = {
+  embedding: 'Embeddings',
+  reranker: 'Reranker',
+  llm: 'Browser LLM',
+  runtime: 'ONNX Runtime',
+};
+
+/**
+ * Render per-kind packaged-model readiness from the PackagedModelsReport.
+ *
+ * Issue #24 F6: the aggregate `allReady` collapsed a real distinction
+ * (excluded-vs-present) into a single misleading green. This surfaces each
+ * kind individually so a missing browser LLM isn't hidden by green embeddings.
+ *
+ * For the webllm engine, the packaged `llm` kind (the wllama GGUF) is NOT
+ * what webllm uses — webllm weights live in Cache Storage — so that row is
+ * suppressed with an explanatory note to avoid a contradictory "Ready" signal
+ * (issue #24 critic M4).
+ */
+function PackagedModelReadiness({
+  report,
+  browserEngine,
+}: {
+  report: PackagedModelsReport;
+  browserEngine: 'wllama' | 'webllm';
+}): React.ReactElement {
+  // Group models by kind, preserving a stable display order.
+  const kindOrder: PackagedModelKind[] = ['embedding', 'runtime', 'reranker', 'llm'];
+  const byKind = new Map<PackagedModelKind, typeof report.models>();
+  for (const m of report.models) {
+    const arr = byKind.get(m.kind) ?? [];
+    arr.push(m);
+    byKind.set(m.kind, arr);
+  }
+
+  return (
+    <>
+      <div style={storageRowStyle}>
+        <span style={storageLabelStyle}>Packaged Models (overall)</span>
+        <span style={{ fontWeight: 500, color: report.allReady ? 'var(--color-success)' : 'var(--color-danger)' }}>
+          <span aria-hidden="true">{report.allReady ? '✓ ' : '✗ '}</span>
+          {report.allReady ? 'Ready' : 'Missing'}
+        </span>
+      </div>
+      {kindOrder.map((kind) => {
+        const models = byKind.get(kind);
+        if (!models || models.length === 0) return null;
+        // Suppress the packaged llm kind for webllm — its weights are in Cache
+        // Storage, not packaged. Showing "Ready" here would contradict the
+        // "Not cached" status above for a webllm user without a download.
+        if (kind === 'llm' && browserEngine === 'webllm') {
+          return (
+            <div key={kind} style={storageRowStyle}>
+              <span style={storageLabelStyle}>{KIND_LABELS[kind]}</span>
+              <span style={{ fontSize: 'var(--font-size-caption)', color: 'var(--color-text-muted)' }}>
+                WebLLM weights are not packaged — see cache status above
+              </span>
+            </div>
+          );
+        }
+        const allReady = models.every((m) => m.ready);
+        const allExcluded = models.every((m) => m.excluded);
+        // Check allExcluded BEFORE allReady: an excluded model reports
+        // ready=true (model-manifest.ts marks excluded groups ready), so
+        // allReady would otherwise win and show green for "Excluded from
+        // build" — a misleading color. Map excluded to 'not-ready' (warning)
+        // to match the label.
+        const status: 'ready' | 'error' | 'not-ready' = allExcluded
+          ? 'not-ready'
+          : allReady
+            ? 'ready'
+            : 'error';
+        const label = allExcluded
+          ? 'Excluded from build'
+          : allReady
+            ? 'Ready'
+            : 'Missing';
+        return (
+          <div key={kind} style={storageRowStyle}>
+            <span style={storageLabelStyle}>{KIND_LABELS[kind]}</span>
+            <StatusBadge status={status} label={label} />
+          </div>
+        );
+      })}
+    </>
   );
 }
 

--- a/web_ui/src/pages/SettingsPage.tsx
+++ b/web_ui/src/pages/SettingsPage.tsx
@@ -78,7 +78,16 @@ async function openSettingsDatabase(): Promise<IDBDatabase> {
     };
 
     request.onsuccess = () => {
-      settingsDbInstance = request.result;
+      const db = request.result;
+      // PRR-001: close the cached connection when a version change (e.g.
+      // deleteDatabase from Clear Cache) is requested, so the delete is not
+      // permanently blocked by this open connection. Without this, the
+      // settings DB survives "Clear Cache" while the UI reports success.
+      db.onversionchange = () => {
+        db.close();
+        settingsDbInstance = null;
+      };
+      settingsDbInstance = db;
       resolve(settingsDbInstance);
     };
 
@@ -159,26 +168,28 @@ async function saveSettings(settings: UserPreferences): Promise<void> {
  * (`getStorageDbNames().vector`) in the `'data'` object store of `edgevec-db`
  * (see vite.config.ts `IndexedDbBackend` + vector-index.ts `INDEX_NAME`).
  * Deleting only this key preserves other profiles' blobs — deleting the whole
- * `edgevec-db` would affect ALL profiles. Best-effort: never throws.
+ * `edgevec-db` would affect ALL profiles.
+ *
+ * F-003/PRR-002: rejects on genuine failures (open error, tx error, tx abort)
+ * so the caller's catch block surfaces "Could not clear all data" instead of
+ * falsely reporting success. The "DB/store doesn't exist" path resolves
+ * cleanly (nothing to delete — that's not an error). A synchronous throw from
+ * `db.transaction()` also rejects so no connection is leaked.
  */
 function deleteEdgeVecBlob(prefix: string): Promise<void> {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     if (typeof indexedDB === 'undefined') {
+      // No IndexedDB at all → nothing to delete; not an error.
       resolve();
       return;
     }
     const vectorKey = `${prefix}-doc-qa-index`;
-    let settled = false;
-    const finish = () => {
-      if (!settled) {
-        settled = true;
-        resolve();
-      }
-    };
+    const fail = (reason: string) => reject(new Error(reason));
     try {
       const req = indexedDB.open('edgevec-db', 1);
       req.onupgradeneeded = () => {
-        // The DB may not exist yet in this session; ensure the 'data' store.
+        // The DB may not exist yet in this session; ensure the 'data' store
+        // so the subsequent transaction does not throw.
         const db = req.result;
         if (!db.objectStoreNames.contains('data')) {
           db.createObjectStore('data');
@@ -187,9 +198,9 @@ function deleteEdgeVecBlob(prefix: string): Promise<void> {
       req.onsuccess = () => {
         const db = req.result;
         if (!db.objectStoreNames.contains('data')) {
-          // No store → no blob to delete.
+          // No store → no blob to delete. Clean exit, not an error.
           db.close();
-          finish();
+          resolve();
           return;
         }
         try {
@@ -198,20 +209,27 @@ function deleteEdgeVecBlob(prefix: string): Promise<void> {
           store.delete(vectorKey);
           tx.oncomplete = () => {
             db.close();
-            finish();
+            resolve();
           };
+          // PRR-002: handle abort (quota, competing tx) so the Promise does
+          // not hang. F-003: reject on error/abort so the caller knows.
           tx.onerror = () => {
             db.close();
-            finish();
+            fail('EdgeVec transaction error');
           };
-        } catch {
+          tx.onabort = () => {
+            db.close();
+            fail('EdgeVec transaction aborted');
+          };
+        } catch (txErr) {
           db.close();
-          finish();
+          fail(`EdgeVec transaction failed: ${txErr instanceof Error ? txErr.message : String(txErr)}`);
         }
       };
-      req.onerror = () => finish();
-    } catch {
-      finish();
+      req.onerror = () => fail('Failed to open edgevec-db');
+      req.onblocked = () => fail('edgevec-db open blocked');
+    } catch (openErr) {
+      fail(`edgevec-db open threw: ${openErr instanceof Error ? openErr.message : String(openErr)}`);
     }
   });
 }
@@ -511,10 +529,17 @@ function SettingsPageInner(): React.ReactElement {
   useEffect(() => {
     if (!settingsLoaded) return;
 
+    // PRR-004: cancellation token prevents an older, slower checkModelCached
+    // promise from overwriting modelCached with stale data after a rapid
+    // engine switch. Mirrors the cancelled-flag pattern in the detect effect.
+    let cancelled = false;
     const modelId = modelIdForEngine(browserEngine);
     readinessGate.checkModelCached(modelId, browserEngine).then((cached) => {
-      if (isMountedRef.current) setModelCached(cached);
+      if (!cancelled && isMountedRef.current) setModelCached(cached);
     });
+    return () => {
+      cancelled = true;
+    };
   }, [browserEngine, readinessGate, settingsLoaded]);
 
   // Detect hardware capability + packaged-model readiness once on mount.
@@ -618,6 +643,11 @@ function SettingsPageInner(): React.ReactElement {
   // webllm-only: downloads weights from the WebLLM CDN into Cache Storage.
   // wllama weights are packaged same-origin and need no download.
   const handleDownloadModel = useCallback(async () => {
+    // PRR-006: engine guard — only webllm has a download step. The UI button
+    // is also gated to webllm, but this prevents a future caller from
+    // triggering a webllm download while wllama is selected.
+    if (browserEngine !== 'webllm') return;
+
     if (!downloadManagerRef.current) {
       downloadManagerRef.current = new ModelDownloadManager();
     }
@@ -656,7 +686,7 @@ function SettingsPageInner(): React.ReactElement {
       }
       setIsDownloading(false);
     }
-  }, []);
+  }, [browserEngine]);
 
   // Cancel download
   const handleCancelDownload = useCallback(() => {
@@ -702,12 +732,20 @@ function SettingsPageInner(): React.ReactElement {
         }
 
         // 4. Settings IndexedDB (non-prefixed).
+        // Close the cached connection first so deleteDatabase is not blocked
+        // (PRR-001). The onversionchange handler in openSettingsDatabase also
+        // fires, but closing here is deterministic and immediate.
+        if (settingsDbInstance) {
+          try {
+            settingsDbInstance.close();
+          } catch {
+            // already closed
+          }
+          settingsDbInstance = null;
+        }
         await new Promise<void>((resolve) => {
           const settingsDeleteReq = indexedDB.deleteDatabase(SETTINGS_DB_NAME);
-          settingsDeleteReq.onsuccess = () => {
-            settingsDbInstance = null;
-            resolve();
-          };
+          settingsDeleteReq.onsuccess = () => resolve();
           settingsDeleteReq.onerror = () => resolve();
           settingsDeleteReq.onblocked = () => resolve();
         });
@@ -1141,7 +1179,7 @@ function SettingsPageInner(): React.ReactElement {
             </button>
             <span id="clear-cache-desc" style={descriptionStyle} aria-live="polite">
               {clearCacheState === 'confirming'
-                ? 'This will delete all documents, keyword/vector indexes, cached model weights, and settings for this profile. This cannot be undone.'
+                ? 'This will delete all documents, keyword/vector indexes, cached model weights, and settings for this profile, plus any orphaned data from previous sessions. This cannot be undone.'
                 : 'Clear cached documents, indexes, model weights, and settings from browser storage.'}
             </span>
             {/* Result feedback (issue #24 F1) — announced to screen readers */}

--- a/web_ui/vitest.config.ts
+++ b/web_ui/vitest.config.ts
@@ -70,7 +70,6 @@ export default defineConfig({
       'src/lib/processing/pptx-extractor.test.ts',
       'src/lib/llm/web-llm-service.test.ts',
       'src/lib/llm/webgpu-watchdog.test.ts',
-      'src/pages/SettingsPage.test.tsx',
       // Allocates multi-GB page fixtures for TextChunker stress/verification;
       // exceeds the per-fork memory limit under the tuned pool. Owned by
       // document-ingestion PR #23 (rework to stream fixtures).


### PR DESCRIPTION
Closes #24

## Summary

Rebuilds the `web_ui` Settings page to resolve all 9 actionable findings from the audit — the page was "almost entirely useless": nearly every control was a dead end, misleading, or destructive-but-ineffective. All prerequisite PRs (#27/#20, #28/#21, #30/#23) are merged; this PR consumes their new APIs (profile-scoped storage namespace, engine-aware readiness gate, per-kind model manifest report).

### Findings closed

| # | Severity | Finding | Fix |
|---|----------|---------|-----|
| F1 | CRITICAL | Clear Cache deleted a nonexistent bare `doc-qa-documents` DB (no profile prefix) + an OPFS dir no engine uses → near-total no-op | Reuses PR-4's `deleteNamespace(getProfilePrefix())` + `listStalePrefixes()` for real user-prefixed DBs; adds `deleteEdgeVecBlob` to clear the HNSW vector blob from shared `edgevec-db` (resolves PRR-008); accurate confirmation text + result feedback |
| F2 | HIGH | Model Selection dropdown had 1 option; `preferredModel` persisted but read by no runtime code | Deleted the entire section (dead); moved cache-status/download into Browser Engine section |
| F3 | HIGH | Download Model fetched ~1.9GB from CDN; showed for wllama (which never uses it) | Download button now webllm-only + "requires internet (~1.9 GB)" warning; wllama shows "weights bundled, no download needed" |
| F4 | HIGH | `checkModelCached` defaulted to `engine='webllm'` regardless of selected engine | Passes `modelIdForEngine(browserEngine)` + `browserEngine` as args |
| F5 | MEDIUM×2 | "System" theme called `toggleTheme()` which re-wrote localStorage, defeating follow-system; theme in 2 stores | Added `setTheme(mode)` to ThemeContext (`'system'` clears the preference); removed `toggleTheme`; removed `theme` from IndexedDB → single source of truth (localStorage only); `<label>` pattern fixes double-fire |
| F6 | MEDIUM | Aggregate `allReady` showed green while LLM was missing (excluded group) | New `PackagedModelReadiness` component renders per-kind status; suppresses the packaged `llm` row for webllm engine (its weights are in Cache Storage, not packaged) |
| F7 | MEDIUM | Memory pressure indicator ran once, no interval | Added `setInterval(updateMemoryStatus, 5000)` + `clearInterval` on unmount |
| F8 | MEDIUM | Test asserted `setServerUrl` on `onChange`; component persists on `onBlur` | Fixed test to assert blur-persist (correct UX); removed `SettingsPage.test.tsx` from vitest exclude list |
| F9 | HIGH (a11y) | All 4 radio groups nested visible native `<input type="radio">` inside `<div role="radio">` → duplicate semantics; status feedback lacked `aria-live` | Converted wrapping `div` → `<label>` (presentational); native input is the sole radio; removed all `role="radio"`/`aria-checked`/`tabIndex`/`onKeyDown` from wrappers; added `aria-live="polite"`/`role="status"` to status regions |

### Files changed
- `web_ui/src/pages/SettingsPage.tsx` — major rewrite (all 9 findings)
- `web_ui/src/pages/SettingsPage.test.tsx` — rewritten, un-excluded from CI (17 tests)
- `web_ui/src/pages/SettingsPage.clearCache.test.tsx` — updated mocks + new assertions (8 tests)
- `web_ui/src/lib/theme/ThemeContext.tsx` — `setTheme(mode)` + `themePreference`, removed `toggleTheme`
- `web_ui/src/lib/theme/ThemeContext.test.tsx` — NEW (9 tests)
- `web_ui/src/lib/theme/index.ts` — exported `ThemePreference` type
- `web_ui/src/lib/llm/readiness-gate.ts` — exported `modelIdForEngine` (was private)
- `web_ui/vitest.config.ts` — removed `SettingsPage.test.tsx` from exclude list

## Invariant audit

| Invariant | Evidence |
|-----------|----------|
| Build succeeds | `npm run build` — PASS (6.53s) |
| Typecheck passes | `npm run typecheck:all` — PASS (clean, both tsconfig + tsconfig.test) |
| Tests pass | `npx vitest run` — 55 files, 899 passed, 1 skipped, 0 failed |
| No generated artifacts staged | Only source + test files in diff |
| No secrets in diff | Pre-push scan: no `sk_live_`/`ghp_`/`xox`/`AKIA`/`eyJ`/`AIza` patterns |
| New code has tests | ThemeContext (9 tests), SettingsPage (17 tests), ClearCache (8 tests) — all new behavior covered |

## Backward compatibility

- **IndexedDB `UserPreferences`:** `theme` and `preferredModel` fields removed. Old records carrying these stale fields are silently ignored on load (`loadSettings` only reads `serverUrl`). No migration needed.
- **Theme:** A user whose `localStorage` was cleared but whose IndexedDB retained `theme:'dark'` will now see "system" instead of "dark" on next load — the intended consequence of unifying to one source of truth (`localStorage['theme-preference']`).
- **`toggleTheme` removed:** No production consumer remained after this PR (only SettingsPage used it). Test mocks updated.

## Validation gates (swarm mode)

This PR was developed under the swarm/issue-tracer workflow with independent review:
- **Plan critic** (GLM-5.2): NEEDS_REVISION → 3 blockers + 3 medium items addressed before implementation.
- **Implementation reviewer** (GLM-5.2): APPROVE → 2 non-blocking fixes applied (EdgeVec blob test assertion, excluded-model status color).
- **Final critic** (GLM-5.2): APPROVE — "Ship it." All 9 findings verified closed end-to-end, all 6 acceptance criteria met.

## Test plan

Exact commands run + results:
```
npm run typecheck:all          → PASS (clean)
npx vitest run                 → 55 files, 899 passed, 1 skipped, 0 failed
npx vitest run src/pages/SettingsPage.test.tsx          → 17 passed
npx vitest run src/pages/SettingsPage.clearCache.test.tsx → 8 passed
npx vitest run src/lib/theme/ThemeContext.test.tsx       → 9 passed
npm run build                  → PASS (6.53s)
```

### Manual verification (acceptance criteria)
- [ ] Clear Cache removes document/keyword/vector index DBs (DevTools → Application → IndexedDB before/after)
- [ ] Selecting "System" theme, then changing OS `prefers-color-scheme`, updates the app theme live
- [ ] Clicking directly on a radio circle changes selection exactly once
- [ ] Model cache status reflects the actually-selected engine, not a hardcoded default
- [x] `npx vitest run src/pages/SettingsPage.test.tsx` passes
- [x] Every radio group is operable via native input (sole radio, keyboard-accessible)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/trainingapp/pull/31?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

