### PR TITLE
fix(web_ui): chat correctness & UX overhaul — renderer, streaming/persistence integrity, a11y (Issue #36)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The application uses GGUF models via llama-cpp-python for fully offline inferenc
 ### Chat UI (Phase 3)
 - **Streaming Chat Interface**: Full-featured chat page (`ChatPage.tsx`) with real-time token streaming display using RAF-batched updates via `TokenStreamManager`
 - **Role-Based Message Bubbles**: Distinct styling for user, assistant, and system messages with relative timestamps ("2m ago", "just now")
-- **Inline Markdown Renderer**: Zero-dependency markdown parser supporting bold, italic, inline code, fenced code blocks, ordered/unordered lists, and links with URL validation (rejects javascript: and data: URLs)
+- **Inline Markdown Renderer**: react-markdown + remark-gfm based renderer supporting CommonMark + GFM (tables, strikethrough, task lists, autolinks, nested emphasis), fenced code blocks with language chips and per-block copy, and a URL allowlist (allows http/https/mailto/tel; rejects javascript:, data:, and scheme-less/relative URLs)
 - **Source Citation Pills**: Expandable/collapsible source pills with filename truncation, full path reveal on click, and one-click copy-to-clipboard
 - **Inference Mode Toggle**: Status indicator (green/yellow/red) for browser-local vs API mode with server connectivity check against `/auth/status` endpoint
 - **Streaming Cursor Animation**: Blinking cursor (`@keyframes blink`) appended to assistant messages during streaming for visual feedback
@@ -225,7 +225,7 @@ The application uses GGUF models via llama-cpp-python for fully offline inferenc
 | `ChatMessageList.tsx` | `src/components/` | Centered transcript (768px max-width), rich empty state with suggested prompts (Phase 2) |
 | `ChatMessageBubble.tsx` | `src/components/` | Role-based messages: assistant full-width prose, user 75% bubbles, action-row copy (Phase 2) |
 | `ChatInput.tsx` | `src/components/` | Raised card composer with focus feedback, elevation shadow, 20px radius (Phase 2) |
-| `MarkdownRenderer.tsx` | `src/components/` | Zero-dependency inline markdown parser |
+| `MarkdownRenderer.tsx` | `src/components/` | react-markdown + remark-gfm renderer (CommonMark + GFM, URL allowlist) |
 | `SourceCitation.tsx` | `src/components/` | Expandable citation pills with copy-to-clipboard |
 | `InferenceModeToggle.tsx` | `src/components/` | Status dot (green/yellow/red) for browser-local vs API mode |
 | `StreamingIndicator.tsx` | `src/components/` | Bouncing dots animation during generation |
@@ -965,7 +965,7 @@ doc_qa_app/
 │   │   │   ├── ChatMessageBubble.tsx # Role-based message bubbles (Phase 3)
 │   │   │   ├── ChatMessageList.tsx   # Scrollable message container (Phase 3)
 │   │   │   ├── ChatInput.tsx         # Input with send/cancel (Phase 3)
-│   │   │   ├── MarkdownRenderer.tsx  # Zero-dependency markdown (Phase 3)
+│   │   │   ├── MarkdownRenderer.tsx  # react-markdown + remark-gfm (Phase 3)
 │   │   │   ├── SourceCitation.tsx    # Expandable citation pills (Phase 3)
 │   │   │   ├── InferenceModeToggle.tsx # Mode status toggle (Phase 3)
 │   │   │   ├── StreamingIndicator.tsx  # Bouncing dots animation (Phase 3)

--- a/web_ui/package-lock.json
+++ b/web_ui/package-lock.json
@@ -20,6 +20,8 @@
         "pdfjs-dist": "^4.4.168",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-markdown": "^9.1.0",
+        "remark-gfm": "^4.0.1",
         "xlsx": "^0.18.5"
       },
       "devDependencies": {
@@ -2316,6 +2318,15 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -2327,7 +2338,39 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -2343,14 +2386,12 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.29",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.29.tgz",
       "integrity": "sha512-ch0qJdr2JY0r04NXSprbK6TXOgnaJ1Tz23fm5W+z0/CBah6BSBc3n96h7K9GOtwh0HrilNWHIBzE1Ko4Dcw/Wg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -2366,6 +2407,18 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+      "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -2611,6 +2664,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -2736,6 +2799,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/cfb": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
@@ -2764,6 +2837,46 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/check-error": {
@@ -2805,6 +2918,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/convert-source-map": {
@@ -2864,7 +2987,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -2885,7 +3007,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2905,6 +3026,19 @@
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
@@ -2964,7 +3098,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2984,6 +3117,19 @@
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "license": "MIT"
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/dexie": {
       "version": "4.4.4",
@@ -3179,6 +3325,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -3198,6 +3354,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -3468,6 +3630,46 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
@@ -3479,6 +3681,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -3543,6 +3755,68 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
@@ -3677,6 +3951,16 @@
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -3762,6 +4046,16 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/matcher": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
@@ -3783,6 +4077,851 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
@@ -3842,7 +4981,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -3944,6 +5082,31 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "license": "(MIT AND Zlib)"
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
     },
     "node_modules/parse5": {
       "version": "7.3.0",
@@ -4073,6 +5236,16 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
     },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/protobufjs": {
       "version": "7.6.1",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.1.tgz",
@@ -4140,6 +5313,33 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/react-markdown": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-9.1.0.tgz",
+      "integrity": "sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -4177,6 +5377,72 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/roarr": {
@@ -4399,6 +5665,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -4440,6 +5716,20 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-indent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -4472,6 +5762,24 @@
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
+      }
     },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
@@ -4612,6 +5920,26 @@
         "node": ">=18"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -4657,6 +5985,93 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -4693,6 +6108,34 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/vite": {
       "version": "6.4.2",
@@ -5036,6 +6479,16 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     }
   }
 }

--- a/web_ui/package.json
+++ b/web_ui/package.json
@@ -29,6 +29,8 @@
     "pdfjs-dist": "^4.4.168",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-markdown": "^9.1.0",
+    "remark-gfm": "^4.0.1",
     "xlsx": "^0.18.5"
   },
   "devDependencies": {

--- a/web_ui/src/App.test.tsx
+++ b/web_ui/src/App.test.tsx
@@ -154,7 +154,7 @@ describe('App — AC2: navigating between pages preserves the conversation', () 
     render(<App />);
 
     // Chat is the default page; send a real message through the real ChatPage.
-    const textarea = await screen.findByPlaceholderText('Ask a question...');
+    const textarea = await screen.findByPlaceholderText('Ask a question… (Enter to send, Shift+Enter for a new line)');
     fireEvent.change(textarea, { target: { value: 'Hello from AC2 test' } });
     await act(async () => {
       fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false });
@@ -172,7 +172,7 @@ describe('App — AC2: navigating between pages preserves the conversation', () 
       expect(screen.getByTestId('documents-page-marker')).toBeInTheDocument();
     });
     expect(screen.queryByText('Hello from AC2 test')).not.toBeInTheDocument();
-    expect(screen.queryByPlaceholderText('Ask a question...')).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('Ask a question… (Enter to send, Shift+Enter for a new line)')).not.toBeInTheDocument();
 
     // Navigate back to Chat — this remounts ChatPage. The regression this
     // test guards: if useConversations() were ever moved back inside
@@ -190,7 +190,7 @@ describe('App — AC2: navigating between pages preserves the conversation', () 
   it('keeps chat messages after navigating Chat -> Settings -> Chat', async () => {
     render(<App />);
 
-    const textarea = await screen.findByPlaceholderText('Ask a question...');
+    const textarea = await screen.findByPlaceholderText('Ask a question… (Enter to send, Shift+Enter for a new line)');
     fireEvent.change(textarea, { target: { value: 'Second round trip' } });
     await act(async () => {
       fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false });

--- a/web_ui/src/App.tsx
+++ b/web_ui/src/App.tsx
@@ -80,6 +80,7 @@ function LoadingOverlay({
 
 function AppContent() {
   const [currentPage, setCurrentPage] = useState('chat');
+  const [initErrorDismissed, setInitErrorDismissed] = useState(false);
   const { setModelReady, setModelLoadingProgress, browserEngine } = useInferenceMode();
 
   const {
@@ -87,6 +88,7 @@ function AppContent() {
     currentConversationId,
     currentMessages,
     setCurrentMessages,
+    setCurrentConversationId,
     selectConversation,
     newChat,
     saveMessages,
@@ -105,6 +107,7 @@ function AppContent() {
   });
 
   const openSettings = () => setCurrentPage('settings');
+  const goToDocuments = () => setCurrentPage('documents');
 
   // Global Ctrl+, (Open Settings) shortcut, registered here so it works from
   // every page (Documents, Settings, Chat), not just while ChatPage is mounted.
@@ -136,8 +139,11 @@ function AppContent() {
               messages={currentMessages}
               onMessagesChange={setCurrentMessages}
               onSaveConversation={saveMessages}
+              currentConversationId={currentConversationId}
+              setCurrentConversationId={setCurrentConversationId}
               onNewChat={newChat}
               onOpenSettings={openSettings}
+              onNavigateToDocuments={goToDocuments}
             />
           </ErrorBoundary>
         );
@@ -160,11 +166,14 @@ function AppContent() {
               messages={currentMessages}
               onMessagesChange={setCurrentMessages}
               onSaveConversation={saveMessages}
+              currentConversationId={currentConversationId}
+              setCurrentConversationId={setCurrentConversationId}
               onNewChat={newChat}
               onOpenSettings={openSettings}
+              onNavigateToDocuments={goToDocuments}
             />
           </ErrorBoundary>
-        );
+      );
     }
   };
 
@@ -196,6 +205,49 @@ function AppContent() {
         }}>
           <span>{persistenceError}</span>
           <button onClick={clearPersistenceError} aria-label="Dismiss error" style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'inherit', fontSize: 'var(--font-size-body)' }}>×</button>
+        </div>
+      )}
+      {/* U3a: boot init-error banner. useServiceInitialization sets both
+          setInitError and setIsInitialized(true) in one synchronous block, so
+          React 18 batches them and the !isInitialized-gated overlay never
+          paints the error. This banner surfaces it POST-init so search/vector
+          init failures are visible. Retry reloads the page (the most reliable
+          re-init, since the hook guards against re-running in-process). */}
+      {initError && !initErrorDismissed && (
+        <div
+          role="status"
+          style={{
+            padding: 'var(--spacing-sm) var(--spacing-md)',
+            backgroundColor: 'rgba(234, 179, 8, 0.12)',
+            border: '1px solid var(--color-warning-strong)',
+            borderRadius: 'var(--radius-sm)',
+            color: 'var(--color-warning-strong)',
+            fontSize: 'var(--font-size-caption)',
+            margin: 'var(--spacing-sm) var(--spacing-md)',
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            gap: 'var(--spacing-md)',
+          }}
+        >
+          <span>Search is degraded — answers may miss information. ({initError})</span>
+          <span style={{ display: 'flex', gap: 'var(--spacing-sm)', flexShrink: 0 }}>
+            <button
+              type="button"
+              onClick={() => window.location.reload()}
+              style={{ background: 'transparent', border: '1px solid currentColor', borderRadius: 'var(--radius-sm)', cursor: 'pointer', color: 'inherit', fontSize: 'var(--font-size-caption)', padding: '2px var(--spacing-sm)' }}
+            >
+              Retry
+            </button>
+            <button
+              type="button"
+              onClick={() => setInitErrorDismissed(true)}
+              aria-label="Dismiss degraded-search notice"
+              style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'inherit', fontSize: 'var(--font-size-body)' }}
+            >
+              ×
+            </button>
+          </span>
         </div>
       )}
       {renderPage()}

--- a/web_ui/src/components/ChatInput.test.tsx
+++ b/web_ui/src/components/ChatInput.test.tsx
@@ -45,7 +45,7 @@ describe('ChatInput', () => {
       const mockSend = vi.fn();
       render(<ChatInput onSend={mockSend} isLoading={false} onCancel={vi.fn()} />);
 
-      expect(screen.getByPlaceholderText('Ask a question...')).toBeInTheDocument();
+      expect(screen.getByPlaceholderText('Ask a question… (Enter to send, Shift+Enter for a new line)')).toBeInTheDocument();
     });
 
     it('renders Send button initially', () => {
@@ -59,14 +59,14 @@ describe('ChatInput', () => {
       const mockSend = vi.fn();
       render(<ChatInput onSend={mockSend} isLoading={false} onCancel={vi.fn()} disabled={true} />);
 
-      expect(screen.getByPlaceholderText('Ask a question...')).toBeDisabled();
+      expect(screen.getByPlaceholderText('Ask a question… (Enter to send, Shift+Enter for a new line)')).toBeDisabled();
     });
 
     it('renders disabled textarea when isLoading is true', () => {
       const mockSend = vi.fn();
       render(<ChatInput onSend={mockSend} isLoading={true} onCancel={vi.fn()} />);
 
-      expect(screen.getByPlaceholderText('Ask a question...')).toBeDisabled();
+      expect(screen.getByPlaceholderText('Ask a question… (Enter to send, Shift+Enter for a new line)')).toBeDisabled();
     });
   });
 
@@ -75,7 +75,7 @@ describe('ChatInput', () => {
       const mockSend = vi.fn();
       render(<ChatInput onSend={mockSend} isLoading={false} onCancel={vi.fn()} />);
 
-      const textarea = screen.getByPlaceholderText('Ask a question...');
+      const textarea = screen.getByPlaceholderText('Ask a question… (Enter to send, Shift+Enter for a new line)');
       fireEvent.change(textarea, { target: { value: '  Hello world  ' } });
 
       const sendButton = screen.getByRole('button', { name: /send message/i });
@@ -88,7 +88,7 @@ describe('ChatInput', () => {
       const mockSend = vi.fn();
       render(<ChatInput onSend={mockSend} isLoading={false} onCancel={vi.fn()} />);
 
-      const textarea = screen.getByPlaceholderText('Ask a question...');
+      const textarea = screen.getByPlaceholderText('Ask a question… (Enter to send, Shift+Enter for a new line)');
       fireEvent.change(textarea, { target: { value: 'Test message' } });
 
       const sendButton = screen.getByRole('button', { name: /send message/i });
@@ -111,7 +111,7 @@ describe('ChatInput', () => {
       const mockSend = vi.fn();
       render(<ChatInput onSend={mockSend} isLoading={false} onCancel={vi.fn()} />);
 
-      const textarea = screen.getByPlaceholderText('Ask a question...');
+      const textarea = screen.getByPlaceholderText('Ask a question… (Enter to send, Shift+Enter for a new line)');
       fireEvent.change(textarea, { target: { value: '   ' } });
 
       const sendButton = screen.getByRole('button', { name: /send message/i });
@@ -126,7 +126,7 @@ describe('ChatInput', () => {
       const mockSend = vi.fn();
       render(<ChatInput onSend={mockSend} isLoading={false} onCancel={vi.fn()} />);
 
-      const textarea = screen.getByPlaceholderText('Ask a question...');
+      const textarea = screen.getByPlaceholderText('Ask a question… (Enter to send, Shift+Enter for a new line)');
       fireEvent.change(textarea, { target: { value: 'Test' } });
       fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false });
 
@@ -137,7 +137,7 @@ describe('ChatInput', () => {
       const mockSend = vi.fn();
       render(<ChatInput onSend={mockSend} isLoading={false} onCancel={vi.fn()} />);
 
-      const textarea = screen.getByPlaceholderText('Ask a question...');
+      const textarea = screen.getByPlaceholderText('Ask a question… (Enter to send, Shift+Enter for a new line)');
       fireEvent.change(textarea, { target: { value: 'Test\nNew line' } });
       fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: true });
 
@@ -148,7 +148,7 @@ describe('ChatInput', () => {
       const mockSend = vi.fn();
       render(<ChatInput onSend={mockSend} isLoading={true} onCancel={vi.fn()} />);
 
-      const textarea = screen.getByPlaceholderText('Ask a question...');
+      const textarea = screen.getByPlaceholderText('Ask a question… (Enter to send, Shift+Enter for a new line)');
       fireEvent.change(textarea, { target: { value: 'Test' } });
       fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false });
 
@@ -159,7 +159,7 @@ describe('ChatInput', () => {
       const mockSend = vi.fn();
       render(<ChatInput onSend={mockSend} isLoading={false} onCancel={vi.fn()} />);
 
-      const textarea = screen.getByPlaceholderText('Ask a question...');
+      const textarea = screen.getByPlaceholderText('Ask a question… (Enter to send, Shift+Enter for a new line)');
       fireEvent.change(textarea, { target: { value: 'こんにちは' } });
       // Enter confirms an IME candidate — isComposing must prevent send.
       // Construct a real KeyboardEvent with isComposing=true so React's
@@ -208,7 +208,7 @@ describe('ChatInput', () => {
       const mockSend = vi.fn();
       render(<ChatInput onSend={mockSend} isLoading={false} onCancel={vi.fn()} />);
 
-      const textarea = screen.getByPlaceholderText('Ask a question...');
+      const textarea = screen.getByPlaceholderText('Ask a question… (Enter to send, Shift+Enter for a new line)');
       fireEvent.change(textarea, { target: { value: 'Test' } });
 
       expect(screen.getByRole('button', { name: /clear input/i })).toBeInTheDocument();
@@ -225,7 +225,7 @@ describe('ChatInput', () => {
       const mockSend = vi.fn();
       render(<ChatInput onSend={mockSend} isLoading={true} onCancel={vi.fn()} />);
 
-      const textarea = screen.getByPlaceholderText('Ask a question...');
+      const textarea = screen.getByPlaceholderText('Ask a question… (Enter to send, Shift+Enter for a new line)');
       fireEvent.change(textarea, { target: { value: 'Test' } });
 
       expect(screen.queryByRole('button', { name: /clear input/i })).not.toBeInTheDocument();
@@ -235,7 +235,7 @@ describe('ChatInput', () => {
       const mockSend = vi.fn();
       render(<ChatInput onSend={mockSend} isLoading={false} onCancel={vi.fn()} />);
 
-      const textarea = screen.getByPlaceholderText('Ask a question...');
+      const textarea = screen.getByPlaceholderText('Ask a question… (Enter to send, Shift+Enter for a new line)');
       fireEvent.change(textarea, { target: { value: 'Test message' } });
 
       const clearButton = screen.getByRole('button', { name: /clear input/i });
@@ -248,7 +248,7 @@ describe('ChatInput', () => {
       const mockSend = vi.fn();
       render(<ChatInput onSend={mockSend} isLoading={false} onCancel={vi.fn()} />);
 
-      const textarea = screen.getByPlaceholderText('Ask a question...');
+      const textarea = screen.getByPlaceholderText('Ask a question… (Enter to send, Shift+Enter for a new line)');
       fireEvent.change(textarea, { target: { value: 'Test' } });
 
       const clearButton = screen.getByRole('button', { name: /clear input/i });
@@ -263,7 +263,7 @@ describe('ChatInput', () => {
       const mockSend = vi.fn();
       render(<ChatInput onSend={mockSend} isLoading={false} onCancel={vi.fn()} />);
 
-      const textarea = screen.getByPlaceholderText('Ask a question...');
+      const textarea = screen.getByPlaceholderText('Ask a question… (Enter to send, Shift+Enter for a new line)');
       fireEvent.change(textarea, { target: { value: 'Line 1\nLine 2\nLine 3' } });
 
       // The height should change based on content
@@ -293,7 +293,7 @@ describe('ChatInput', () => {
       const mockSend = vi.fn();
       render(<ChatInput onSend={mockSend} isLoading={false} onCancel={vi.fn()} />);
 
-      const textarea = screen.getByPlaceholderText('Ask a question...');
+      const textarea = screen.getByPlaceholderText('Ask a question… (Enter to send, Shift+Enter for a new line)');
       fireEvent.change(textarea, { target: { value: 'Test' } });
 
       const sendButton = screen.getByRole('button', { name: /send message/i });
@@ -307,7 +307,7 @@ describe('ChatInput', () => {
       render(<ChatInput onSend={mockSend} isLoading={false} onCancel={vi.fn()} />);
 
       const longText = 'A'.repeat(10000);
-      const textarea = screen.getByPlaceholderText('Ask a question...');
+      const textarea = screen.getByPlaceholderText('Ask a question… (Enter to send, Shift+Enter for a new line)');
       fireEvent.change(textarea, { target: { value: longText } });
 
       expect((textarea as HTMLTextAreaElement).value).toBe(longText);
@@ -317,7 +317,7 @@ describe('ChatInput', () => {
       const mockSend = vi.fn();
       render(<ChatInput onSend={mockSend} isLoading={false} onCancel={vi.fn()} />);
 
-      const textarea = screen.getByPlaceholderText('Ask a question...');
+      const textarea = screen.getByPlaceholderText('Ask a question… (Enter to send, Shift+Enter for a new line)');
       fireEvent.change(textarea, { target: { value: 'Test with `code` and **bold** and "quotes"' } });
 
       const sendButton = screen.getByRole('button', { name: /send message/i });
@@ -330,7 +330,7 @@ describe('ChatInput', () => {
       const mockSend = vi.fn();
       render(<ChatInput onSend={mockSend} isLoading={false} onCancel={vi.fn()} />);
 
-      const textarea = screen.getByPlaceholderText('Ask a question...');
+      const textarea = screen.getByPlaceholderText('Ask a question… (Enter to send, Shift+Enter for a new line)');
       fireEvent.change(textarea, { target: { value: 'Line 1\nLine 2' } });
 
       // Shift+Enter should not send
@@ -368,7 +368,7 @@ describe('ChatInput', () => {
       await act(async () => { await Promise.resolve(); });
 
       // Type and send
-      const textarea = screen.getByPlaceholderText('Ask a question...');
+      const textarea = screen.getByPlaceholderText('Ask a question… (Enter to send, Shift+Enter for a new line)');
       fireEvent.change(textarea, { target: { value: 'Describe this image' } });
       fireEvent.click(screen.getByRole('button', { name: /send message/i }));
 
@@ -381,7 +381,7 @@ describe('ChatInput', () => {
       const mockSend = vi.fn();
       render(<ChatInput onSend={mockSend} isLoading={false} onCancel={vi.fn()} imageUploadEnabled />);
 
-      const textarea = screen.getByPlaceholderText('Ask a question...');
+      const textarea = screen.getByPlaceholderText('Ask a question… (Enter to send, Shift+Enter for a new line)');
       fireEvent.change(textarea, { target: { value: 'Text only message' } });
       fireEvent.click(screen.getByRole('button', { name: /send message/i }));
 
@@ -401,7 +401,7 @@ describe('ChatInput', () => {
       await act(async () => { await Promise.resolve(); });
 
       // Send
-      const textarea = screen.getByPlaceholderText('Ask a question...');
+      const textarea = screen.getByPlaceholderText('Ask a question… (Enter to send, Shift+Enter for a new line)');
       fireEvent.change(textarea, { target: { value: 'hi' } });
       fireEvent.click(screen.getByRole('button', { name: /send message/i }));
 

--- a/web_ui/src/components/ChatInput.tsx
+++ b/web_ui/src/components/ChatInput.tsx
@@ -269,7 +269,7 @@ export const ChatInput: React.FC<ChatInputProps> = React.memo(({
             onKeyDown={handleKeyDown}
             onFocus={() => setIsFocused(true)}
             onBlur={() => setIsFocused(false)}
-            placeholder="Ask a question..."
+            placeholder="Ask a question… (Enter to send, Shift+Enter for a new line)"
             disabled={isLoading || disabled}
             rows={1}
             style={{

--- a/web_ui/src/components/ChatMessageBubble.tsx
+++ b/web_ui/src/components/ChatMessageBubble.tsx
@@ -13,9 +13,16 @@ interface ChatMessageBubbleProps {
   message: ChatMessage;
   /** When set, renders a Regenerate action (last assistant message only). */
   onRegenerate?: () => void;
+  /** S8: current timestamp tick from the parent, so relative-time labels
+   *  recompute every 60s instead of freezing at first paint. The prop change
+   *  defeats React.memo so formatRelativeTime re-runs. */
+  now?: number;
 }
 
-export const ChatMessageBubble: React.FC<ChatMessageBubbleProps> = React.memo(({ message, onRegenerate }) => {
+export const ChatMessageBubble: React.FC<ChatMessageBubbleProps> = React.memo(({ message, onRegenerate, now }) => {
+  // S8: recompute the label whenever `now` changes. Falling back to Date.now()
+  // keeps one-off renders (tests, direct usage) correct.
+  const relativeLabel = formatRelativeTime(message.timestamp, now);
   const [copied, setCopied] = useState(false);
   const copyFeedbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -132,7 +139,7 @@ export const ChatMessageBubble: React.FC<ChatMessageBubbleProps> = React.memo(({
               ))}
             </div>
           )}
-          <div style={{ ...timeStyle, textAlign: 'right' }}>{formatRelativeTime(message.timestamp)}</div>
+          <div style={{ ...timeStyle, textAlign: 'right' }}>{relativeLabel}</div>
           <div style={{ display: 'flex', gap: 'var(--spacing-sm)', marginTop: 'var(--spacing-sm)' }}>
             <button
               className="bubble-action"
@@ -213,12 +220,53 @@ export const ChatMessageBubble: React.FC<ChatMessageBubbleProps> = React.memo(({
               ? 'Retrieval is degraded (semantic search unavailable) and no relevant passages were found.'
               : 'Insufficient evidence in the knowledge base to answer this question.'}
           </div>
+        ) : message.error ? (
+          // S6: structured error card. The error message is stored on the
+          // dedicated `error` field (NOT injected into content, which would be
+          // parsed as markdown and could linkify/mangle). The Try-again button
+          // only renders when onRegenerate is present (M4) — otherwise the card
+          // just reports the failure.
+          <div
+            role="alert"
+            style={{
+              padding: 'var(--spacing-md)',
+              borderRadius: '8px',
+              backgroundColor: 'rgba(211, 47, 47, 0.08)',
+              border: '1px solid var(--color-danger)',
+              color: 'var(--color-danger)',
+              fontFamily: 'var(--font-family)',
+            }}
+          >
+            <div style={{ fontSize: 'var(--font-size-body)', marginBottom: 'var(--spacing-xs)' }}>
+              Something went wrong while answering.
+            </div>
+            <div style={{ fontSize: 'var(--font-size-caption)', opacity: 0.85, wordBreak: 'break-word' }}>
+              {message.error}
+            </div>
+            {onRegenerate && (
+              <button
+                className="bubble-action"
+                type="button"
+                onClick={onRegenerate}
+                aria-label="Try again"
+                style={{ ...regenerateStyle, marginTop: 'var(--spacing-sm)' }}
+              >
+                ↻ Try again
+              </button>
+            )}
+          </div>
         ) : (
           <>
-            <div style={{ fontFamily: 'var(--font-family)', lineHeight: 'var(--line-height-body)' }}>
-              <MarkdownRenderer content={message.content} />
-              {message.isStreaming && <span style={cursorStyle} aria-hidden="true" />}
-            </div>
+            {/* A7: an empty assistant message (Stop before first token, or a
+                placeholder that never received content) renders only the
+                cursor while streaming, and nothing at all once settled — no
+                bordered box, no Copy button that copies "". */}
+            {message.content === '' && !message.isStreaming ? null : (
+              <div style={{ fontFamily: 'var(--font-family)', lineHeight: 'var(--line-height-body)' }}>
+                <MarkdownRenderer content={message.content} isStreaming={message.isStreaming} />
+                {message.isStreaming && <span style={cursorStyle} aria-hidden="true" />}
+              </div>
+            )}
             {/* F4: non-blocking indicator when only keyword search was available. */}
             {message.retrievalDegraded && (
               <div
@@ -234,7 +282,7 @@ export const ChatMessageBubble: React.FC<ChatMessageBubbleProps> = React.memo(({
                 Retrieval is degraded — semantic search unavailable (showing keyword-only results).
               </div>
             )}
-            <div style={{ ...timeStyle, textAlign: 'left' }}>{formatRelativeTime(message.timestamp)}</div>
+            <div style={{ ...timeStyle, textAlign: 'left' }}>{relativeLabel}</div>
             <div style={{ display: 'flex', gap: 'var(--spacing-sm)', marginTop: 'var(--spacing-sm)' }}>
               <button
                 className="bubble-action"

--- a/web_ui/src/components/ChatMessageList.test.tsx
+++ b/web_ui/src/components/ChatMessageList.test.tsx
@@ -9,10 +9,25 @@ import '@testing-library/jest-dom';
 import { ChatMessageList } from './ChatMessageList';
 import type { ChatMessage } from '../types/chat';
 
+// U4: ChatMessageList now keys its empty state off useDocumentCount(). In
+// jsdom the underlying raw-IndexedDB document store throws ("indexedDB is
+// not defined") so the hook reports count=0 — which would route every
+// existing "How can I help" / suggested-prompt test into the zero-doc branch
+// and silently stop exercising that path. Default the mock to count>0 so the
+// legacy empty-state behavior is tested as before; the zero-doc branch is
+// covered explicitly below.
+const mockUseDocumentCount = vi.fn();
+vi.mock('../hooks/useDocumentCount', () => ({
+  useDocumentCount: (...args: unknown[]) => mockUseDocumentCount(...args),
+}));
+
 describe('ChatMessageList', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     cleanup();
+    // Default: documents present so the legacy "How can I help" + suggested
+    // prompts empty state is exercised.
+    mockUseDocumentCount.mockReturnValue({ count: 3, loading: false });
   });
 
   afterEach(() => {
@@ -364,6 +379,55 @@ describe('ChatMessageList', () => {
       // The visually-hidden status region should now carry the completion text.
       const status = screen.getByRole('status');
       expect(status.textContent).toContain('Response complete');
+    });
+  });
+
+  describe('Zero-document empty state (U4)', () => {
+    it('renders the add-documents hero when documentCount is 0', () => {
+      mockUseDocumentCount.mockReturnValue({ count: 0, loading: false });
+
+      render(<ChatMessageList messages={[]} isStreaming={false} />);
+
+      expect(screen.getByText('Add documents to get started')).toBeInTheDocument();
+      // The doc-present hero must NOT render in the zero-doc branch.
+      expect(screen.queryByText('How can I help with your documents?')).not.toBeInTheDocument();
+      // And no suggested-prompt buttons (those route through a cold load then
+      // abstain when there are no documents — a guaranteed dead end).
+      expect(screen.queryByLabelText('Suggested prompt: Summarize my documents')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Suggested prompt: What are the key topics?')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Suggested prompt: Find specific information')).not.toBeInTheDocument();
+    });
+
+    it('does NOT render the "Go to Documents" button when onNavigateToDocuments is omitted', () => {
+      mockUseDocumentCount.mockReturnValue({ count: 0, loading: false });
+
+      render(<ChatMessageList messages={[]} isStreaming={false} />);
+
+      expect(screen.queryByRole('button', { name: /go to documents/i })).not.toBeInTheDocument();
+    });
+
+    it('renders the "Go to Documents" button and calls onNavigateToDocuments on click', () => {
+      mockUseDocumentCount.mockReturnValue({ count: 0, loading: false });
+      const onNavigate = vi.fn();
+
+      render(<ChatMessageList messages={[]} isStreaming={false} onNavigateToDocuments={onNavigate} />);
+
+      const button = screen.getByRole('button', { name: /go to documents/i });
+      expect(button).toBeInTheDocument();
+
+      fireEvent.click(button);
+      expect(onNavigate).toHaveBeenCalledTimes(1);
+    });
+
+    it('uses the doc-present hero when documentCount > 0', () => {
+      mockUseDocumentCount.mockReturnValue({ count: 5, loading: false });
+
+      render(<ChatMessageList messages={[]} isStreaming={false} />);
+
+      expect(screen.getByText('How can I help with your documents?')).toBeInTheDocument();
+      expect(screen.queryByText('Add documents to get started')).not.toBeInTheDocument();
+      // Suggested prompts render in the doc-present branch.
+      expect(screen.getByLabelText('Suggested prompt: Summarize my documents')).toBeInTheDocument();
     });
   });
 });

--- a/web_ui/src/components/ChatMessageList.tsx
+++ b/web_ui/src/components/ChatMessageList.tsx
@@ -1,17 +1,24 @@
 import React, { useEffect, useRef, useCallback, useState } from 'react';
 import type { ChatMessage } from '../types/chat';
 import { ChatMessageBubble } from './ChatMessageBubble';
+import { useDocumentCount } from '../hooks/useDocumentCount';
 
 interface ChatMessageListProps {
   messages: ChatMessage[];
   isStreaming: boolean;
   onRegenerate?: () => void;
   onSuggestedPrompt?: (prompt: string) => void;
+  /** U4: navigate to the Documents page (for the zero-doc empty state). */
+  onNavigateToDocuments?: () => void;
 }
 
 const SCROLL_THRESHOLD = 100;
 /** Re-render interval so relative timestamps ("3m ago") stay fresh. */
 const RELATIVE_TIME_TICK_MS = 60_000;
+/** S5: cap on how many messages RENDER at once. Windowing is render-only —
+ *  the full history remains in state + IndexedDB. The indicator is a
+ *  non-persisted render element, never written to Dexie. */
+const MAX_RENDERED_MESSAGES = 200;
 
 const suggestedPrompts = [
   "Summarize my documents",
@@ -24,7 +31,11 @@ export const ChatMessageList: React.FC<ChatMessageListProps> = React.memo(({
   isStreaming,
   onRegenerate,
   onSuggestedPrompt,
+  onNavigateToDocuments,
 }) => {
+  // U4: document-count-aware empty state. With zero docs, suggesting prompts
+  // that route through the cold-load then abstain is a guaranteed dead end.
+  const { count: documentCount } = useDocumentCount();
   const containerRef = useRef<HTMLDivElement>(null);
   const isNearBottomRef = useRef(true);
   // Render-mirror of isNearBottomRef so we can show/hide the Jump-to-latest button.
@@ -110,11 +121,14 @@ export const ChatMessageList: React.FC<ChatMessageListProps> = React.memo(({
     onSuggestedPrompt?.(prompt);
   };
 
-  // The `now` state setter triggers a re-render every 60s. formatRelativeTime
-  // reads Date.now() at render time, so the re-render refreshes the relative
-  // timestamps. `now` itself doesn't need to be passed down — the re-render
-  // is what drives the refresh. The void just silences the unused-var lint.
-  void now;
+  // S8: the `now` tick is passed down to ChatMessageBubble so its React.memo
+  // comparison sees a changed prop and re-renders, recomputing the relative
+  // timestamp. Previously the tick was discarded (`void now;`) and the memo
+  // blocked the re-render, freezing timestamps at first paint.
+  // S5: window the render array to the last MAX_RENDERED_MESSAGES items. This
+  // is render-only — the full `messages` array stays in state + IndexedDB.
+  const hiddenCount = Math.max(0, messages.length - MAX_RENDERED_MESSAGES);
+  const renderedMessages = hiddenCount > 0 ? messages.slice(hiddenCount) : messages;
 
   const containerStyle: React.CSSProperties = {
     flex: 1,
@@ -212,7 +226,7 @@ export const ChatMessageList: React.FC<ChatMessageListProps> = React.memo(({
   };
 
   return (
-    <div ref={containerRef} style={containerStyle} role="log" aria-live="polite">
+    <div ref={containerRef} style={containerStyle} role="log">
       {/* Visually-hidden completion announcement. The log container announces
           streamed content mutations, but not the generation-complete
           transition; this status region does. */}
@@ -221,39 +235,92 @@ export const ChatMessageList: React.FC<ChatMessageListProps> = React.memo(({
       </div>
       {messages.length === 0 ? (
         <div style={emptyStateStyle} role="region" aria-labelledby="welcome-heading">
-          <div>
-            <h1 id="welcome-heading" style={heroStyle}>How can I help with your documents?</h1>
-            <p style={subtitleStyle}>
-              Ask anything about your uploaded documents. Get summaries, extract insights, or find specific information instantly.
-            </p>
-          </div>
-          <div style={promptsStyle} role="group" aria-label="Suggested prompts">
-            {suggestedPrompts.map((prompt, index) => (
-              <button
-                key={index}
-                type="button"
-                style={cardStyle}
-                onMouseOver={(e) => { Object.assign(e.currentTarget.style, cardHoverStyle); }}
-                onMouseOut={(e) => { Object.assign(e.currentTarget.style, cardStyle); }}
-                onClick={() => handlePromptClick(prompt)}
-                aria-label={`Suggested prompt: ${prompt}`}
-              >
-                {prompt}
-              </button>
-            ))}
-          </div>
+          {documentCount === 0 ? (
+            // U4: zero-doc first-run state. Suggesting "Summarize my documents"
+            // here would route through a multi-minute cold load then abstain —
+            // a guaranteed dead end. Guide the user to add documents first.
+            <>
+              <div>
+                <h1 id="welcome-heading" style={heroStyle}>Add documents to get started</h1>
+                <p style={subtitleStyle}>
+                  Upload your documents and I can summarize them, extract key topics, and answer specific questions — all locally in your browser.
+                </p>
+              </div>
+              {onNavigateToDocuments && (
+                <button
+                  type="button"
+                  style={{
+                    padding: 'var(--spacing-sm) var(--spacing-xl)',
+                    backgroundColor: 'var(--color-primary)',
+                    color: 'var(--color-text-on-primary)',
+                    border: 'none',
+                    borderRadius: 'var(--radius-sm)',
+                    fontSize: 'var(--font-size-body)',
+                    fontFamily: 'var(--font-family)',
+                    cursor: 'pointer',
+                    fontWeight: 500,
+                  }}
+                  onClick={onNavigateToDocuments}
+                >
+                  Go to Documents
+                </button>
+              )}
+            </>
+          ) : (
+            <>
+              <div>
+                <h1 id="welcome-heading" style={heroStyle}>How can I help with your documents?</h1>
+                <p style={subtitleStyle}>
+                  Ask anything about your uploaded documents. Get summaries, extract insights, or find specific information instantly.
+                </p>
+              </div>
+              <div style={promptsStyle} role="group" aria-label="Suggested prompts">
+                {suggestedPrompts.map((prompt, index) => (
+                  <button
+                    key={index}
+                    type="button"
+                    style={cardStyle}
+                    onMouseOver={(e) => { Object.assign(e.currentTarget.style, cardHoverStyle); }}
+                    onMouseOut={(e) => { Object.assign(e.currentTarget.style, cardStyle); }}
+                    onClick={() => handlePromptClick(prompt)}
+                    aria-label={`Suggested prompt: ${prompt}`}
+                  >
+                    {prompt}
+                  </button>
+                ))}
+              </div>
+            </>
+          )}
           <div style={footerStyle}>All conversations are stored locally in your browser</div>
         </div>
       ) : (
         <>
-          {messages.map((message, idx) => (
+          {/* S5: render-only windowing indicator. The full history is still in
+              state + IndexedDB; this only limits what is painted. Never
+              persisted (it's a <div>, not a ChatMessage). */}
+          {hiddenCount > 0 && (
+            <div
+              role="status"
+              style={{
+                textAlign: 'center',
+                fontSize: 'var(--font-size-caption)',
+                color: 'var(--color-text-muted)',
+                padding: 'var(--spacing-xs) var(--spacing-sm)',
+                fontStyle: 'italic',
+              }}
+            >
+              {hiddenCount} earlier message{hiddenCount === 1 ? '' : 's'} hidden (showing the last {MAX_RENDERED_MESSAGES})
+            </div>
+          )}
+          {renderedMessages.map((message, idx) => (
             <ChatMessageBubble
               key={message.id}
               message={message}
+              now={now}
               onRegenerate={
                 onRegenerate &&
                 message.role === 'assistant' &&
-                idx === messages.length - 1 &&
+                idx === renderedMessages.length - 1 &&
                 !message.isStreaming
                   ? onRegenerate
                   : undefined

--- a/web_ui/src/components/DocumentList.test.tsx
+++ b/web_ui/src/components/DocumentList.test.tsx
@@ -242,17 +242,48 @@ describe('DocumentList', () => {
       expect(deleteButtons).toHaveLength(2);
     });
 
-    it('calls onDelete with document id when delete button clicked', () => {
+    it('calls onDelete with document id only after confirming (two-step delete, issue #36)', () => {
       const mockOnDelete = vi.fn();
       const documents = [
         createDocument({ id: 'doc-123', fileName: 'delete-me.pdf' }),
       ];
       render(<DocumentList documents={documents} onDelete={mockOnDelete} deletingId={null} />);
 
+      // Step 1: clicking the trash icon arms the inline confirm — it must NOT
+      // call onDelete yet.
+      const deleteButton = screen.getByRole('button', { name: /delete delete-me\.pdf/i });
+      fireEvent.click(deleteButton);
+      expect(mockOnDelete).not.toHaveBeenCalled();
+
+      // The confirm UI is now shown.
+      const confirmButton = screen.getByRole('button', { name: /confirm delete delete-me\.pdf/i });
+      fireEvent.click(confirmButton);
+
+      // Step 2: only Confirm actually fires onDelete.
+      expect(mockOnDelete).toHaveBeenCalledTimes(1);
+      expect(mockOnDelete).toHaveBeenCalledWith('doc-123');
+    });
+
+    it('does NOT call onDelete when Cancel is clicked in the confirm step (issue #36)', () => {
+      const mockOnDelete = vi.fn();
+      const documents = [
+        createDocument({ id: 'doc-123', fileName: 'delete-me.pdf' }),
+      ];
+      render(<DocumentList documents={documents} onDelete={mockOnDelete} deletingId={null} />);
+
+      // Arm the confirm.
       const deleteButton = screen.getByRole('button', { name: /delete delete-me\.pdf/i });
       fireEvent.click(deleteButton);
 
-      expect(mockOnDelete).toHaveBeenCalledWith('doc-123');
+      // Cancel the confirm.
+      const cancelButton = screen.getByRole('button', { name: /cancel delete delete-me\.pdf/i });
+      fireEvent.click(cancelButton);
+
+      expect(mockOnDelete).not.toHaveBeenCalled();
+
+      // The trash icon reappears (confirm UI dismissed) and is usable again.
+      const deleteButtonAgain = screen.getByRole('button', { name: /delete delete-me\.pdf/i });
+      expect(deleteButtonAgain).toBeInTheDocument();
     });
 
     it('disables delete button when document is being deleted', () => {

--- a/web_ui/src/components/DocumentList.tsx
+++ b/web_ui/src/components/DocumentList.tsx
@@ -9,6 +9,11 @@ interface DocumentListProps {
   documents: DocumentEntry[];
   onDelete: (docId: string) => void;
   deletingId: string | null;
+  /**
+   * U2: optional per-document indexing-cancel handler. When provided, the
+   * processing row renders a small Cancel button that aborts in-flight indexing.
+   */
+  onCancelIndexing?: (docId: string) => void;
 }
 
 function formatFileSize(bytes: number): string {
@@ -29,14 +34,17 @@ function formatDate(timestamp: number): string {
   });
 }
 
+// U6a: status labels render at --font-size-small (11px) on the light bubble
+// surface and must meet WCAG AA. The base info/warning/success tokens are
+// borderline AA at small sizes, so use the *-strong variants here.
 function getStatusColor(status: DocumentEntry['status']): string {
   switch (status) {
     case 'uploading':
-      return 'var(--color-info)';
+      return 'var(--color-info-strong)';
     case 'processing':
-      return 'var(--color-warning)';
+      return 'var(--color-warning-strong)';
     case 'ready':
-      return 'var(--color-success)';
+      return 'var(--color-success-strong)';
     case 'error':
       return 'var(--color-danger)';
     default:
@@ -66,12 +74,28 @@ const DocumentItem = React.memo<{
   doc: DocumentEntry;
   onDelete: (docId: string) => void;
   isDeleting: boolean;
-}>(({ doc, onDelete, isDeleting }) => {
+  onCancelIndexing?: (docId: string) => void;
+}>(({ doc, onDelete, isDeleting, onCancelIndexing }) => {
+  // U5: two-step delete confirmation. First click of the trash icon arms the
+  // inline confirm (reusing the SidebarConversationItem idiom); Confirm fires
+  // onDelete, Cancel reverts. Keeps the virtualized 60px row height by showing
+  // the confirm controls in place of the status badge + delete button.
+  const [isConfirming, setIsConfirming] = useState(false);
+
   const handleDelete = useCallback(() => {
     if (!isDeleting) {
-      onDelete(doc.id);
+      setIsConfirming(true);
     }
-  }, [doc.id, onDelete, isDeleting]);
+  }, [isDeleting]);
+
+  const handleConfirmDelete = useCallback(() => {
+    setIsConfirming(false);
+    onDelete(doc.id);
+  }, [doc.id, onDelete]);
+
+  const handleCancelDelete = useCallback(() => {
+    setIsConfirming(false);
+  }, []);
 
   return (
     <div
@@ -160,118 +184,210 @@ const DocumentItem = React.memo<{
         </div>
       </div>
 
-      {/* Status badge */}
-      <div
-        aria-live="polite"
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'flex-end',
-          gap: 'var(--spacing-xs)',
-        }}
-      >
-        <span
+      {/* Status badge (collapsed during delete-confirmation to make room). */}
+      {!isConfirming && (
+        <div
+          aria-live="polite"
           style={{
-            fontSize: 'var(--font-size-small)',
-            fontFamily: 'var(--font-family)',
-            color: getStatusColor(doc.status),
-            fontWeight: 500,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'flex-end',
+            gap: 'var(--spacing-xs)',
           }}
         >
-          {getStatusLabel(doc.status)}
-        </span>
-
-        {/* Progress bar for uploading/processing */}
-        {(doc.status === 'uploading' || doc.status === 'processing') && (
-          <div
-            role="progressbar"
-            aria-valuenow={Math.round(doc.progress)}
-            aria-valuemin={0}
-            aria-valuemax={100}
-            aria-label={`${getStatusLabel(doc.status)}: ${Math.round(doc.progress)}%`}
-            style={{
-              width: '80px',
-              height: '4px',
-              backgroundColor: 'var(--color-bubble-system)',
-              borderRadius: '2px',
-              overflow: 'hidden',
-            }}
-          >
-            <div
-              style={{
-                width: `${doc.progress}%`,
-                height: '100%',
-                backgroundColor: getStatusColor(doc.status),
-                transition: 'width 0.3s ease',
-              }}
-            />
-          </div>
-        )}
-
-        {/* Error message */}
-        {doc.status === 'error' && doc.errorMessage && (
           <span
             style={{
               fontSize: 'var(--font-size-small)',
               fontFamily: 'var(--font-family)',
-              color: 'var(--color-danger)',
-              maxWidth: '200px',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
+              color: getStatusColor(doc.status),
+              fontWeight: 500,
+            }}
+          >
+            {getStatusLabel(doc.status)}
+          </span>
+
+          {/* Progress bar for uploading/processing */}
+          {(doc.status === 'uploading' || doc.status === 'processing') && (
+            <div
+              role="progressbar"
+              aria-valuenow={Math.round(doc.progress)}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-label={`${getStatusLabel(doc.status)}: ${Math.round(doc.progress)}%`}
+              style={{
+                width: '80px',
+                height: '4px',
+                backgroundColor: 'var(--color-bubble-system)',
+                borderRadius: '2px',
+                overflow: 'hidden',
+              }}
+            >
+              <div
+                style={{
+                  width: `${doc.progress}%`,
+                  height: '100%',
+                  backgroundColor: getStatusColor(doc.status),
+                  transition: 'width 0.3s ease',
+                }}
+              />
+            </div>
+          )}
+
+          {/* U2: per-document indexing Cancel button. Only rendered during the
+              processing stage and only when the host wires the cancel handler. */}
+          {doc.status === 'processing' && onCancelIndexing && (
+            <button
+              type="button"
+              onClick={() => onCancelIndexing(doc.id)}
+              aria-label={`Cancel indexing ${doc.fileName}`}
+              style={{
+                border: '1px solid var(--color-text-muted)',
+                borderRadius: '6px',
+                backgroundColor: 'transparent',
+                color: 'var(--color-text-muted)',
+                fontSize: 'var(--font-size-small)',
+                fontFamily: 'var(--font-family)',
+                padding: '0 var(--spacing-xs)',
+                cursor: 'pointer',
+                lineHeight: 1.4,
+                whiteSpace: 'nowrap',
+              }}
+            >
+              Cancel
+            </button>
+          )}
+
+          {/* Error message */}
+          {doc.status === 'error' && doc.errorMessage && (
+            <span
+              style={{
+                fontSize: 'var(--font-size-small)',
+                fontFamily: 'var(--font-family)',
+                color: 'var(--color-danger)',
+                maxWidth: '200px',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+              title={doc.errorMessage}
+            >
+              {doc.errorMessage}
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* U5: two-step delete confirmation (inline alert, SidebarConversationItem idiom).
+          Confirm/Cancel buttons replace the status badge + trash icon when armed. */}
+      {isConfirming ? (
+        <div
+          role="alert"
+          aria-label={`Delete ${doc.fileName}?`}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 'var(--spacing-xs)',
+            flexShrink: 0,
+          }}
+        >
+          <span
+            style={{
+              fontSize: 'var(--font-size-small)',
+              fontFamily: 'var(--font-family)',
+              color: 'var(--color-text-on-bubble-assistant)',
+              marginRight: 'var(--spacing-xs)',
               whiteSpace: 'nowrap',
             }}
-            title={doc.errorMessage}
           >
-            {doc.errorMessage}
+            Delete {doc.fileName}?
           </span>
-        )}
-      </div>
-
-      {/* Delete button */}
-      <button
-        type="button"
-        onClick={handleDelete}
-        disabled={isDeleting}
-        aria-label={`Delete ${doc.fileName}`}
-        style={{
-          width: '32px',
-          height: '32px',
-          border: 'none',
-          borderRadius: '6px',
-          backgroundColor: 'transparent',
-          cursor: isDeleting ? 'not-allowed' : 'pointer',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          flexShrink: 0,
-          color: 'var(--color-text-muted)',
-          transition: 'all 0.2s ease',
-        }}
-        onMouseEnter={(e) => {
-          if (!isDeleting) {
-            e.currentTarget.style.backgroundColor = 'var(--color-danger)';
-            e.currentTarget.style.color = 'var(--color-text-on-primary)';
-          }
-        }}
-        onMouseLeave={(e) => {
-          e.currentTarget.style.backgroundColor = 'transparent';
-          e.currentTarget.style.color = 'var(--color-text-muted)';
-        }}
-      >
-        <svg
-          width="16"
-          height="16"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
+          <button
+            type="button"
+            onClick={handleConfirmDelete}
+            disabled={isDeleting}
+            aria-label={`Confirm delete ${doc.fileName}`}
+            style={{
+              padding: 'var(--spacing-xs) var(--spacing-sm)',
+              backgroundColor: 'var(--color-danger)',
+              color: 'var(--color-text-on-primary)',
+              border: 'none',
+              borderRadius: '6px',
+              fontSize: 'var(--font-size-small)',
+              fontFamily: 'var(--font-family)',
+              fontWeight: 500,
+              cursor: isDeleting ? 'not-allowed' : 'pointer',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            Confirm
+          </button>
+          <button
+            type="button"
+            onClick={handleCancelDelete}
+            disabled={isDeleting}
+            aria-label={`Cancel delete ${doc.fileName}`}
+            style={{
+              padding: 'var(--spacing-xs) var(--spacing-sm)',
+              backgroundColor: 'transparent',
+              color: 'var(--color-text-muted)',
+              border: '1px solid var(--color-text-muted)',
+              borderRadius: '6px',
+              fontSize: 'var(--font-size-small)',
+              fontFamily: 'var(--font-family)',
+              cursor: 'pointer',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            Cancel
+          </button>
+        </div>
+      ) : (
+        /* Delete trigger button (arms the inline confirm). */
+        <button
+          type="button"
+          onClick={handleDelete}
+          disabled={isDeleting}
+          aria-label={`Delete ${doc.fileName}`}
+          style={{
+            width: '32px',
+            height: '32px',
+            border: 'none',
+            borderRadius: '6px',
+            backgroundColor: 'transparent',
+            cursor: isDeleting ? 'not-allowed' : 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexShrink: 0,
+            color: 'var(--color-text-muted)',
+            transition: 'all 0.2s ease',
+          }}
+          onMouseEnter={(e) => {
+            if (!isDeleting) {
+              e.currentTarget.style.backgroundColor = 'var(--color-danger)';
+              e.currentTarget.style.color = 'var(--color-text-on-primary)';
+            }
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.backgroundColor = 'transparent';
+            e.currentTarget.style.color = 'var(--color-text-muted)';
+          }}
         >
-          <polyline points="3 6 5 6 21 6" />
-          <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
-        </svg>
-      </button>
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <polyline points="3 6 5 6 21 6" />
+            <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+          </svg>
+        </button>
+      )}
     </div>
   );
 });
@@ -279,7 +395,7 @@ const DocumentItem = React.memo<{
 DocumentItem.displayName = 'DocumentItem';
 
 export const DocumentList: React.FC<DocumentListProps> = React.memo(
-  ({ documents, onDelete, deletingId }) => {
+  ({ documents, onDelete, deletingId, onCancelIndexing }) => {
     const [scrollTop, setScrollTop] = useState(0);
     const [containerHeight, setContainerHeight] = useState(300);
     const listRef = useRef<HTMLDivElement>(null);
@@ -421,6 +537,7 @@ export const DocumentList: React.FC<DocumentListProps> = React.memo(
                   doc={doc}
                   onDelete={onDelete}
                   isDeleting={deletingId === doc.id}
+                  onCancelIndexing={onCancelIndexing}
                 />
               </div>
             );

--- a/web_ui/src/components/DropZone.tsx
+++ b/web_ui/src/components/DropZone.tsx
@@ -9,6 +9,14 @@ interface DropZoneProps {
   onFilesSelected: (files: File[]) => void;
   accept?: string;
   disabled?: boolean;
+  /**
+   * U7a: optional callback invoked with the names of dropped files that were
+   * rejected by the `accept` filter, so callers can surface rejection
+   * feedback. When omitted the filter stays silent (preserves existing
+   * behavior). Only fires for the drag-and-drop path — the native file picker
+   * already enforces `accept` and never offers unsupported files.
+   */
+  onFilesRejected?: (fileNames: string[]) => void;
 }
 
 /**
@@ -45,7 +53,7 @@ export function matchesAccept(file: File, accept?: string): boolean {
 }
 
 export const DropZone: React.FC<DropZoneProps> = React.memo(
-  ({ onFilesSelected, accept, disabled = false }) => {
+  ({ onFilesSelected, accept, disabled = false, onFilesRejected }) => {
     const inputRef = useRef<HTMLInputElement>(null);
     const [isDragOver, setIsDragOver] = useState(false);
 
@@ -79,12 +87,23 @@ export const DropZone: React.FC<DropZoneProps> = React.memo(
         // F15: apply the same accept filter the native file picker uses, so
         // unsupported files dropped via drag-and-drop are filtered out instead
         // of reaching the extractor and failing later.
-        const files = Array.from(e.dataTransfer.files).filter((f) => matchesAccept(f, accept));
+        const allDropped = Array.from(e.dataTransfer.files);
+        const files = allDropped.filter((f) => matchesAccept(f, accept));
+        // U7a: surface the rejected files so callers can show feedback instead
+        // of silently dropping them. Silent when the callback isn't provided.
+        if (onFilesRejected) {
+          const rejected = allDropped
+            .filter((f) => !matchesAccept(f, accept))
+            .map((f) => f.name);
+          if (rejected.length > 0) {
+            onFilesRejected(rejected);
+          }
+        }
         if (files.length > 0) {
           onFilesSelected(files);
         }
       },
-      [disabled, onFilesSelected, accept]
+      [disabled, onFilesSelected, accept, onFilesRejected]
     );
 
     const handleClick = useCallback(() => {

--- a/web_ui/src/components/InferenceModeToggle.tsx
+++ b/web_ui/src/components/InferenceModeToggle.tsx
@@ -12,6 +12,7 @@ export function InferenceModeToggle() {
     isModelReady,
     isServerConnected,
     modeError,
+    serverUrl,
     setMode,
     checkServerConnectivity,
   } = useInferenceMode();
@@ -52,8 +53,9 @@ export function InferenceModeToggle() {
   };
 
   const getModeLabel = (): string => {
-    if (mode === 'browser-local') return 'Local';
-    return 'API';
+    // U7b: plain-English labels instead of 'Local'/'API' jargon.
+    if (mode === 'browser-local') return 'On this computer';
+    return 'Company server';
   };
 
   const getTooltipText = (): string => {
@@ -69,6 +71,15 @@ export function InferenceModeToggle() {
 
   const statusColor = getStatusColor();
 
+  // U7b air-gap safety: the toggle is a one-click flip to API mode, so only
+  // render it when an API server is actually configured. When `serverUrl` is
+  // empty the app is browser-local only and the toggle would be a dead control
+  // (and a confusing "Company server" affordance) — hide it and let the parent
+  // layout collapse the slot.
+  if (!serverUrl) {
+    return null;
+  }
+
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--spacing-sm)' }}>
       {/* Status indicator dot */}
@@ -82,6 +93,20 @@ export function InferenceModeToggle() {
           transition: 'background-color 0.2s ease',
         }}
       />
+
+      {/* U7b: visible mode label next to the dot, so the current mode is
+          legible without hovering for the tooltip. */}
+      <span
+        aria-label={getTooltipText()}
+        style={{
+          fontSize: 'var(--font-size-caption)',
+          fontFamily: 'var(--font-family)',
+          color: 'var(--color-text-muted)',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {getModeLabel()}
+      </span>
 
       {/* Mode toggle button */}
       <button

--- a/web_ui/src/components/MarkdownRenderer.test.tsx
+++ b/web_ui/src/components/MarkdownRenderer.test.tsx
@@ -14,9 +14,12 @@ describe('MarkdownRenderer', () => {
       expect(screen.getByText('Hello, world!')).toBeInTheDocument();
     });
 
-    it('renders empty string', () => {
+    it('renders empty string without crashing', () => {
       const { container } = render(<MarkdownRenderer content="" />);
-      expect(container.firstChild).toBeNull();
+      // The renderer always wraps output in a styled <div> host; empty content
+      // simply yields no markdown children inside it. Assert it does not throw
+      // and produces no list/heading/table structure.
+      expect(container.querySelector('ol, ul, table, h1, h2, h3, h4, h5, h6')).toBeNull();
     });
   });
 
@@ -49,6 +52,25 @@ describe('MarkdownRenderer', () => {
 
       expect(screen.getByText('const str = "Hello \\"World\\"";')).toBeInTheDocument();
     });
+
+    it('renders a copy button and language chip for a fenced code block (issue #36)', () => {
+      const content = '```js\nconsole.log(1)\n```';
+      const { container } = render(<MarkdownRenderer content={content} />);
+
+      // A copy button exists with an accessible name containing "Copy".
+      const copyButton = container.querySelector('button');
+      expect(copyButton).not.toBeNull();
+      const copyAria = copyButton!.getAttribute('aria-label') || '';
+      const copyText = copyButton!.textContent || '';
+      expect(copyAria.toLowerCase()).toContain('copy');
+
+      // The language chip renders the fence's language ("js").
+      const chips = Array.from(container.querySelectorAll('span')).map((s) => s.textContent);
+      expect(chips).toContain('js');
+
+      // And the code body is present.
+      expect(container.textContent).toContain('console.log(1)');
+    });
   });
 
   describe('List Parsing', () => {
@@ -77,6 +99,54 @@ describe('MarkdownRenderer', () => {
       // Bold/code inline parsing splits each item across multiple span/code
       // elements, so assert on the list text rather than a single node.
       expect(screen.getAllByText(/Item with/).length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('groups a loose ordered list (blank lines between items) into ONE <ol> (issue #36)', () => {
+      // The old regex parser fragmented this into two separate <ol> elements
+      // because of the blank line. react-markdown correctly treats it as a
+      // single "loose" ordered list with two <li> children.
+      const content = '1. a\n\n2. b';
+      const { container } = render(<MarkdownRenderer content={content} />);
+
+      const ols = container.querySelectorAll('ol');
+      expect(ols.length).toBe(1);
+
+      const lis = ols[0].querySelectorAll('li');
+      expect(lis.length).toBe(2);
+      // Loose-list items are wrapped in <p>, so trim the surrounding whitespace.
+      expect(lis[0].textContent?.trim()).toBe('a');
+      expect(lis[1].textContent?.trim()).toBe('b');
+    });
+
+    it('preserves the marker value via the <ol start> attribute (issue #36)', () => {
+      // Starting at "3." sets start="3" on the <ol> rather than resetting to 1.
+      const content = '3. c\n4. d';
+      const { container } = render(<MarkdownRenderer content={content} />);
+
+      const ol = container.querySelector('ol');
+      expect(ol).not.toBeNull();
+      expect(ol!.getAttribute('start')).toBe('3');
+
+      const lis = ol!.querySelectorAll('li');
+      expect(lis.length).toBe(2);
+      expect(lis[0].textContent).toBe('c');
+      expect(lis[1].textContent).toBe('d');
+    });
+
+    it('keeps a bare leading year intact (issue #36)', () => {
+      // CommonMark treats a bare "1969. " line as a list item; react-markdown
+      // emits an <ol start="1969">. The acceptance criterion is "year intact":
+      // assert the year survives into the rendered DOM (via the start attr)
+      // and the rest of the sentence renders as the item body.
+      const content = '1969. It was a great year';
+      const { container } = render(<MarkdownRenderer content={content} />);
+
+      const ol = container.querySelector('ol');
+      expect(ol).not.toBeNull();
+      // The year is preserved as the list's starting marker.
+      expect(ol!.getAttribute('start')).toBe('1969');
+      // And the body text renders.
+      expect(container.textContent).toContain('It was a great year');
     });
   });
 
@@ -115,10 +185,13 @@ describe('MarkdownRenderer', () => {
 
     it('renders bold text with __', () => {
       const content = 'This is __bold__ text.';
-      const { container } = render(<MarkdownRenderer content={content} />);
+      render(<MarkdownRenderer content={content} />);
 
-      // The regex only matches ** pattern, not __
-      expect(container.textContent).toContain('This is __bold__ text.');
+      // Issue #36: the rewritten renderer (react-markdown + remark-gfm) now
+      // correctly parses __bold__ as <strong> (the old regex parser only
+      // matched ** and left the underscores literal).
+      const bold = screen.getByText('bold');
+      expect(bold.tagName).toBe('STRONG');
     });
   });
 
@@ -129,6 +202,25 @@ describe('MarkdownRenderer', () => {
 
       const italic = screen.getByText('italic');
       expect(italic.tagName).toBe('EM');
+    });
+
+    it('renders italic text with _ (issue #36)', () => {
+      const content = 'This is _italic_ text.';
+      render(<MarkdownRenderer content={content} />);
+
+      // remark-gfm parses _italic_ into <em>.
+      const italic = screen.getByText('italic');
+      expect(italic.tagName).toBe('EM');
+    });
+  });
+
+  describe('Inline Formatting - Strikethrough (issue #36)', () => {
+    it('renders ~~strike~~ as <del>', () => {
+      const content = 'This is ~~strike~~ text.';
+      render(<MarkdownRenderer content={content} />);
+
+      const del = screen.getByText('strike');
+      expect(del.tagName).toBe('DEL');
     });
   });
 
@@ -179,6 +271,32 @@ describe('MarkdownRenderer', () => {
       expect(container.textContent).toContain('Code:');
       expect(container.textContent).toContain('with nested marks.');
     });
+
+    it('does NOT turn a markdown link inside inline code into a live <a> (issue #36)', () => {
+      const content = '`[a](https://b)`';
+      const { container } = render(<MarkdownRenderer content={content} />);
+
+      // The whole `[a](https://b)` is inline code — no <a> should be rendered.
+      expect(container.querySelector('a')).toBeNull();
+      const code = container.querySelector('code');
+      expect(code).not.toBeNull();
+      expect(code!.textContent).toBe('[a](https://b)');
+    });
+  });
+
+  describe('GFM Tables (issue #36)', () => {
+    it('renders a pipe table as a <table> element', () => {
+      const content = '| a | b |\n|---|---|\n| 1 | 2 |';
+      const { container } = render(<MarkdownRenderer content={content} />);
+
+      const table = container.querySelector('table');
+      expect(table).not.toBeNull();
+      // Header + body cells render.
+      expect(container.textContent).toContain('a');
+      expect(container.textContent).toContain('b');
+      expect(container.textContent).toContain('1');
+      expect(container.textContent).toContain('2');
+    });
   });
 
   describe('Inline Formatting - Links', () => {
@@ -226,6 +344,36 @@ describe('MarkdownRenderer', () => {
       expect(link).not.toBeInTheDocument();
     });
 
+    it('strips scheme-relative URLs like //evil.com/y (issue #36)', () => {
+      // The old parser resolved this against a placeholder base and produced a
+      // live open-redirect link. The new urlTransform rejects scheme-less URLs.
+      const content = '[x](//evil.com/y)';
+      const { container } = render(<MarkdownRenderer content={content} />);
+
+      expect(container.textContent).toContain('x');
+      // No live <a> is rendered.
+      expect(container.querySelector('a')).toBeNull();
+      expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    });
+
+    it('strips root-relative URLs like /settings (issue #36)', () => {
+      const content = '[x](/settings)';
+      const { container } = render(<MarkdownRenderer content={content} />);
+
+      expect(container.textContent).toContain('x');
+      expect(container.querySelector('a')).toBeNull();
+      expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    });
+
+    it('renders a sanitized https link with the href intact (issue #36)', () => {
+      const content = '[x](https://valid.com)';
+      const { container } = render(<MarkdownRenderer content={content} />);
+
+      const a = container.querySelector('a');
+      expect(a).not.toBeNull();
+      expect(a!.getAttribute('href')).toBe('https://valid.com');
+    });
+
     it('allows mailto: URLs', () => {
       const content = 'Contact [us](mailto:test@example.com).';
       render(<MarkdownRenderer content={content} />);
@@ -244,14 +392,15 @@ describe('MarkdownRenderer', () => {
       expect(link).toHaveAttribute('href', 'tel:+1234567890');
     });
 
-    it('renders invalid URLs as plain text', () => {
+    it('renders invalid URLs as plain text (no live link)', () => {
       const content = 'Check [this](not-a-url).';
       const { container } = render(<MarkdownRenderer content={content} />);
 
-      // The text content should be present regardless of whether the URL
-      // validates (the URL `not-a-url` may resolve relative to the placeholder
-      // base; assert on content presence, not link absence).
+      // `not-a-url` is scheme-less with no path separator, so urlTransform
+      // rejects it (returns '') → no <a> element renders. The link text is
+      // still visible as plain text.
       expect(container.textContent).toContain('this');
+      expect(container.querySelector('a')).toBeNull();
     });
 
     it('handles links with special characters', () => {

--- a/web_ui/src/components/MarkdownRenderer.tsx
+++ b/web_ui/src/components/MarkdownRenderer.tsx
@@ -1,400 +1,383 @@
 /**
- * Lightweight inline markdown renderer.
- * Supports common patterns found in LLM output.
- * NO external dependencies.
+ * Markdown renderer built on react-markdown + remark-gfm.
+ *
+ * Replaces the prior hand-rolled regex parser (which fragmented loose ordered
+ * lists, discarded marker values, and could not represent tables/strike/task
+ * lists/nested emphasis). react-markdown + remark-gfm are pure-JS, ESM, and
+ * air-gap-safe (no runtime fetches), so the offline packaging guarantee is
+ * preserved. No `rehype-raw` is used, so raw HTML in model output stays
+ * escaped — the zero-HTML-injection property is preserved.
+ *
+ * Issue #36 Part 1: A1, N2, N3, A2, A3, A4, A5, A6, A8, N9, N10, N11, N12.
  */
 
-import React, { useMemo } from 'react';
+import React, { useEffect, useRef, useState, useCallback } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 
-interface ParsedSegment {
-  type: 'text' | 'bold' | 'italic' | 'code' | 'link';
-  content: string;
-  url?: string;
-}
+/** Schemes allowed in rendered links. Everything else (javascript:, data:,
+ *  blob:, file:, …) is stripped. N10 additionally rejects scheme-less URLs
+ *  (relative + scheme-relative like //evil.com/x and /settings). */
+const ALLOWED_SCHEMES = /^(https?|mailto|tel):$/i;
 
-function isValidUrl(url: string): boolean {
+/**
+ * react-markdown v9 `urlTransform`. Return the URL to keep it, or '' to strip
+ * it (rendering the link text without an href). N10: reject scheme-less URLs
+ * (which previously resolved against a placeholder base and became live links)
+ * and non-allowlisted schemes.
+ */
+function allowlistUrlTransform(url: string): string {
+  // Reject protocol-relative (//host) and root-relative (/path) and relative
+  // (path) URLs up front — they have no explicit allowlisted scheme.
+  if (url.startsWith('//') || url.startsWith('/') || !url.includes(':')) {
+    // Allow bare fragment links (#section) — they are same-document anchors.
+    if (url.startsWith('#')) return url;
+    return '';
+  }
   try {
-    const parsed = new URL(url, 'https://placeholder.invalid');
-    return /^(https?|mailto|tel):$/i.test(parsed.protocol);
+    const parsed = new URL(url);
+    return ALLOWED_SCHEMES.test(parsed.protocol) ? url : '';
   } catch {
-    return false;
+    // Not an absolute URL with a parseable scheme — reject.
+    return '';
   }
 }
 
-function parseInlineCodes(text: string): ParsedSegment[] {
-  const segments: ParsedSegment[] = [];
-  const regex = /`([^`]+)`/g;
-  let lastIndex = 0;
-  let match;
-
-  while ((match = regex.exec(text)) !== null) {
-    if (match.index > lastIndex) {
-      segments.push({ type: 'text', content: text.slice(lastIndex, match.index) });
-    }
-    segments.push({ type: 'code', content: match[1] });
-    lastIndex = regex.lastIndex;
-  }
-
-  if (lastIndex < text.length) {
-    segments.push({ type: 'text', content: text.slice(lastIndex) });
-  }
-
-  return segments.length > 0 ? segments : [{ type: 'text', content: text }];
+interface CodeBlockProps {
+  language: string;
+  code: string;
 }
 
-function parseInlinePatterns(text: string): ParsedSegment[] {
-  const segments: ParsedSegment[] = [];
-  const regex = /(\*\*[^*]+\*\*)|(\*[^*]+\*)/g;
-  let lastIndex = 0;
-  let match;
+/** A8: fenced code block with a language chip + per-block copy button.
+ *  Reuses the copy pattern from ChatMessageBubble. */
+const CodeBlock: React.FC<CodeBlockProps> = ({ language, code }) => {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  while ((match = regex.exec(text)) !== null) {
-    if (match.index > lastIndex) {
-      segments.push({ type: 'text', content: text.slice(lastIndex, match.index) });
+  useEffect(() => () => {
+    if (timerRef.current !== null) clearTimeout(timerRef.current);
+  }, []);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      if (timerRef.current !== null) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => {
+        setCopied(false);
+        timerRef.current = null;
+      }, 1500);
+    } catch {
+      console.warn('[MarkdownRenderer] Clipboard write failed');
     }
+  }, [code]);
 
-    const boldMatch = match[1];
-    const italicMatch = match[2];
-
-    if (boldMatch) {
-      segments.push({ type: 'bold', content: boldMatch.slice(2, -2) });
-    } else if (italicMatch) {
-      segments.push({ type: 'italic', content: italicMatch.slice(1, -1) });
-    }
-
-    lastIndex = regex.lastIndex;
-  }
-
-  if (lastIndex < text.length) {
-    segments.push({ type: 'text', content: text.slice(lastIndex) });
-  }
-
-  return segments.length > 0 ? segments : [{ type: 'text', content: text }];
-}
-
-function parseLinks(text: string): ParsedSegment[] {
-  const segments: ParsedSegment[] = [];
-  const regex = /\[([^\]]+)\]\(([^)]+)\)/g;
-  let lastIndex = 0;
-  let match;
-
-  while ((match = regex.exec(text)) !== null) {
-    if (match.index > lastIndex) {
-      segments.push({ type: 'text', content: text.slice(lastIndex, match.index) });
-    }
-    const url = match[2];
-    if (isValidUrl(url)) {
-      segments.push({ type: 'link', content: match[1], url });
-    } else {
-      segments.push({ type: 'text', content: `[${match[1]}](${url})` });
-    }
-    lastIndex = regex.lastIndex;
-  }
-
-  if (lastIndex < text.length) {
-    segments.push({ type: 'text', content: text.slice(lastIndex) });
-  }
-
-  return segments.length > 0 ? segments : [{ type: 'text', content: text }];
-}
-
-function renderInlineContent(text: string): React.ReactNode[] {
-  const linkSegments = parseLinks(text);
-
-  return linkSegments.flatMap((segment, idx) => {
-    if (segment.type === 'link') {
-      return (
-        <a
-          key={`link-${idx}`}
-          href={segment.url}
-          target="_blank"
-          rel="noopener noreferrer"
-          style={{ color: 'var(--color-primary)', textDecoration: 'underline' }}
-        >
-          {segment.content}
-        </a>
-      );
-    }
-
-    // Parse inline code BEFORE bold/italic so backtick-delimited spans are protected
-    const codeSegments = parseInlineCodes(segment.content);
-
-    return codeSegments.map((cSegment, cIdx) => {
-      if (cSegment.type === 'code') {
-        return (
-          <code
-            key={`code-${idx}-${cIdx}`}
-            style={{
-              backgroundColor: 'var(--color-bubble-system)',
-              padding: '1px 4px',
-              borderRadius: '3px',
-              fontFamily: 'monospace',
-              fontSize: '0.95em',
-            }}
-          >
-            {cSegment.content}
-          </code>
-        );
-      }
-
-      // Parse bold/italic on remaining text segments
-      const patternSegments = parseInlinePatterns(cSegment.content);
-
-      return patternSegments.map((pSegment, pIdx) => {
-        if (pSegment.type === 'bold') {
-          return <strong key={`bold-${idx}-${cIdx}-${pIdx}`}>{pSegment.content}</strong>;
-        }
-        if (pSegment.type === 'italic') {
-          return <em key={`italic-${idx}-${cIdx}-${pIdx}`}>{pSegment.content}</em>;
-        }
-        return <span key={`text-${idx}-${cIdx}-${pIdx}`}>{pSegment.content}</span>;
-      });
-    });
-  });
-}
-
-type BlockType =
-  | { kind: 'paragraph'; lines: string[] }
-  | { kind: 'codeBlock'; language: string; content: string }
-  | { kind: 'unorderedList'; items: string[] }
-  | { kind: 'orderedList'; items: string[] }
-  | { kind: 'heading'; level: 1 | 2 | 3 | 4 | 5 | 6; text: string }
-  | { kind: 'blockquote'; lines: string[] };
-
-// Detects ATX headings (# .. ######), unordered lists (-, *, +), ordered
-// lists (digit + .), and blockquotes (>), plus fenced code. Anything else
-// falls through to a paragraph.
-const HEADING_RE = /^(#{1,6})\s+(.*)$/;
-const UNORDERED_RE = /^[-*+]\s+/;
-const ORDERED_RE = /^\d+\.\s+/;
-const BLOCKQUOTE_RE = /^>\s?/;
-
-function isListMarker(line: string): boolean {
-  return UNORDERED_RE.test(line.trim()) || ORDERED_RE.test(line.trim());
-}
-
-function parseBlocks(text: string): BlockType[] {
-  const lines = text.split('\n');
-  const blocks: BlockType[] = [];
-  let i = 0;
-
-  while (i < lines.length) {
-    const line = lines[i];
-
-    // Fenced code block
-    if (line.trimStart().startsWith('```')) {
-      const language = line.trim().slice(3).trim();
-      const codeLines: string[] = [];
-      i++;
-      while (i < lines.length && !lines[i].trimStart().startsWith('```')) {
-        codeLines.push(lines[i]);
-        i++;
-      }
-      // Skip closing ```
-      if (i < lines.length) i++;
-      blocks.push({ kind: 'codeBlock', language, content: codeLines.join('\n') });
-      continue;
-    }
-
-    // Heading (ATX): # .. ######
-    const headingMatch = HEADING_RE.exec(line.trim());
-    if (headingMatch) {
-      const level = headingMatch[1].length as 1 | 2 | 3 | 4 | 5 | 6;
-      blocks.push({ kind: 'heading', level, text: headingMatch[2].trim() });
-      i++;
-      continue;
-    }
-
-    // Unordered list (accepts -, *, and + bullets)
-    if (UNORDERED_RE.test(line.trim())) {
-      const items: string[] = [];
-      while (i < lines.length && UNORDERED_RE.test(lines[i].trim())) {
-        items.push(lines[i].trim().replace(UNORDERED_RE, ''));
-        i++;
-      }
-      blocks.push({ kind: 'unorderedList', items });
-      continue;
-    }
-
-    // Ordered list
-    if (ORDERED_RE.test(line.trim())) {
-      const items: string[] = [];
-      while (i < lines.length && ORDERED_RE.test(lines[i].trim())) {
-        items.push(lines[i].trim().replace(ORDERED_RE, ''));
-        i++;
-      }
-      blocks.push({ kind: 'orderedList', items });
-      continue;
-    }
-
-    // Blockquote
-    if (BLOCKQUOTE_RE.test(line.trim())) {
-      const quoteLines: string[] = [];
-      while (i < lines.length && BLOCKQUOTE_RE.test(lines[i].trim())) {
-        quoteLines.push(lines[i].trim().replace(BLOCKQUOTE_RE, ''));
-        i++;
-      }
-      blocks.push({ kind: 'blockquote', lines: quoteLines });
-      continue;
-    }
-
-    // Empty line — skip
-    if (line.trim() === '') {
-      i++;
-      continue;
-    }
-
-    // Paragraph — collect until empty line or another block start
-    const paraLines: string[] = [];
-    while (
-      i < lines.length &&
-      lines[i].trim() !== '' &&
-      !lines[i].trimStart().startsWith('```') &&
-      !HEADING_RE.test(lines[i].trim()) &&
-      !isListMarker(lines[i].trim()) &&
-      !BLOCKQUOTE_RE.test(lines[i].trim())
-    ) {
-      paraLines.push(lines[i]);
-      i++;
-    }
-    if (paraLines.length > 0) {
-      blocks.push({ kind: 'paragraph', lines: paraLines });
-    }
-  }
-
-  return blocks;
-}
-
-function parseMarkdown(text: string): React.ReactNode[] {
-  const blocks = parseBlocks(text);
-  const result: React.ReactNode[] = [];
-
-  blocks.forEach((block, i) => {
-    switch (block.kind) {
-      case 'heading': {
-        // Map heading levels to the existing font-size tokens (display/h1/h2/h3)
-        // and fall back to body size for levels 4-6.
-        const headingStyles: Record<number, React.CSSProperties> = {
-          1: { fontSize: 'var(--font-size-display)', marginTop: 'var(--spacing-lg)', marginBottom: 'var(--spacing-sm)' },
-          2: { fontSize: 'var(--font-size-h1)', marginTop: 'var(--spacing-lg)', marginBottom: 'var(--spacing-sm)' },
-          3: { fontSize: 'var(--font-size-h2)', marginTop: 'var(--spacing-md)', marginBottom: 'var(--spacing-xs)' },
-          4: { fontSize: 'var(--font-size-h3)', marginTop: 'var(--spacing-md)', marginBottom: 'var(--spacing-xs)' },
-          5: { fontSize: 'var(--font-size-body)', marginTop: 'var(--spacing-sm)', marginBottom: 'var(--spacing-xs)' },
-          6: { fontSize: 'var(--font-size-caption)', marginTop: 'var(--spacing-sm)', marginBottom: 'var(--spacing-xs)' },
-        };
-        const sharedHeadingStyle: React.CSSProperties = {
-          fontWeight: 600,
+  return (
+    <div style={{ margin: 'var(--spacing-sm) 0', position: 'relative' }}>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          backgroundColor: 'var(--color-bubble-system)',
+          color: 'var(--color-text-muted)',
+          fontSize: 'var(--font-size-caption)',
           fontFamily: 'var(--font-family)',
-          color: 'var(--color-text-primary)',
-          lineHeight: 'var(--line-height-tight)',
-        };
-        const Tag = (`h${block.level}` as 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6');
-        result.push(
-          <Tag key={`h-${i}`} style={{ ...sharedHeadingStyle, ...headingStyles[block.level] }}>
-            {renderInlineContent(block.text)}
-          </Tag>
-        );
-        break;
-      }
+          padding: 'var(--spacing-xs) var(--spacing-sm)',
+          borderRadius: '6px 6px 0 0',
+          borderBottom: '1px solid var(--color-bubble-system)',
+        }}
+      >
+        <span>{language || 'code'}</span>
+        <button
+          type="button"
+          className="bubble-action"
+          onClick={handleCopy}
+          aria-label={copied ? 'Copied code to clipboard' : 'Copy code to clipboard'}
+          style={{
+            background: 'transparent',
+            border: '1px solid var(--color-bubble-system)',
+            borderRadius: 'var(--radius-sm)',
+            cursor: 'pointer',
+            padding: 'var(--spacing-xs) var(--spacing-sm)',
+            fontSize: 'var(--font-size-caption)',
+            fontFamily: 'var(--font-family)',
+            color: 'var(--color-text-muted)',
+          }}
+        >
+          {copied ? 'Copied!' : 'Copy'}
+        </button>
+      </div>
+      <pre
+        style={{
+          backgroundColor: 'var(--color-bubble-system)',
+          padding: 'var(--spacing-md)',
+          borderRadius: '0 0 6px 6px',
+          overflowX: 'auto',
+          fontFamily: 'monospace',
+          fontSize: 'var(--font-size-body)',
+          margin: 0,
+        }}
+      >
+        <code>{code}</code>
+      </pre>
+    </div>
+  );
+};
 
-      case 'blockquote': {
-        result.push(
-          <blockquote
-            key={`bq-${i}`}
-            style={{
-              margin: 'var(--spacing-sm) 0',
-              paddingLeft: 'var(--spacing-md)',
-              borderLeft: `3px solid var(--color-secondary)`,
-              color: 'var(--color-text-muted)',
-              fontStyle: 'italic',
-            }}
-          >
-            {block.lines.flatMap((line, j) => [
-              ...renderInlineContent(line),
-              j < block.lines.length - 1 ? <br key={`bqbr-${i}-${j}`} /> : null,
-            ]).filter(Boolean)}
-          </blockquote>
-        );
-        break;
-      }
-
-      case 'codeBlock':
-        result.push(
-          <pre
-            key={`code-${i}`}
-            style={{
-              backgroundColor: 'var(--color-bubble-system)',
-              padding: 'var(--spacing-md)',
-              borderRadius: '6px',
-              overflowX: 'auto',
-              fontFamily: 'monospace',
-              fontSize: 'var(--font-size-body)',
-              margin: 'var(--spacing-sm) 0',
-            }}
-          >
-            <code>{block.content}</code>
-          </pre>
-        );
-        break;
-
-      case 'unorderedList':
-        result.push(
-          <ul
-            key={`ul-${i}`}
-            style={{ margin: 'var(--spacing-sm) 0', paddingLeft: 'var(--spacing-xl)' }}
-          >
-            {block.items.map((item, j) => (
-              <li key={`uli-${i}-${j}`} style={{ marginBottom: 'var(--spacing-xs)' }}>
-                {renderInlineContent(item)}
-              </li>
-            ))}
-          </ul>
-        );
-        break;
-
-      case 'orderedList':
-        result.push(
-          <ol
-            key={`ol-${i}`}
-            style={{ margin: 'var(--spacing-sm) 0', paddingLeft: 'var(--spacing-xl)' }}
-          >
-            {block.items.map((item, j) => (
-              <li key={`oli-${i}-${j}`} style={{ marginBottom: 'var(--spacing-xs)' }}>
-                {renderInlineContent(item)}
-              </li>
-            ))}
-          </ol>
-        );
-        break;
-
-      case 'paragraph':
-        if (block.lines.length === 1) {
-          result.push(
-            <p key={`p-${i}`} style={{ margin: 'var(--spacing-sm) 0' }}>
-              {renderInlineContent(block.lines[0])}
-            </p>
-          );
-        } else {
-          result.push(
-            <p key={`p-${i}`} style={{ margin: 'var(--spacing-sm) 0' }}>
-              {block.lines.flatMap((line, j) => [
-                ...renderInlineContent(line),
-                j < block.lines.length - 1 ? <br key={`br-${i}-${j}`} /> : null,
-              ]).filter(Boolean)}
-            </p>
-          );
-        }
-        break;
-    }
-  });
-
-  return result;
+interface MarkdownRendererProps {
+  content: string;
+  /** A6: when true, throttle re-parsing to at most once per ~100ms so a fast
+   *  token stream does not re-parse on every flush. The final content is
+   *  always parsed when streaming ends. */
+  isStreaming?: boolean;
 }
 
-export const MarkdownRenderer: React.FC<{ content: string }> = React.memo(({ content }) => {
-  const rendered = useMemo(() => parseMarkdown(content), [content]);
+const PARSE_THROTTLE_MS = 100;
 
-  return <>{rendered}</>;
+/**
+ * MarkdownRenderer. Memoized on `content` + `isStreaming`. While streaming,
+ * the internal parse is throttled (A6) so remark is not re-run on every token
+ * flush; the last-throttled content is always parsed once streaming settles.
+ */
+export const MarkdownRenderer: React.FC<MarkdownRendererProps> = React.memo(({ content, isStreaming }) => {
+  // A6: throttle the source we hand to ReactMarkdown while streaming. We track
+  // the latest content in a ref and a "rendered content" state that we update
+  // on a timer during streaming, or immediately when not streaming.
+  const latestContentRef = useRef(content);
+  latestContentRef.current = content;
+  const [renderedContent, setRenderedContent] = useState(content);
+  const lastParseTsRef = useRef(0);
+  const throttleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!isStreaming) {
+      // Not streaming — always render the final content immediately, and clear
+      // any pending throttled parse.
+      if (throttleTimerRef.current !== null) {
+        clearTimeout(throttleTimerRef.current);
+        throttleTimerRef.current = null;
+      }
+      setRenderedContent(content);
+      return;
+    }
+
+    // Streaming: parse at most once per PARSE_THROTTLE_MS. Schedule a deferred
+    // parse that always runs against the LATEST content (reads the ref), so we
+    // never lose the tail.
+    const now = Date.now();
+    const elapsed = now - lastParseTsRef.current;
+    if (elapsed >= PARSE_THROTTLE_MS) {
+      lastParseTsRef.current = now;
+      setRenderedContent(latestContentRef.current);
+    } else if (throttleTimerRef.current === null) {
+      throttleTimerRef.current = setTimeout(() => {
+        throttleTimerRef.current = null;
+        lastParseTsRef.current = Date.now();
+        setRenderedContent(latestContentRef.current);
+      }, PARSE_THROTTLE_MS - elapsed);
+    }
+  }, [content, isStreaming]);
+
+  // Clean up the throttle timer on unmount.
+  useEffect(() => () => {
+    if (throttleTimerRef.current !== null) clearTimeout(throttleTimerRef.current);
+  }, []);
+
+  return (
+    <div style={{ fontFamily: 'var(--font-family)', lineHeight: 'var(--line-height-body)', wordBreak: 'break-word' }}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        urlTransform={allowlistUrlTransform}
+        components={{
+          // react-markdown v9: no `inline` prop. Distinguish inline vs block
+          // code by the presence of a `language-*` className (block fences
+          // carry it; inline code does not). (Critic M1)
+          code({ className, children, ...rest }) {
+            const match = /language-(\w+)/.exec(className || '');
+            const text = String(children).replace(/\n$/, '');
+            if (match) {
+              return <CodeBlock language={match[1]} code={text} />;
+            }
+            // Inline code (no language class) — but react-markdown v9 renders
+            // indented/fenced code WITHOUT a language as a <code> inside <pre>
+            // too. Detect block vs inline via the `node` position: a block code
+            // has a `position` spanning a line. We fall back to inline styling
+            // when there's no language and no newline (typical inline case).
+            const isBlock = text.includes('\n');
+            if (isBlock) {
+              return <CodeBlock language="" code={text} />;
+            }
+            return (
+              <code
+                style={{
+                  backgroundColor: 'var(--color-bubble-system)',
+                  padding: '1px 4px',
+                  borderRadius: '3px',
+                  fontFamily: 'monospace',
+                  fontSize: '0.95em',
+                }}
+                {...rest}
+              >
+                {children}
+              </code>
+            );
+          },
+          a({ href, children, ...rest }) {
+            // href is already sanitized by urlTransform (allowlist). Links
+            // that were rejected have href === '' → render as plain text.
+            if (!href) {
+              return <>{children}</>;
+            }
+            return (
+              <a
+                href={href}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ color: 'var(--color-primary)', textDecoration: 'underline' }}
+                {...rest}
+              >
+                {children}
+              </a>
+            );
+          },
+          table({ children, ...rest }) {
+            return (
+              <div style={{ overflowX: 'auto', margin: 'var(--spacing-sm) 0' }}>
+                <table
+                  style={{
+                    borderCollapse: 'collapse',
+                    width: '100%',
+                    fontSize: 'var(--font-size-body)',
+                  }}
+                  {...rest}
+                >
+                  {children}
+                </table>
+              </div>
+            );
+          },
+          th({ children, ...rest }) {
+            return (
+              <th
+                style={{
+                  border: '1px solid var(--color-bubble-system)',
+                  padding: 'var(--spacing-xs) var(--spacing-sm)',
+                  textAlign: 'left',
+                  backgroundColor: 'var(--color-bubble-system)',
+                  fontWeight: 600,
+                }}
+                {...rest}
+              >
+                {children}
+              </th>
+            );
+          },
+          td({ children, ...rest }) {
+            return (
+              <td
+                style={{
+                  border: '1px solid var(--color-bubble-system)',
+                  padding: 'var(--spacing-xs) var(--spacing-sm)',
+                }}
+                {...rest}
+              >
+                {children}
+              </td>
+            );
+          },
+          blockquote({ children, ...rest }) {
+            return (
+              <blockquote
+                style={{
+                  margin: 'var(--spacing-sm) 0',
+                  paddingLeft: 'var(--spacing-md)',
+                  borderLeft: '3px solid var(--color-secondary)',
+                  color: 'var(--color-text-muted)',
+                  fontStyle: 'italic',
+                }}
+                {...rest}
+              >
+                {children}
+              </blockquote>
+            );
+          },
+          hr({ ...rest }) {
+            return (
+              <hr
+                style={{
+                  border: 'none',
+                  borderTop: '1px solid var(--color-bubble-system)',
+                  margin: 'var(--spacing-md) 0',
+                }}
+                {...rest}
+              />
+            );
+          },
+          ul({ children, ...rest }) {
+            return (
+              <ul style={{ margin: 'var(--spacing-sm) 0', paddingLeft: 'var(--spacing-xl)' }} {...rest}>
+                {children}
+              </ul>
+            );
+          },
+          ol({ children, ...rest }) {
+            return (
+              <ol style={{ margin: 'var(--spacing-sm) 0', paddingLeft: 'var(--spacing-xl)' }} {...rest}>
+                {children}
+              </ol>
+            );
+          },
+          li({ children, ...rest }) {
+            return (
+              <li style={{ marginBottom: 'var(--spacing-xs)' }} {...rest}>
+                {children}
+              </li>
+            );
+          },
+          p({ children, ...rest }) {
+            return (
+              <p style={{ margin: 'var(--spacing-sm) 0' }} {...rest}>
+                {children}
+              </p>
+            );
+          },
+          h1: (props) => <Heading level={1} {...props} />,
+          h2: (props) => <Heading level={2} {...props} />,
+          h3: (props) => <Heading level={3} {...props} />,
+          h4: (props) => <Heading level={4} {...props} />,
+          h5: (props) => <Heading level={5} {...props} />,
+          h6: (props) => <Heading level={6} {...props} />,
+        }}
+      >
+        {renderedContent}
+      </ReactMarkdown>
+    </div>
+  );
 });
 
+/** Map heading levels onto the existing font-size tokens. */
+const HEADING_STYLES: Record<number, React.CSSProperties> = {
+  1: { fontSize: 'var(--font-size-display)', marginTop: 'var(--spacing-lg)', marginBottom: 'var(--spacing-sm)' },
+  2: { fontSize: 'var(--font-size-h1)', marginTop: 'var(--spacing-lg)', marginBottom: 'var(--spacing-sm)' },
+  3: { fontSize: 'var(--font-size-h2)', marginTop: 'var(--spacing-md)', marginBottom: 'var(--spacing-xs)' },
+  4: { fontSize: 'var(--font-size-h3)', marginTop: 'var(--spacing-md)', marginBottom: 'var(--spacing-xs)' },
+  5: { fontSize: 'var(--font-size-body)', marginTop: 'var(--spacing-sm)', marginBottom: 'var(--spacing-xs)' },
+  6: { fontSize: 'var(--font-size-caption)', marginTop: 'var(--spacing-sm)', marginBottom: 'var(--spacing-xs)' },
+};
+
+const SHARED_HEADING_STYLE: React.CSSProperties = {
+  fontWeight: 600,
+  fontFamily: 'var(--font-family)',
+  color: 'var(--color-text-primary)',
+  lineHeight: 'var(--line-height-tight)',
+};
+
+const Heading: React.FC<{ level: 1 | 2 | 3 | 4 | 5 | 6; children?: React.ReactNode }> = ({ level, children }) => {
+  const Tag = (`h${level}` as 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6');
+  return <Tag style={{ ...SHARED_HEADING_STYLE, ...HEADING_STYLES[level] }}>{children}</Tag>;
+};
+
 MarkdownRenderer.displayName = 'MarkdownRenderer';
+
+export default MarkdownRenderer;

--- a/web_ui/src/components/SidebarConversationItem.tsx
+++ b/web_ui/src/components/SidebarConversationItem.tsx
@@ -21,6 +21,10 @@ export function SidebarConversationItem({
   onDelete,
 }: SidebarConversationItemProps) {
   const [hovered, setHovered] = useState(false);
+  // U6b: track keyboard/programmatic focus on the row so a visible focus ring
+  // replaces the bare `outline: 'none'`, and the kebab menu is revealed for
+  // keyboard users (not just on mouse hover).
+  const [isFocused, setIsFocused] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
   const [isRenaming, setIsRenaming] = useState(false);
@@ -152,6 +156,8 @@ export function SidebarConversationItem({
       onKeyDown={handleRootKeyDown}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
+      onFocus={() => setIsFocused(true)}
+      onBlur={() => setIsFocused(false)}
       aria-current={isSelected ? 'page' : undefined}
       style={{
         position: 'relative',
@@ -171,9 +177,15 @@ export function SidebarConversationItem({
           : 'var(--color-text-on-bubble-assistant)',
         cursor: isRenaming ? 'default' : 'pointer',
         textAlign: 'left',
-        transition: 'background-color 150ms ease',
+        transition: 'background-color 150ms ease, box-shadow 150ms ease',
         gap: 'var(--spacing-xs)',
         outline: 'none',
+        // U6b: replace the bare outline:none with a visible focus ring driven
+        // by focus state (covers both keyboard and programmatic focus). Uses a
+        // box-shadow so it renders outside the row's rounded background.
+        boxShadow: isFocused
+          ? '0 0 0 2px rgb(var(--color-primary-rgb), 0.5)'
+          : 'none',
       }}
     >
       <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--spacing-sm)', width: '100%' }}>
@@ -215,7 +227,7 @@ export function SidebarConversationItem({
             aria-haspopup="menu"
             aria-expanded={isMenuOpen || isDeleteConfirmOpen}
             style={{
-              opacity: hovered ? 1 : 0,
+              opacity: hovered || isFocused ? 1 : 0,
               transition: 'opacity 150ms ease',
               backgroundColor: 'transparent', border: 'none', color: 'inherit',
               fontSize: '20px', lineHeight: 1, padding: 'var(--spacing-xs)',

--- a/web_ui/src/components/StreamingIndicator.tsx
+++ b/web_ui/src/components/StreamingIndicator.tsx
@@ -7,15 +7,27 @@ import React, { useEffect, useState } from 'react';
 
 interface StreamingIndicatorProps {
   isVisible: boolean;
+  /** U1: when a model load is in progress, render a determinate progress bar
+   *  instead of the indeterminate "Generating" cursor so a multi-minute cold
+   *  load on first send is visible. Optional. */
+  modelLoadProgress?: number;
+  /** U1: human-readable label for the model-load stage. wllama supplies this. */
+  modelLoadLabel?: string;
 }
 
 /**
  * Animated streaming indicator with blinking cursor.
  * Shows "Generating" + blinking cursor when motion is allowed.
  * Shows "Generating..." static text when reduced motion is preferred.
+ *
+ * U1: when `modelLoadProgress` is provided (0-100), renders a determinate bar
+ * with `modelLoadLabel` so a cold first-send model load is visible rather than
+ * appearing as an indeterminate hang.
  */
-export function StreamingIndicator({ isVisible }: StreamingIndicatorProps): React.ReactElement | null {
+export function StreamingIndicator({ isVisible, modelLoadProgress, modelLoadLabel }: StreamingIndicatorProps): React.ReactElement | null {
   const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  const isLoadingModel = typeof modelLoadProgress === 'number' && modelLoadProgress >= 0 && modelLoadProgress < 100;
 
   useEffect(() => {
     const mediaQuery =
@@ -61,6 +73,43 @@ export function StreamingIndicator({ isVisible }: StreamingIndicatorProps): Reac
     color: 'var(--color-text-muted)',
     marginLeft: '2px',
   };
+
+  // U1: determinate model-load bar.
+  if (isLoadingModel) {
+    const pct = Math.max(0, Math.min(100, Math.round(modelLoadProgress ?? 0)));
+    return (
+      <div
+        style={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-xs)', padding: '4px 0', width: '100%', maxWidth: '420px' }}
+        data-testid="streaming-indicator"
+        role="status"
+        aria-live="polite"
+        aria-label={`Loading AI model, ${pct}% complete`}
+      >
+        <span style={textStyle}>
+          {modelLoadLabel ?? 'Loading the AI model — one-time, may take a few minutes…'} {pct}%
+        </span>
+        <div
+          style={{
+            height: '6px',
+            width: '100%',
+            backgroundColor: 'var(--color-bubble-system)',
+            borderRadius: 'var(--radius-xs)',
+            overflow: 'hidden',
+          }}
+        >
+          <div
+            style={{
+              height: '100%',
+              width: `${pct}%`,
+              backgroundColor: 'var(--color-primary)',
+              borderRadius: 'var(--radius-xs)',
+              transition: 'width 200ms ease',
+            }}
+          />
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div style={containerStyle} data-testid="streaming-indicator" role="status" aria-live="polite" aria-label="Generating response">

--- a/web_ui/src/db/conversations.ts
+++ b/web_ui/src/db/conversations.ts
@@ -112,24 +112,3 @@ export async function countConversations(): Promise<number> {
     throw error;
   }
 }
-
-/**
- * Update only the title of a conversation.
- *
- * @param conversationId - Target conversation ID
- * @param title - New title string
- */
-export async function updateTitle(
-  conversationId: string,
-  title: string
-): Promise<void> {
-  try {
-    await db.conversations.update(conversationId, {
-      title,
-      updatedAt: Date.now()
-    });
-  } catch (error) {
-    console.error('[conversations] Failed to update title:', error);
-    throw error;
-  }
-}

--- a/web_ui/src/db/conversations.ts
+++ b/web_ui/src/db/conversations.ts
@@ -114,30 +114,6 @@ export async function countConversations(): Promise<number> {
 }
 
 /**
- * Append a message to a conversation and update its updatedAt timestamp.
- *
- * @param conversationId - Target conversation ID
- * @param message - ChatMessage to append
- */
-export async function appendMessage(
-  conversationId: string,
-  message: ChatMessage
-): Promise<void> {
-  try {
-    await db.conversations
-      .where('id')
-      .equals(conversationId)
-      .modify((conversation) => {
-        conversation.messages.push(message);
-        conversation.updatedAt = Date.now();
-      });
-  } catch (error) {
-    console.error('[conversations] Failed to append message:', error);
-    throw error;
-  }
-}
-
-/**
  * Update only the title of a conversation.
  *
  * @param conversationId - Target conversation ID

--- a/web_ui/src/hooks/useConversations.test.ts
+++ b/web_ui/src/hooks/useConversations.test.ts
@@ -469,7 +469,7 @@ describe('useConversations', () => {
       const { result } = renderHook(() => useConversations());
 
       await act(async () => {
-        await result.current.saveMessages([], 'server', 'test-model');
+        await result.current.saveMessages('conv-1', [], 'server', 'test-model');
       });
 
       expect(mockCreateConversation).not.toHaveBeenCalled();
@@ -488,7 +488,7 @@ describe('useConversations', () => {
       const { result } = renderHook(() => useConversations());
 
       await act(async () => {
-        await result.current.saveMessages(messages, 'server', 'gpt-4');
+        await result.current.saveMessages(undefined, messages, 'server', 'gpt-4');
       });
 
       expect(mockCreateConversation).toHaveBeenCalledWith(
@@ -529,7 +529,7 @@ describe('useConversations', () => {
       mockListConversations.mockResolvedValue([existingConv]);
 
       await act(async () => {
-        await result.current.saveMessages(newMessages, 'wllama', 'llama2');
+        await result.current.saveMessages('existing-conv', newMessages, 'wllama', 'llama2');
       });
 
       expect(mockUpdateConversation).toHaveBeenCalledWith(
@@ -555,7 +555,7 @@ describe('useConversations', () => {
       const { result } = renderHook(() => useConversations());
 
       await act(async () => {
-        await result.current.saveMessages(messages, 'server', 'test-model');
+        await result.current.saveMessages(undefined, messages, 'server', 'test-model');
       });
 
       // Title should be first 50 chars + '...'
@@ -577,7 +577,7 @@ describe('useConversations', () => {
       const { result } = renderHook(() => useConversations());
 
       await act(async () => {
-        await result.current.saveMessages(messages, 'server', 'test-model');
+        await result.current.saveMessages(undefined, messages, 'server', 'test-model');
       });
 
       expect(mockCreateConversation).toHaveBeenCalledWith(
@@ -601,12 +601,159 @@ describe('useConversations', () => {
 
       // Call saveMessages - it should throw and be caught
       act(() => {
-        result.current.saveMessages(messages, 'server', 'test-model');
+        result.current.saveMessages(undefined, messages, 'server', 'test-model');
       });
 
       // The error should be caught and persistenceError should be set
       expect(mockCreateConversation).toHaveBeenCalled();
       expect(result.current.persistenceError).toBe('Failed to save conversation');
+    });
+
+    it('strips isStreaming before persisting (S3 regression)', async () => {
+      // The transient render-only isStreaming flag must NEVER be written to
+      // IndexedDB — it would leave a permanent blinking cursor after reload.
+      const messages: ChatMessage[] = [
+        { id: 'msg-1', role: 'user', content: 'Hello', timestamp: Date.now() },
+        { id: 'msg-2', role: 'assistant', content: 'Hi!', timestamp: Date.now(), isStreaming: true },
+      ];
+
+      mockListConversations.mockResolvedValue([]);
+
+      const { result } = renderHook(() => useConversations());
+
+      await act(async () => {
+        await result.current.saveMessages(undefined, messages, 'server', 'gpt-4');
+      });
+
+      expect(mockCreateConversation).toHaveBeenCalledTimes(1);
+      const persisted = mockCreateConversation.mock.calls[0][0];
+      // No persisted message may carry isStreaming.
+      expect(persisted.messages.every((m: ChatMessage) => m.isStreaming === undefined)).toBe(true);
+      // And the streaming assistant content is still preserved.
+      expect(persisted.messages).toHaveLength(2);
+      expect(persisted.messages[1].content).toBe('Hi!');
+    });
+
+    it('strips isStreaming when updating an existing conversation (S3 regression)', async () => {
+      const existingConv = createMockConversation({
+        id: 'existing-conv',
+        title: 'Existing',
+        messages: [{ id: 'msg-1', role: 'user', content: 'Old', timestamp: Date.now() }],
+      });
+
+      mockListConversations
+        .mockResolvedValueOnce([existingConv])
+        .mockResolvedValueOnce([existingConv]);
+      mockGetConversation.mockResolvedValueOnce(existingConv);
+      mockCountConversations.mockResolvedValueOnce(1);
+
+      const { result } = renderHook(() => useConversations());
+
+      await waitFor(() => {
+        expect(result.current.currentConversationId).toBe('existing-conv');
+      });
+
+      const newMessages: ChatMessage[] = [
+        { id: 'msg-2', role: 'assistant', content: 'Streaming reply', timestamp: Date.now(), isStreaming: true },
+      ];
+
+      mockListConversations.mockResolvedValue([existingConv]);
+
+      await act(async () => {
+        await result.current.saveMessages('existing-conv', newMessages, 'server', 'gpt-4');
+      });
+
+      expect(mockUpdateConversation).toHaveBeenCalledWith(
+        'existing-conv',
+        expect.objectContaining({
+          messages: expect.any(Array),
+        })
+      );
+      const persisted = mockUpdateConversation.mock.calls[0][1].messages;
+      expect(persisted.every((m: ChatMessage) => m.isStreaming === undefined)).toBe(true);
+    });
+
+    it('passes the new conversation id to onCreate when creating', async () => {
+      const messages: ChatMessage[] = [
+        { id: 'msg-1', role: 'user', content: 'Hello', timestamp: Date.now() },
+      ];
+
+      mockListConversations.mockResolvedValue([]);
+
+      const { result } = renderHook(() => useConversations());
+
+      const onCreate = vi.fn();
+      await act(async () => {
+        await result.current.saveMessages(undefined, messages, 'server', 'gpt-4', onCreate);
+      });
+
+      expect(mockCreateConversation).toHaveBeenCalledTimes(1);
+      const newId = mockCreateConversation.mock.calls[0][0].id;
+      expect(onCreate).toHaveBeenCalledTimes(1);
+      expect(onCreate).toHaveBeenCalledWith(newId);
+    });
+
+    it('does not call onCreate when updating an existing conversation', async () => {
+      const existingConv = createMockConversation({
+        id: 'existing-conv',
+        title: 'Existing',
+        messages: [{ id: 'msg-1', role: 'user', content: 'Old', timestamp: Date.now() }],
+      });
+
+      mockListConversations
+        .mockResolvedValueOnce([existingConv])
+        .mockResolvedValueOnce([existingConv]);
+      mockGetConversation.mockResolvedValueOnce(existingConv);
+      mockCountConversations.mockResolvedValueOnce(1);
+
+      const { result } = renderHook(() => useConversations());
+
+      await waitFor(() => {
+        expect(result.current.currentConversationId).toBe('existing-conv');
+      });
+
+      const newMessages: ChatMessage[] = [
+        { id: 'msg-2', role: 'user', content: 'Follow up', timestamp: Date.now() },
+      ];
+      mockListConversations.mockResolvedValue([existingConv]);
+
+      const onCreate = vi.fn();
+      await act(async () => {
+        await result.current.saveMessages('existing-conv', newMessages, 'server', 'gpt-4', onCreate);
+      });
+
+      expect(onCreate).not.toHaveBeenCalled();
+      expect(mockUpdateConversation).toHaveBeenCalled();
+    });
+  });
+
+  describe('setCurrentConversationId', () => {
+    it('exposes setCurrentConversationId as a function', async () => {
+      const { result } = renderHook(() => useConversations());
+
+      await waitFor(() => {
+        expect(mockListConversations).toHaveBeenCalled();
+      });
+
+      expect(typeof result.current.setCurrentConversationId).toBe('function');
+    });
+
+    it('sets the current conversation id (string | undefined)', async () => {
+      const { result } = renderHook(() => useConversations());
+
+      await waitFor(() => {
+        expect(mockListConversations).toHaveBeenCalled();
+      });
+
+      await act(async () => {
+        result.current.setCurrentConversationId('conv-42');
+      });
+      expect(result.current.currentConversationId).toBe('conv-42');
+
+      await act(async () => {
+        result.current.setCurrentConversationId(undefined);
+      });
+      expect(result.current.currentConversationId).toBeUndefined();
     });
   });
 });

--- a/web_ui/src/hooks/useConversations.ts
+++ b/web_ui/src/hooks/useConversations.ts
@@ -10,6 +10,21 @@ import {
 } from '../db/conversations';
 import type { ChatMessage } from '../types/chat';
 
+/**
+ * Strip transient UI state from messages before persistence so nothing
+ * render-only (the streaming cursor flag) is ever written to IndexedDB.
+ * Persisting `isStreaming:true` causes a permanent blinking cursor after
+ * reload (S3). The flag is always re-derived in-memory at send time. */
+function stripTransientFlags(messages: ChatMessage[]): ChatMessage[] {
+  return messages.map((m) => {
+    if (m.isStreaming === undefined) return m;
+    // Destructure out isStreaming; keep every other field.
+    const { isStreaming: _isStreaming, ...rest } = m;
+    void _isStreaming;
+    return rest as ChatMessage;
+  });
+}
+
 export interface ConversationSummary {
   id: string;
   title: string;
@@ -53,6 +68,18 @@ export function useConversations() {
   const [persistenceError, setPersistenceError] = useState<string | null>(null);
   const pageSize = 50;
   const isInitialized = useRef(false);
+
+  // Ref mirror of currentConversationId so async callbacks (e.g. an in-flight
+  // generation's onDone/onError) can read the LIVE id for the no-re-point
+  // guard (S1) without a stale closure. Kept in sync by the effect below.
+  const currentConversationIdRef = useRef<string | undefined>(currentConversationId);
+  useEffect(() => {
+    currentConversationIdRef.current = currentConversationId;
+  }, [currentConversationId]);
+  const setCurrentConversationIdBoth = useCallback((id: string | undefined) => {
+    currentConversationIdRef.current = id;
+    setCurrentConversationId(id);
+  }, []);
 
   const clearPersistenceError = useCallback(() => setPersistenceError(null), []);
 
@@ -127,7 +154,7 @@ export function useConversations() {
           const list = await listConversations(0, 1);
           if (list.length > 0) {
             const last = list[0];
-            setCurrentConversationId(last.id);
+            setCurrentConversationIdBoth(last.id);
             setCurrentMessages(last.messages);
           }
         } catch (error) {
@@ -146,7 +173,7 @@ export function useConversations() {
     try {
       const conv = await getConversation(id);
       if (conv) {
-        setCurrentConversationId(conv.id);
+        setCurrentConversationIdBoth(conv.id);
         setCurrentMessages(conv.messages);
       }
       setPersistenceError(null);
@@ -160,51 +187,79 @@ export function useConversations() {
    * Clear current conversation state to start a new chat.
    */
   const newChat = useCallback(() => {
-    setCurrentConversationId(undefined);
+    setCurrentConversationIdBoth(undefined);
     setCurrentMessages([]);
   }, []);
 
   /**
-   * Save messages to Dexie. Creates new conversation if currentConversationId is null,
-   * otherwise updates the existing conversation. Auto-generates title from first user message.
+   * Save messages to Dexie, targeting a SPECIFIC conversation id.
    *
+   * S1 fix: the `conversationId` param is the OWNING id captured at send time
+   * (not the live `currentConversationId`). This breaks the stale-closure race
+   * where an in-flight stream's onDone would save the switched-to
+   * conversation's messages into the switched-FROM conversation. Callers
+   * capture the owning id once (in ChatPage.handleSend) and pass it through
+   * runGeneration to onDone/onError. When `conversationId` is undefined (no
+   * prior conversation), a new conversation is created and its id returned via
+   * the ref + state setters so subsequent saves target it.
+   *
+   * S3 fix: transient `isStreaming` is stripped before writing so a saved
+   * mid-stream snapshot never persists a blinking-cursor flag.
+   *
+   * @param conversationId - Owning conversation ID (captured at send time);
+   *   undefined creates a new conversation.
    * @param messages - ChatMessage array to save
    * @param mode - Inference mode ('server' or 'wllama')
    * @param modelUsed - Model identifier string
+   * @param onCreate - Optional callback receiving the created conversation id
+   *   when a new conversation is created (lets the caller re-point its owning
+   *   id + the active conversation atomically).
    */
   const saveMessages = useCallback(async (
+    conversationId: string | undefined,
     messages: ChatMessage[],
     mode: 'server' | 'wllama',
-    modelUsed: string
+    modelUsed: string,
+    onCreate?: (newId: string) => void
   ) => {
-    if (messages.length === 0) return;
+    const persisted = stripTransientFlags(messages);
+    if (persisted.length === 0) return;
 
     const now = Date.now();
-    const firstUserMsg = messages.find(m => m.role === 'user');
-    const title = firstUserMsg
+    // Preserve an existing conversation's title; only derive for new ones.
+    const existing = conversationId ? await getConversation(conversationId) : undefined;
+    const firstUserMsg = persisted.find(m => m.role === 'user');
+    const title = existing?.title ?? (firstUserMsg
       ? firstUserMsg.content.slice(0, 50) + (firstUserMsg.content.length > 50 ? '...' : '')
-      : 'New conversation';
+      : 'New conversation');
 
     try {
-      if (!currentConversationId) {
+      if (!conversationId || !existing) {
         // Create new conversation
         const newConv: Conversation = {
           id: (typeof crypto !== 'undefined' && crypto.randomUUID)
             ? crypto.randomUUID()
             : Date.now().toString(36) + Math.random().toString(36).slice(2, 8),
           title,
-          messages,
+          messages: persisted,
           createdAt: now,
           updatedAt: now,
           mode,
           modelUsed,
         };
         await createConversation(newConv);
-        setCurrentConversationId(newConv.id);
+        // Only re-point the ACTIVE conversation when the caller is still on
+        // the conversation that produced this save (S1 no-re-point guard).
+        // The onCreate callback lets the caller decide whether to adopt the
+        // new id as the owning id for the in-flight stream.
+        onCreate?.(newConv.id);
+        if (currentConversationIdRef.current === conversationId) {
+          setCurrentConversationIdBoth(newConv.id);
+        }
       } else {
-        // Update existing
-        await updateConversation(currentConversationId, {
-          messages,
+        // Update existing — strip transient flags and write.
+        await updateConversation(conversationId, {
+          messages: persisted,
           updatedAt: now,
         });
       }
@@ -214,7 +269,7 @@ export function useConversations() {
       console.error('[useConversations] Failed to save conversation:', error);
       setPersistenceError('Failed to save conversation');
     }
-  }, [currentConversationId, refreshConversations]);
+  }, [refreshConversations]);
 
   /**
    * Delete a conversation by ID. If the deleted conversation is the current one,
@@ -226,7 +281,7 @@ export function useConversations() {
     try {
       await deleteConversation(id);
       if (currentConversationId === id) {
-        setCurrentConversationId(undefined);
+        setCurrentConversationIdBoth(undefined);
         setCurrentMessages([]);
       }
       await refreshConversations();
@@ -242,6 +297,9 @@ export function useConversations() {
     currentConversationId,
     currentMessages,
     setCurrentMessages,
+    // Exposed so ChatPage can adopt a send-time-created conversation id as
+    // both the owning id (for the in-flight stream) and the active id.
+    setCurrentConversationId: setCurrentConversationIdBoth,
     selectConversation,
     newChat,
     saveMessages,

--- a/web_ui/src/hooks/useDocumentCount.ts
+++ b/web_ui/src/hooks/useDocumentCount.ts
@@ -1,0 +1,74 @@
+/**
+ * Hook that subscribes to the persisted document count.
+ *
+ * U4: used by the empty-chat state to decide whether to show the "no documents
+ * yet" hint. The repo's document persistence layer
+ * (`src/lib/storage/document-store.ts`) uses the raw IndexedDB API rather than
+ * Dexie, so there is no reactive `liveQuery` source to subscribe to. Instead we
+ * count on mount and re-count whenever the user returns to this tab
+ * (`visibilitychange`). This keeps the count fresh after background uploads or
+ * deletes performed in another tab without burning a polling timer.
+ *
+ * `loadDocuments` already swallows IndexedDB errors and returns `[]`, so the
+ * hook is robust to the object store not existing (e.g. a fresh profile before
+ * the first migration): `count` simply reports `0`.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { loadDocuments } from '../lib/storage/document-store';
+
+export interface UseDocumentCountResult {
+  /** Number of persisted documents, or 0 if the store is unavailable. */
+  count: number;
+  /** True until the initial count has resolved. */
+  loading: boolean;
+}
+
+/**
+ * Subscribe to the persisted document count.
+ *
+ * Re-counts on mount and whenever the document becomes visible again (so a
+ * user returning to the tab sees deletes/uploads performed elsewhere).
+ *
+ * @returns `{ count, loading }` — `loading` is true until the first count
+ *   resolves, then false for the rest of the hook's lifetime.
+ */
+export function useDocumentCount(): UseDocumentCountResult {
+  const [count, setCount] = useState(0);
+  const [loading, setLoading] = useState(true);
+
+  const recount = useCallback(async () => {
+    try {
+      const docs = await loadDocuments();
+      setCount(Array.isArray(docs) ? docs.length : 0);
+    } catch {
+      // Store missing / unavailable — treat as empty.
+      setCount(0);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    // Initial count on mount.
+    void (async () => {
+      await recount();
+      if (cancelled) return;
+    })();
+
+    const handleVisibility = () => {
+      if (document.visibilityState === 'visible') {
+        void recount();
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibility);
+
+    return () => {
+      cancelled = true;
+      document.removeEventListener('visibilitychange', handleVisibility);
+    };
+  }, [recount]);
+
+  return { count, loading };
+}

--- a/web_ui/src/hooks/useKeyboardShortcuts.ts
+++ b/web_ui/src/hooks/useKeyboardShortcuts.ts
@@ -29,9 +29,12 @@ export function useKeyboardShortcuts({
             onSendMessage();
           }
           break;
+        // U7d: Ctrl+Shift+L clears the chat. Plain Ctrl+L is the browser's
+        // focus-address-bar shortcut and must NOT be hijacked (the previous
+        // binding overrode it app-wide and double-press cleared the chat).
         case 'l':
         case 'L':
-          if (onClearChat) {
+          if (event.shiftKey && onClearChat) {
             event.preventDefault();
             onClearChat();
           }

--- a/web_ui/src/lib/llm/web-llm-service.test.ts
+++ b/web_ui/src/lib/llm/web-llm-service.test.ts
@@ -341,11 +341,15 @@ describe('WebLLMService', () => {
     await service.initialize();
 
     const messages: LLMMessage[] = [{ role: 'user', content: 'hi' }];
-    await service.generate(messages, {
+    // generate() is an async generator — its body (and the completions.create
+    // call) only runs when iterated. Drain it so the options are forwarded.
+    for await (const _ of service.generate(messages, {
       maxTokens: 100,
       temperature: 0.7,
       topP: 0.9,
-    });
+    })) {
+      void _;
+    }
 
     expect(mockEngine.chat.completions.create).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -410,6 +414,137 @@ describe('WebLLMService', () => {
     service.dispose();
 
     expect(() => service.interrupt()).not.toThrow();
+  });
+
+  // -------------------------------------------------------------------------
+  // S7 (issue #36): generate() wires an abort listener that calls
+  // engine.interruptGenerate() and removes it on settle (no listener leak).
+  // -------------------------------------------------------------------------
+  test('generate calls engine.interruptGenerate() when the abort signal fires (S7)', async () => {
+    // The completion iterator stays open until interruptGenerate() ends it;
+    // we release it only after the abort fires so the test reaches the
+    // abort-listener path deterministically.
+    let releaseIterator: () => void = () => {};
+    const iteratorDone = new Promise<void>((resolve) => {
+      releaseIterator = resolve;
+    });
+    let firstTokenDelivered: () => void = () => {};
+    const firstTokenSeen = new Promise<void>((resolve) => {
+      firstTokenDelivered = resolve;
+    });
+    const mockCompletion = {
+      [Symbol.asyncIterator]: async function* () {
+        yield { choices: [{ delta: { content: 'partial' } }] };
+        await iteratorDone;
+      },
+    };
+
+    const mockEngine = createMockEngine({
+      chat: {
+        completions: {
+          create: vi.fn().mockResolvedValue(mockCompletion),
+        },
+      },
+    });
+    mockCreateMLCEngine.mockResolvedValue(mockEngine);
+
+    const service = WebLLMService.getInstance();
+    await service.initialize();
+
+    const controller = new AbortController();
+    const messages: LLMMessage[] = [{ role: 'user', content: 'hi' }];
+
+    // Drive the generator. The first chunk yields; then we abort, which must
+    // trigger engine.interruptGenerate() via the abort listener.
+    const collected: string[] = [];
+    const generation = (async () => {
+      for await (const tok of service.generate(messages, { signal: controller.signal })) {
+        collected.push(tok);
+        firstTokenDelivered();
+      }
+    })();
+
+    // Wait until the first token is actually delivered to the consumer so we
+    // know the generator body has run and the abort listener is registered.
+    await firstTokenSeen;
+    expect(mockEngine.interruptGenerate).not.toHaveBeenCalled();
+
+    controller.abort();
+    releaseIterator();
+
+    await generation;
+
+    expect(mockEngine.interruptGenerate).toHaveBeenCalledTimes(1);
+    expect(collected).toEqual(['partial']);
+  });
+
+  test('generate removes its abort listener after settling — no leak (S7)', async () => {
+    const mockCompletion = {
+      [Symbol.asyncIterator]: async function* () {
+        yield { choices: [{ delta: { content: 'hi' } }] };
+      },
+    };
+
+    const mockEngine = createMockEngine({
+      chat: {
+        completions: {
+          create: vi.fn().mockResolvedValue(mockCompletion),
+        },
+      },
+    });
+    mockCreateMLCEngine.mockResolvedValue(mockEngine);
+
+    const service = WebLLMService.getInstance();
+    await service.initialize();
+
+    const controller = new AbortController();
+    const removeEventListenerSpy = vi.spyOn(controller.signal, 'removeEventListener');
+
+    // Drain the generator to completion so the finally block runs.
+    for await (const _ of service.generate([{ role: 'user', content: 'hi' }], {
+      signal: controller.signal,
+    })) {
+      void _;
+    }
+
+    // The abort listener registered in generate() must be removed in the
+    // finally block so repeated generations don't accumulate stale listeners
+    // on long-lived AbortSignals/AbortControllers.
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('abort', expect.any(Function));
+    removeEventListenerSpy.mockRestore();
+  });
+
+  test('generate calls interruptGenerate() up front if the signal is already aborted (S7)', async () => {
+    const mockCompletion = {
+      [Symbol.asyncIterator]: async function* () {
+        yield { choices: [{ delta: { content: 'hi' } }] };
+      },
+    };
+
+    const mockEngine = createMockEngine({
+      chat: {
+        completions: {
+          create: vi.fn().mockResolvedValue(mockCompletion),
+        },
+      },
+    });
+    mockCreateMLCEngine.mockResolvedValue(mockEngine);
+
+    const service = WebLLMService.getInstance();
+    await service.initialize();
+
+    const controller = new AbortController();
+    controller.abort();
+
+    for await (const _ of service.generate([{ role: 'user', content: 'hi' }], {
+      signal: controller.signal,
+    })) {
+      void _;
+    }
+
+    // When the signal is already aborted at entry, generate() invokes
+    // interruptGenerate() immediately (mirrors the addEventListener path).
+    expect(mockEngine.interruptGenerate).toHaveBeenCalled();
   });
 
   // -------------------------------------------------------------------------
@@ -563,7 +698,11 @@ describe('WebLLMService', () => {
       { role: 'assistant', content: 'Hi there' },
     ];
 
-    await service.generate(messages);
+    // generate() is an async generator — drain it so the body runs and the
+    // messages are mapped and forwarded to completions.create.
+    for await (const _ of service.generate(messages)) {
+      void _;
+    }
 
     expect(mockEngine.chat.completions.create).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/web_ui/src/lib/llm/web-llm-service.ts
+++ b/web_ui/src/lib/llm/web-llm-service.ts
@@ -333,6 +333,26 @@ export class WebLLMService implements LLMService {
 
     const signal = options?.signal ?? new AbortController().signal;
 
+    // S7: web-llm's `signal` field on chat.completions.create is inert at
+    // runtime (it is not honored by the MLCEngine streaming loop). The REAL
+    // cancellation primitive is engine.interruptGenerate(), invoked via the
+    // service's interrupt() — but the orchestrator/RAG path only has the
+    // AbortSignal. Wire an abort listener here so aborting the signal (from
+    // ChatPage.cancelActiveStream → abortController.abort()) actually stops
+    // the WebGPU generation. Mirrors the wllama path's abort-forwarding.
+    const onAbort = () => {
+      try {
+        this._engine?.interruptGenerate();
+      } catch (err) {
+        console.warn('[WebLLM] interruptGenerate on abort failed', err);
+      }
+    };
+    if (signal.aborted) {
+      onAbort();
+    } else {
+      signal.addEventListener('abort', onAbort);
+    }
+
     try {
       const completion = await this._engine.chat.completions.create({
         messages: messages.map((m) => ({ role: m.role, content: messageContentToText(m.content) })),
@@ -344,6 +364,11 @@ export class WebLLMService implements LLMService {
       });
 
       for await (const chunk of completion) {
+        if (signal.aborted) {
+          // interruptGenerate() causes the async iterator to end/throw; break
+          // defensively if it hasn't yet.
+          break;
+        }
         const content = chunk.choices?.[0]?.delta?.content;
         if (content) {
           yield content;
@@ -355,6 +380,8 @@ export class WebLLMService implements LLMService {
         throw err;
       }
       throw err;
+    } finally {
+      signal.removeEventListener('abort', onAbort);
     }
   }
 

--- a/web_ui/src/lib/rag/rag-orchestrator.test.ts
+++ b/web_ui/src/lib/rag/rag-orchestrator.test.ts
@@ -1290,5 +1290,70 @@ describe('RAGOrchestrator', () => {
       expect(complete.data.retrievalDegraded).toBe(true);
       expect(complete.data.abstain).not.toBe(true);
     });
+
+    // U8a / PRR-010: a multimodal question with an attached image must NOT
+    // abstain on an empty corpus. The abstain guard's `&& !(options.images?.length)`
+    // clause is what keeps the pipeline alive so buildMessages can forward the
+    // image to the VLM. This is a TRUE regression test: revert that clause and
+    // the pipeline would abstain (the LLM would never be called and there would
+    // be no image part in any message), failing both assertions below.
+    test('U8a: image-on-empty-corpus does NOT abstain, falls through to the VLM (PRR-010)', async () => {
+      const mockEmbedding = createMockEmbedding();
+      mockEmbeddingService.encodeWithMetadata.mockResolvedValue({
+        vector: mockEmbedding,
+        text: 'q',
+        dimensions: 384,
+      });
+      // Empty corpus — the condition that would normally trigger F2 abstention.
+      mockVectorIndex.search.mockResolvedValue([]);
+      mockKeywordIndex.search.mockReturnValue([]);
+      (rrfFuse as ReturnType<typeof vi.fn>).mockReturnValue([]);
+
+      // Capture the message array handed to the LLM so we can assert the image
+      // part survived the fall-through into buildMessages.
+      let capturedMessages: LLMMessage[] | null = null;
+      mockWebLLMService.generateComplete.mockImplementation(async (messages: LLMMessage[]) => {
+        capturedMessages = messages;
+        return 'a screenshot of a dashboard';
+      });
+
+      // A real-ish image payload: a few PNG-ish bytes in an ArrayBuffer.
+      const imageData = new ArrayBuffer(8);
+      new Uint8Array(imageData).set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+      const orchestrator = new RAGOrchestrator();
+      const events: any[] = [];
+      for await (const ev of orchestrator.query(
+        "what's in this screenshot?",
+        {
+          streamTokens: false,
+          rerank: false,
+          images: [{ data: imageData, mimeType: 'image/png' }],
+        }
+      )) {
+        events.push(ev);
+      }
+
+      // 1. The pipeline must NOT yield an abstaining complete event. (If the
+      //    U8a clause were removed, this would be the failure mode.)
+      const complete = events.find((e) => e.type === 'complete');
+      expect(complete).toBeDefined();
+      expect(complete.data.abstain).not.toBe(true);
+
+      // 2. The pipeline fell through to generation: the LLM was invoked, and
+      //    the user message carries the image part (data is the same
+      //    ArrayBuffer we passed in). buildMessages builds a multimodal content
+      //    array only when images are present, so observing an `image` part
+      //    proves both the fall-through AND the image-forwarding path.
+      expect(mockWebLLMService.generateComplete).toHaveBeenCalledTimes(1);
+      expect(capturedMessages).not.toBeNull();
+      const userMessage = capturedMessages!.find((m) => m.role === 'user');
+      expect(userMessage).toBeDefined();
+      expect(Array.isArray(userMessage!.content)).toBe(true);
+      const imagePart = (userMessage!.content as Array<{ type: string; data?: unknown }>)
+        .find((p) => p.type === 'image');
+      expect(imagePart).toBeDefined();
+      expect(imagePart!.data).toBe(imageData);
+    });
   });
 });

--- a/web_ui/src/lib/rag/rag-orchestrator.ts
+++ b/web_ui/src/lib/rag/rag-orchestrator.ts
@@ -378,7 +378,12 @@ export class RAGOrchestrator {
     // F2: abstention. If no chunks survive the floor AND budget, short-circuit
     // BEFORE generation so the model never answers from pretrained knowledge
     // with no source. The UI renders a visually distinct abstention state.
-    if (contextChunks.length === 0) {
+    //
+    // U8a: do NOT abstain when the user attached images — a multimodal question
+    // like "what's in this screenshot?" on an empty corpus should reach the VLM
+    // rather than abstaining. buildMessages (below) already forwards images
+    // into the multimodal content array, so falling through here is sufficient.
+    if (contextChunks.length === 0 && !(options.images?.length)) {
       yield {
         type: 'complete',
         data: {

--- a/web_ui/src/lib/streaming/TokenStreamManager.test.ts
+++ b/web_ui/src/lib/streaming/TokenStreamManager.test.ts
@@ -1,8 +1,16 @@
 /**
  * Tests for TokenStreamManager class
+ *
+ * Updated for issue #36 (S4) new contracts:
+ *   - cancel() now FLUSHES buffered tokens via the callback BEFORE clearing
+ *     (previously it dropped them). Stop must deliver every token received
+ *     up to the cancel.
+ *   - pushToken overflow now flushes the buffer (preserving token order)
+ *     instead of splicing the oldest unflushed tokens out.
+ *   - scheduleFlush uses a setTimeout fallback when the document is hidden.
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach, beforeAll } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { TokenStreamManager } from '../streaming/TokenStreamManager';
 
 // Mock the SSEStreamConsumer
@@ -20,12 +28,14 @@ describe('TokenStreamManager', () => {
   let manager: TokenStreamManager;
 
   beforeEach(() => {
+    vi.useFakeTimers();
     vi.clearAllMocks();
     manager = new TokenStreamManager();
   });
 
   afterEach(() => {
     manager.dispose();
+    vi.useRealTimers();
   });
 
   describe('Constructor', () => {
@@ -52,7 +62,11 @@ describe('TokenStreamManager', () => {
       expect(callback).toHaveBeenCalled();
     });
 
-    it('allows multiple token callbacks to be registered', () => {
+    it('last-registered token callback wins (onToken overwrites)', () => {
+      // onToken() assigns (overwrites) the single token callback slot rather
+      // than subscribing; registering a second callback replaces the first.
+      // This documents the actual contract so callers know not to stack
+      // multiple token callbacks expecting fan-out.
       const callback1 = vi.fn();
       const callback2 = vi.fn();
 
@@ -63,8 +77,8 @@ describe('TokenStreamManager', () => {
 
       vi.advanceTimersByTime(100);
 
-      expect(callback1).toHaveBeenCalled();
-      expect(callback2).toHaveBeenCalled();
+      expect(callback2).toHaveBeenCalledWith('Test');
+      expect(callback1).not.toHaveBeenCalled();
     });
   });
 
@@ -127,9 +141,9 @@ describe('TokenStreamManager', () => {
       manager.pushToken('World');
       manager.error('Error occurred');
 
-      vi.advanceTimersByTime(100);
-
-      expect(tokenCallback).toHaveBeenCalled();
+      // error() flushes synchronously before invoking the error callback,
+      // so the token callback has already fired by the time error() returns.
+      expect(tokenCallback).toHaveBeenCalledWith('HelloWorld');
       expect(errorCallback).toHaveBeenCalledWith('Error occurred');
     });
   });
@@ -153,6 +167,8 @@ describe('TokenStreamManager', () => {
       const callback = vi.fn();
       manager.onToken(callback);
 
+      // cancel() with an EMPTY buffer does not invoke the token callback
+      // (nothing to flush), so this still asserts no callback fires.
       manager.cancel();
       manager.pushToken('Should not appear');
 
@@ -190,8 +206,8 @@ describe('TokenStreamManager', () => {
         inferenceTime: 0,
       });
 
-      vi.advanceTimersByTime(100);
-
+      // complete() flushes synchronously before invoking the done callback,
+      // so the token callback fires during the complete() call itself.
       expect(tokenCallback).toHaveBeenCalledWith('Remaining');
     });
 
@@ -218,16 +234,42 @@ describe('TokenStreamManager', () => {
       vi.advanceTimersByTime(100);
     });
 
-    it('clears pending tokens', () => {
+    it('flushes buffered tokens before clearing (S4)', () => {
+      // NEW contract (issue #36 / S4): cancel() flushes the buffered tokens
+      // through the token callback BEFORE clearing, so Stop delivers every
+      // token received up to the cancel. The old behavior (nulling the buffer
+      // without flushing) dropped up to a RAF frame of tokens.
       const callback = vi.fn();
       manager.onToken(callback);
 
       manager.pushToken('Hello');
+      manager.pushToken(' ');
+      manager.pushToken('World');
+
+      // No RAF flush has fired yet — tokens are still buffered.
+      expect(callback).not.toHaveBeenCalled();
+
       manager.cancel();
 
-      vi.advanceTimersByTime(100);
+      // cancel() flushes synchronously: the callback receives every buffered
+      // token joined, in order, before the buffer is cleared.
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledWith('Hello World');
+    });
 
-      expect(callback).not.toHaveBeenCalled();
+    it('cancel after cancel does not re-flush', () => {
+      const callback = vi.fn();
+      manager.onToken(callback);
+
+      manager.pushToken('first');
+      manager.cancel();
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledWith('first');
+
+      // A second cancel is a no-op (cancelled flag guards it) and must not
+      // re-deliver already-flushed tokens.
+      manager.cancel();
+      expect(callback).toHaveBeenCalledTimes(1);
     });
 
     it('stops active consumer', () => {
@@ -237,8 +279,11 @@ describe('TokenStreamManager', () => {
     });
 
     it('clears flush timer', () => {
+      // cancel() only cancels a flush timer if one was actually scheduled.
+      // Pushing a token schedules a RAF, so cancel() must tear it down.
       const cancelAnimationFrameSpy = vi.spyOn(global, 'cancelAnimationFrame');
 
+      manager.pushToken('buffered'); // schedules a RAF
       manager.cancel();
 
       expect(cancelAnimationFrameSpy).toHaveBeenCalled();
@@ -264,7 +309,11 @@ describe('TokenStreamManager', () => {
 
       manager.dispose();
 
-      // After dispose, pushing tokens should not call callbacks
+      // After dispose, pushing tokens should not call callbacks. dispose()
+      // cancels (which would flush buffered tokens) but no tokens have been
+      // pushed yet, so the token callback has not fired.
+      expect(tokenCb).not.toHaveBeenCalled();
+
       manager.pushToken('Test');
       vi.advanceTimersByTime(100);
 
@@ -281,8 +330,6 @@ describe('TokenStreamManager', () => {
 
   describe('RAF Batching', () => {
     it('batches multiple tokens into single RAF frame', () => {
-      vi.useFakeTimers();
-
       const callback = vi.fn();
       manager.onToken(callback);
 
@@ -297,13 +344,9 @@ describe('TokenStreamManager', () => {
       vi.advanceTimersByTime(100);
       expect(callback).toHaveBeenCalledTimes(1);
       expect(callback).toHaveBeenCalledWith('ABC');
-
-      vi.useRealTimers();
     });
 
     it('schedules new RAF after flush', () => {
-      vi.useFakeTimers();
-
       const callback = vi.fn();
       manager.onToken(callback);
 
@@ -316,8 +359,91 @@ describe('TokenStreamManager', () => {
       manager.pushToken('2');
       vi.advanceTimersByTime(100);
       expect(callback).toHaveBeenCalledWith('2');
+    });
+  });
 
-      vi.useRealTimers();
+  describe('Overflow (S4)', () => {
+    it('flushes synchronously on overflow preserving token order (no drops)', () => {
+      // NEW contract (issue #36 / S4): pushToken overflow now flushes the
+      // buffer through the callback (preserving every token in order) instead
+      // of splicing the oldest unflushed tokens out of the middle of the
+      // displayed content. The old splice silently corrupted content.
+      const callback = vi.fn();
+      manager.onToken(callback);
+
+      // MAX_BUFFER_SIZE is 10000. Push more than that synchronously with no
+      // RAF flush in between. Every token must arrive via the callback,
+      // concatenated in push order, with none dropped.
+      const N = 10005;
+      let expected = '';
+      for (let i = 0; i < N; i++) {
+        const tok = `t${i}`;
+        expected += tok;
+        manager.pushToken(tok);
+      }
+
+      // The overflow path flushes the buffer (in order) each time the cap is
+      // crossed, instead of splicing oldest tokens. Whatever has been flushed
+      // so far must be an in-order PREFIX of the full stream — no gaps, no
+      // reordering, no oldest-token drops (the old splice behavior would have
+      // made this a non-prefix by deleting t0..tN from the middle).
+      const flushedSoFar = callback.mock.calls.map((c) => c[0]).join('');
+      expect(expected.startsWith(flushedSoFar)).toBe(true);
+      // The overflow fired at least once (buffer crossed 10000).
+      expect(callback.mock.calls.length).toBeGreaterThanOrEqual(1);
+
+      // Drain anything still buffered at the end via cancel (which also
+      // flushes per the S4 cancel contract) to confirm the tail is delivered
+      // too. After cancel, the concatenation of EVERY callback invocation
+      // must equal the full in-order token stream — nothing dropped.
+      manager.cancel();
+      const receivedAll = callback.mock.calls.map((c) => c[0]).join('');
+      expect(receivedAll).toBe(expected);
+    });
+  });
+
+  describe('Hidden-tab setTimeout fallback (S4)', () => {
+    it('uses setTimeout fallback when document is hidden', () => {
+      // NEW contract (issue #36 / S4): when the tab is hidden, RAF is
+      // suspended by the browser, so scheduleFlush falls back to a setTimeout
+      // (100ms) to keep tokens flushing in background tabs.
+      const originalHidden = Object.getOwnPropertyDescriptor(document, 'visibilityState');
+      Object.defineProperty(document, 'visibilityState', {
+        configurable: true,
+        get: () => 'hidden',
+      });
+
+      const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
+      const rafSpy = vi.spyOn(global, 'requestAnimationFrame');
+
+      try {
+        const callback = vi.fn();
+        manager.onToken(callback);
+
+        manager.pushToken('bg-token');
+
+        // In hidden state, setTimeout must be used to schedule the flush
+        // (requestAnimationFrame would never fire).
+        expect(setTimeoutSpy).toHaveBeenCalled();
+        expect(rafSpy).not.toHaveBeenCalled();
+
+        // Flushing the timer delivers the token.
+        vi.advanceTimersByTime(100);
+        expect(callback).toHaveBeenCalledWith('bg-token');
+      } finally {
+        // Restore
+        if (originalHidden) {
+          Object.defineProperty(document, 'visibilityState', originalHidden);
+        } else {
+          // best-effort restore to visible
+          Object.defineProperty(document, 'visibilityState', {
+            configurable: true,
+            get: () => 'visible',
+          });
+        }
+        setTimeoutSpy.mockRestore();
+        rafSpy.mockRestore();
+      }
     });
   });
 
@@ -332,60 +458,45 @@ describe('TokenStreamManager', () => {
 
     it('wires token callback to consumer', async () => {
       const { SSEStreamConsumer } = await import('../api/streaming');
-      const mockConsumer = vi.mocked(SSEStreamConsumer).mock.results[0].value;
 
       manager.onToken(vi.fn());
       manager.startSSEStream('/api/chat', {});
 
+      const mockConsumer = vi.mocked(SSEStreamConsumer).mock.results.at(-1)?.value;
+      expect(mockConsumer).toBeDefined();
       expect(mockConsumer.onToken).toHaveBeenCalled();
     });
 
     it('wires done callback to consumer', async () => {
       const { SSEStreamConsumer } = await import('../api/streaming');
-      const mockConsumer = vi.mocked(SSEStreamConsumer).mock.results[0].value;
 
       manager.onDone(vi.fn());
       manager.startSSEStream('/api/chat', {});
 
+      const mockConsumer = vi.mocked(SSEStreamConsumer).mock.results.at(-1)?.value;
+      expect(mockConsumer).toBeDefined();
       expect(mockConsumer.onDone).toHaveBeenCalled();
     });
 
     it('wires error callback to consumer', async () => {
       const { SSEStreamConsumer } = await import('../api/streaming');
-      const mockConsumer = vi.mocked(SSEStreamConsumer).mock.results[0].value;
 
       manager.onError(vi.fn());
       manager.startSSEStream('/api/chat', {});
 
+      const mockConsumer = vi.mocked(SSEStreamConsumer).mock.results.at(-1)?.value;
+      expect(mockConsumer).toBeDefined();
       expect(mockConsumer.onError).toHaveBeenCalled();
     });
 
     it('starts the consumer', async () => {
       const { SSEStreamConsumer } = await import('../api/streaming');
-      const mockConsumer = vi.mocked(SSEStreamConsumer).mock.results[0].value;
 
       manager.startSSEStream('/api/chat', {});
 
+      const mockConsumer = vi.mocked(SSEStreamConsumer).mock.results.at(-1)?.value;
+      expect(mockConsumer).toBeDefined();
       expect(mockConsumer.start).toHaveBeenCalled();
     });
   });
-
-  describe.skip('Buffer cap (FR-006)', () => {
-    it('enforces MAX_BUFFER_SIZE and drops oldest tokens', () => {
-      // Cap logic runs synchronously on every pushToken (before any RAF flush).
-      // This test is timer-free and independent of the RAF polyfill issues
-      // present in other tests in this file.
-      for (let i = 0; i < 10001; i++) {
-        manager.pushToken(`t${i}`);
-      }
-
-      const buffer: string[] = (manager as any).tokenBuffer;
-      expect(buffer.length).toBeLessThanOrEqual(10000);
-
-      // Oldest token (t0) was dropped; buffer holds the most recent 10000
-      expect(buffer[0]).toBe('t1');
-      expect(buffer[buffer.length - 1]).toBe('t10000');
-    });
-  });
-
 });

--- a/web_ui/src/lib/streaming/TokenStreamManager.ts
+++ b/web_ui/src/lib/streaming/TokenStreamManager.ts
@@ -93,21 +93,37 @@ export class TokenStreamManager {
       this.scheduleFlush();
     }
 
+    // S4: on overflow, flush the buffer DOWN to a safe size via the normal
+    // callback (preserving token order and the consumer's append contract)
+    // instead of splicing the oldest unflushed tokens out of the middle of
+    // displayed+persisted content. The previous splice silently corrupted
+    // content; flushing preserves every token. We leave a small headroom so
+    // the next push doesn't immediately re-trigger.
     if (this.tokenBuffer.length > TokenStreamManager.MAX_BUFFER_SIZE) {
-      const dropped = this.tokenBuffer.length - TokenStreamManager.MAX_BUFFER_SIZE;
-      this.tokenBuffer.splice(0, dropped);
-      console.warn(`[TokenStreamManager] Buffer overflow: dropped ${dropped} oldest tokens (max ${TokenStreamManager.MAX_BUFFER_SIZE})`);
+      this.flushBuffer();
     }
   }
 
   /**
    * Schedule a requestAnimationFrame flush of the token buffer.
+   *
+   * S4: when the document is hidden (tab in background), RAF is suspended and
+   * the buffer would accrue unbounded until the tab refocuses. Use a setTimeout
+   * fallback so tokens still flush in background tabs.
    */
   private scheduleFlush(): void {
-    this.flushTimer = requestAnimationFrame(() => {
-      this.flushTimer = null;
-      this.flushBuffer();
-    });
+    const useTimeoutFallback = typeof document !== 'undefined' && document.visibilityState === 'hidden';
+    if (useTimeoutFallback) {
+      this.flushTimer = window.setTimeout(() => {
+        this.flushTimer = null;
+        this.flushBuffer();
+      }, 100) as unknown as number;
+    } else {
+      this.flushTimer = requestAnimationFrame(() => {
+        this.flushTimer = null;
+        this.flushBuffer();
+      });
+    }
   }
 
   /**
@@ -222,8 +238,15 @@ export class TokenStreamManager {
 
   /**
    * Cancel any active stream and clear pending operations.
+   *
+   * S4: FLUSH buffered tokens to the callback BEFORE clearing, so Stop
+   * delivers every token received up to the cancel (previously cancel() nulled
+   * the buffer without flushing, dropping up to a RAF frame of tokens — far
+   * more after a hidden tab). Mirrors the flush-first contract of complete()
+   * and error().
    */
   cancel(): void {
+    if (this.cancelled) return;
     this.cancelled = true;
 
     if (this.activeConsumer) {
@@ -231,16 +254,20 @@ export class TokenStreamManager {
       this.activeConsumer = null;
     }
 
+    // Flush remaining tokens so Stop doesn't drop them, THEN clear.
+    this.flushBuffer();
     this.clearFlushTimer();
-    this.tokenBuffer = [];
   }
 
   /**
-   * Clear any pending RAF flush timer.
+   * Clear any pending flush timer (RAF or setTimeout fallback).
    */
   private clearFlushTimer(): void {
     if (this.flushTimer !== null) {
+      // The timer may be either a RAF handle or a setTimeout handle. Use both
+      // cancellers defensively (each is a no-op for the wrong type).
       cancelAnimationFrame(this.flushTimer);
+      clearTimeout(this.flushTimer);
       this.flushTimer = null;
     }
   }

--- a/web_ui/src/pages/ChatPage.init.test.tsx
+++ b/web_ui/src/pages/ChatPage.init.test.tsx
@@ -160,6 +160,10 @@ describe('ChatPage F1 — LLM init before generation (cold send)', () => {
         onMessagesChange={() => {}}
         onSaveConversation={() => {}}
         onNewChat={() => {}}
+        currentConversationId={undefined}
+
+        setCurrentConversationId={() => {}}
+
         onOpenSettings={() => {}}
       />
     );
@@ -203,6 +207,10 @@ describe('ChatPage F1 — LLM init before generation (cold send)', () => {
         onMessagesChange={() => {}}
         onSaveConversation={() => {}}
         onNewChat={() => {}}
+        currentConversationId={undefined}
+
+        setCurrentConversationId={() => {}}
+
         onOpenSettings={() => {}}
       />
     );

--- a/web_ui/src/pages/ChatPage.keyboard-guard.test.tsx
+++ b/web_ui/src/pages/ChatPage.keyboard-guard.test.tsx
@@ -113,6 +113,10 @@ describe('ChatPage — Ctrl+Enter guard while model-blocked (F-CTRL-ENTER-BYPASS
         onMessagesChange={() => {}}
         onSaveConversation={() => {}}
         onNewChat={() => {}}
+        currentConversationId={undefined}
+
+        setCurrentConversationId={() => {}}
+
         onOpenSettings={() => {}}
       />
     );

--- a/web_ui/src/pages/ChatPage.overlay.test.tsx
+++ b/web_ui/src/pages/ChatPage.overlay.test.tsx
@@ -144,6 +144,10 @@ function renderChatPage(onOpenSettings: () => void = () => {}) {
       onMessagesChange={() => {}}
       onSaveConversation={() => {}}
       onNewChat={() => {}}
+      currentConversationId={undefined}
+
+      setCurrentConversationId={() => {}}
+
       onOpenSettings={onOpenSettings}
     />
   );

--- a/web_ui/src/pages/ChatPage.rag.test.tsx
+++ b/web_ui/src/pages/ChatPage.rag.test.tsx
@@ -164,6 +164,10 @@ describe('ChatPage RAG Pipeline Integration', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
     submitMessage(userText);
@@ -196,6 +200,10 @@ describe('ChatPage RAG Pipeline Integration', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
     submitMessage(userText);
@@ -232,6 +240,10 @@ describe('ChatPage RAG Pipeline Integration', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
     submitMessage(userText);
@@ -268,6 +280,10 @@ describe('ChatPage RAG Pipeline Integration', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
     submitMessage(userText);
@@ -299,6 +315,10 @@ describe('ChatPage RAG Pipeline Integration', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -329,6 +349,10 @@ describe('ChatPage RAG Pipeline Integration', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
     submitMessage(userText);
@@ -363,6 +387,10 @@ describe('ChatPage RAG Pipeline Integration', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
     submitMessage(userText);
@@ -402,6 +430,10 @@ describe('ChatPage RAG Pipeline Integration', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -457,6 +489,10 @@ describe('ChatPage RAG Pipeline Integration', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
     submitMessage(userText);
@@ -496,6 +532,10 @@ describe('ChatPage RAG Pipeline Integration', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
     submitMessage(userText);
@@ -540,6 +580,10 @@ describe('ChatPage RAG Pipeline Integration', () => {
           onMessagesChange={setMessages}
           onSaveConversation={onSaveConversation}
           onNewChat={onNewChat}
+          currentConversationId={undefined}
+
+          setCurrentConversationId={() => {}}
+
           onOpenSettings={() => {}}
         />
       );
@@ -604,6 +648,10 @@ describe('ChatPage RAG Pipeline Integration', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
     submitMessage(userText);
@@ -648,6 +696,10 @@ describe('ChatPage RAG Pipeline Integration', () => {
           onMessagesChange={setMessages}
           onSaveConversation={onSaveConversation}
           onNewChat={() => {}}
+          currentConversationId={undefined}
+
+          setCurrentConversationId={() => {}}
+
           onOpenSettings={() => {}}
         />
       );

--- a/web_ui/src/pages/ChatPage.server-mode.test.tsx
+++ b/web_ui/src/pages/ChatPage.server-mode.test.tsx
@@ -142,6 +142,10 @@ describe('ChatPage API Mode (Task 8.4)', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -177,6 +181,10 @@ describe('ChatPage API Mode (Task 8.4)', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -211,6 +219,10 @@ describe('ChatPage API Mode (Task 8.4)', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -244,6 +256,10 @@ describe('ChatPage API Mode (Task 8.4)', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -278,6 +294,10 @@ describe('ChatPage API Mode (Task 8.4)', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -307,6 +327,10 @@ describe('ChatPage API Mode (Task 8.4)', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -341,6 +365,10 @@ describe('ChatPage API Mode (Task 8.4)', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -375,6 +403,10 @@ describe('ChatPage API Mode (Task 8.4)', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -414,6 +446,10 @@ describe('ChatPage API Mode (Task 8.4)', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -457,6 +493,10 @@ describe('ChatPage API Mode (Task 8.4)', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -486,6 +526,10 @@ describe('ChatPage API Mode (Task 8.4)', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -531,6 +575,10 @@ describe('ChatPage API Mode (Task 8.4)', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -575,6 +623,10 @@ describe('ChatPage API Mode (Task 8.4)', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -615,6 +667,10 @@ describe('ChatPage API Mode (Task 8.4)', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -643,6 +699,10 @@ describe('ChatPage API Mode (Task 8.4)', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -677,6 +737,10 @@ describe('ChatPage API Mode (Task 8.4)', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -712,6 +776,10 @@ describe('ChatPage API Mode (Task 8.4)', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -752,6 +820,10 @@ describe('ChatPage API Mode (Task 8.4)', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -789,6 +861,10 @@ describe('ChatPage API Mode (Task 8.4)', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -818,6 +894,10 @@ describe('ChatPage API Mode (Task 8.4)', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 

--- a/web_ui/src/pages/ChatPage.shortcuts.test.tsx
+++ b/web_ui/src/pages/ChatPage.shortcuts.test.tsx
@@ -142,6 +142,10 @@ describe('ChatPage Keyboard Shortcuts (Task 8.6)', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -157,6 +161,10 @@ describe('ChatPage Keyboard Shortcuts (Task 8.6)', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -178,6 +186,10 @@ describe('ChatPage Keyboard Shortcuts (Task 8.6)', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={onOpenSettingsSpy}
 />);
 
@@ -192,6 +204,10 @@ describe('ChatPage Keyboard Shortcuts (Task 8.6)', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -218,6 +234,10 @@ describe('ChatPage Keyboard Shortcuts (Task 8.6)', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -253,6 +273,10 @@ describe('ChatPage Keyboard Shortcuts (Task 8.6)', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -291,6 +315,10 @@ describe('ChatPage Keyboard Shortcuts (Task 8.6)', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -313,6 +341,10 @@ describe('ChatPage Keyboard Shortcuts (Task 8.6)', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -351,6 +383,10 @@ describe('ChatPage Keyboard Shortcuts (Task 8.6)', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -371,6 +407,10 @@ describe('ChatPage Keyboard Shortcuts (Task 8.6)', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={onOpenSettingsSpy}
 />);
 

--- a/web_ui/src/pages/ChatPage.streaming-persistence.test.tsx
+++ b/web_ui/src/pages/ChatPage.streaming-persistence.test.tsx
@@ -90,6 +90,7 @@ vi.mock('../lib/api/auth', () => ({
 import { ChatPage } from './ChatPage';
 import * as ragModule from '../lib/rag/rag-orchestrator';
 import * as inferenceModule from '../lib/inference';
+import * as llmFactoryModule from '../lib/llm/llm-factory';
 
 // --- Test helpers -----------------------------------------------------------
 
@@ -327,5 +328,240 @@ describe('ChatPage S1: switch-mid-stream does not corrupt conversation history',
       rePointToA.length,
       'setCurrentConversationId must not re-point back to owning A'
     ).toBe(0);
+  });
+});
+
+/**
+ * F1 regression: first-turn send (currentConversationId=undefined) with a
+ * FAST-COMPLETE stream must NOT create a duplicate conversation.
+ *
+ * The F1 bug (now fixed) was that `handleSend` set
+ * `owningConversationIdRef.current = currentConversationId` synchronously and
+ * relied on `saveMessages`'s `onCreate` callback to update the ref when the
+ * first-turn conversation was created. But `onCreate` fires inside the ASYNC
+ * `saveMessages` after two awaits (a microtask), so on a fast-complete first
+ * turn (warm model / zero-doc abstain that completes synchronously), `onDone`
+ * fired before `onCreate` resolved, read
+ * `owningConversationIdRef.current === undefined`, and created a SECOND
+ * conversation.
+ *
+ * The fix makes `handleSend` `async` and AWAITS the send-time
+ * `onSaveConversation(...)` call, capturing the resolved owning id
+ * (`resolvedOwningId`) via the `onCreate` callback, THEN sets
+ * `owningConversationIdRef.current = resolvedOwningId` and calls
+ * `runGeneration`. This guarantees the ref is set to the created conversation's
+ * id before any stream completion can fire.
+ *
+ * This test simulates the real `saveMessages` create behavior by invoking the
+ * `onCreate` callback (5th arg) synchronously with a fresh id when
+ * `conversationId === undefined`, and uses a fast-completing orchestrator
+ * (yield a token, then immediately `complete` — no gate). The fast completion
+ * would race the `onCreate` callback under the old synchronous-ref code path
+ * and produce a duplicate conversation; under the fix the awaited send ensures
+ * the ref is set first.
+ */
+describe('ChatPage F1: first-turn fast-complete does not create a duplicate conversation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // The S1 describe's afterEach calls vi.restoreAllMocks(), which strips the
+    // mockImplementation set on getLLMService by the hoisted vi.mock() factory.
+    // When this (second) describe runs, getLLMService() would otherwise return
+    // undefined → the orchestrator IIFE throws on llmService.initialize() and
+    // the stream never runs. Re-establish the factory mock here so the F1 test
+    // is self-contained regardless of test ordering.
+    vi.mocked(llmFactoryModule.getLLMService).mockImplementation(() => ({
+      initialize: vi.fn().mockResolvedValue(undefined),
+      interrupt: vi.fn(),
+      supportsImages: vi.fn().mockReturnValue(false),
+    }) as unknown as ReturnType<typeof llmFactoryModule.getLLMService>);
+
+    vi.mocked(inferenceModule.useInferenceMode).mockReturnValue({
+      mode: 'browser-local',
+      browserEngine: 'wllama',
+      ragPreset: 'balanced',
+      isModelReady: true,
+      isServerConnected: true,
+      modelLoadingProgress: 0,
+      modeError: null,
+      serverUrl: '',
+      setMode: vi.fn(),
+      setBrowserEngine: vi.fn(),
+      setRagPreset: vi.fn(),
+      setServerUrl: vi.fn(),
+      checkServerConnectivity: vi.fn(() => Promise.resolve(false)),
+      setModelReady: vi.fn(),
+      setModelLoadingProgress: vi.fn(),
+    } as unknown as ReturnType<typeof inferenceModule.useInferenceMode>);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('completion save targets the just-created conversation id (not undefined) on a fast-complete first turn', async () => {
+    // --- Orchestrator: a FAST-completing stream (token then complete) ----------
+    // No gate / no delay — the stream completes as soon as the orchestrator loop
+    // runs. This is the warm-model / zero-doc-abstain first-turn scenario. Under
+    // the F1 bug, the completion raced saveMessages' onCreate (which fires after
+    // two awaits inside saveMessages) and read owningConversationId===undefined,
+    // creating a duplicate. Under the fix, handleSend AWAITS the send-time save
+    // (with its synchronous onCreate), so the ref is set before runGeneration.
+    const orchestrator = { query: vi.fn() };
+    vi.mocked(ragModule.RAGOrchestrator).mockImplementation(
+      () => orchestrator as unknown as ragModule.RAGOrchestrator
+    );
+    orchestrator.query.mockImplementation(async function* (): AsyncGenerator<RAGEvent> {
+      yield { type: 'token', data: 'FAST-' };
+      yield {
+        type: 'complete',
+        data: { answer: 'FAST-ANSWER', sources: [], chunks: [] },
+      };
+    });
+
+    // --- onSaveConversation: simulate the REAL saveMessages create behavior ---
+    // The real saveMessages is ASYNC and only fires onCreate INSIDE its async
+    // body after a couple of awaits (microtasks) — this is what produced the F1
+    // race: a fast-complete stream's onDone fired before onCreate resolved, read
+    // the still-undefined owningConversationIdRef, and created a duplicate. We
+    // mirror that timing here by returning a Promise that fires onCreate after a
+    // handful of microtasks. To GUARANTEE the F1 race is observable when the fix
+    // is absent, onCreate is deferred by enough microtasks that a fast-completing
+    // orchestrator (warm model — initialize resolves immediately, then a token
+    // and complete) fires onDone FIRST. Under the fix, handleSend AWAITS this
+    // save, so runGeneration cannot start until onCreate has resolved the ref —
+    // the race is eliminated regardless of relative timing.
+    let createCounter = 0;
+    const calls: Array<{ id: string | undefined; messages: ChatMessage[] }> = [];
+    const onSaveConversation = vi.fn(
+      (id: string | undefined, messages: ChatMessage[], _mode: string, _model: string, onCreate?: (newId: string) => void) => {
+        calls.push({ id, messages });
+        // Return a Promise (the real saveMessages is async) and fire onCreate
+        // from within several microtasks — slower than a fast-complete stream,
+        // reproducing the F1 race when the fix's `await` is removed.
+        return (async () => {
+          for (let i = 0; i < 8; i++) {
+            await Promise.resolve();
+          }
+          if (id === undefined && onCreate) {
+            createCounter += 1;
+            onCreate('NEW_CONV_' + createCounter);
+          }
+        })();
+      }
+    );
+    const setCurrentConversationId = vi.fn();
+
+    // --- Harness: first turn (no current conversation, empty messages) --------
+    type View = { convId: string | undefined; messages: ChatMessage[] };
+    let view: View = { convId: undefined, messages: [] };
+
+    function Harness() {
+      return (
+        <ChatPage
+          messages={view.messages}
+          onMessagesChange={(next) => {
+            view = {
+              ...view,
+              messages:
+                typeof next === 'function'
+                  ? (next as (p: ChatMessage[]) => ChatMessage[])(view.messages)
+                  : next,
+            };
+          }}
+          onSaveConversation={onSaveConversation}
+          currentConversationId={view.convId}
+          setCurrentConversationId={(id: string | undefined) => {
+            setCurrentConversationId(id);
+            // Mirror the parent (App) lifting the new id into state so the
+            // re-render observes it (keeps the test realistic w.r.t. App).
+            view = { ...view, convId: id };
+          }}
+          onNewChat={() => {}}
+          onOpenSettings={() => {}}
+        />
+      );
+    }
+
+    render(<Harness />);
+
+    // --- Trigger a send on the first turn (no current conversation) ----------
+    const textarea = screen.getByRole('textbox');
+    const sendButton = screen.getByRole('button', { name: /send message/i });
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: 'FIRST-TURN-QUESTION' } });
+      fireEvent.click(sendButton);
+    });
+
+    // Flush microtasks so initialize() resolves, the orchestrator loop runs to
+    // completion (token + complete), onDone fires, AND (under the fix) the
+    // send-time save's deferred onCreate resolves before runGeneration starts.
+    // We flush enough microtasks to cover both the fast-complete stream and the
+    // 8-microtask deferral the onSaveConversation mock uses to simulate the
+    // real saveMessages' async onCreate timing.
+    await act(async () => {
+      for (let i = 0; i < 24; i++) {
+        await Promise.resolve();
+      }
+    });
+
+    // === F1 ASSERTIONS =====================================================
+
+    // (1) Exactly ONE create call: exactly one onSaveConversation call had
+    //     conversationId === undefined. Under the F1 bug, onDone would also
+    //     save with undefined (because owningConversationIdRef.current was
+    //     still undefined when onDone fired), producing a SECOND create →
+    //     duplicate conversation. The fix awaits the send-time save so the
+    //     ref is set before onDone, and only ONE create ever happens.
+    const createCalls = calls.filter((c) => c.id === undefined);
+    expect(
+      createCalls.length,
+      'exactly one create (undefined-id) save must happen — a second would be a duplicate conversation'
+    ).toBe(1);
+
+    // (2) The COMPLETION (onDone) save must have a DEFINED conversation id —
+    //     specifically the just-created 'NEW_CONV_1'. This is the CRITICAL F1
+    //     assertion: before the fix it would be undefined (stale owning id
+    //     closure), creating a duplicate conversation. Identify the completion
+    //     save as the one carrying an assistant message with `sources` set.
+    const completionCalls = calls.filter((c) =>
+      c.messages.some((m) => m.role === 'assistant' && Array.isArray(m.sources))
+    );
+    expect(
+      completionCalls.length,
+      'completion (onDone) save must fire after the fast-complete stream'
+    ).toBeGreaterThanOrEqual(1);
+
+    const lastCompletion = completionCalls[completionCalls.length - 1];
+    expect(
+      lastCompletion.id,
+      'completion save must use a DEFINED conversation id (the just-created one), NOT undefined — undefined would create a duplicate conversation (F1 bug)'
+    ).toBeDefined();
+    expect(
+      lastCompletion.id,
+      'completion save must target the just-created NEW_CONV_1, not a later/different id'
+    ).toBe('NEW_CONV_1');
+
+    // (3) Across the WHOLE interaction, exactly ONE create happened (already
+    //     asserted above) and the total number of undefined-id saves is 1.
+    //     Belt-and-braces: re-iterate the duplicate-conversation contract by
+    //     confirming every save AFTER the first create uses a defined id.
+    let sawCreate = false;
+    for (const c of calls) {
+      if (c.id === undefined) {
+        expect(
+          sawCreate,
+          'only one undefined-id (create) save is allowed across the whole interaction'
+        ).toBe(false);
+        sawCreate = true;
+      } else {
+        // Any defined-id save must be the just-created id (no spurious others).
+        expect(c.id).toBe('NEW_CONV_1');
+      }
+    }
+
+    // (4) setCurrentConversationId must have been called with 'NEW_CONV_1' so
+    //     the freshly created conversation becomes the active one (H4 + F1).
+    expect(setCurrentConversationId).toHaveBeenCalledWith('NEW_CONV_1');
   });
 });

--- a/web_ui/src/pages/ChatPage.streaming-persistence.test.tsx
+++ b/web_ui/src/pages/ChatPage.streaming-persistence.test.tsx
@@ -565,3 +565,728 @@ describe('ChatPage F1: first-turn fast-complete does not create a duplicate conv
     expect(setCurrentConversationId).toHaveBeenCalledWith('NEW_CONV_1');
   });
 });
+
+// ============================================================================
+// PR #38 — persistence-of-partial-turn regression suite (PRR-001 / 005 / 006a/b)
+//
+// These tests guard the fix that an in-flight assistant turn is NEVER silently
+// dropped when it is interrupted by: a conversation switch (PRR-001), a user
+// Stop (PRR-005), an unmount (PRR-006a), or an engine switch (PRR-006b). In all
+// four cases the finalized (isStreaming stripped) partial content must be
+// persisted to the OWNING conversation id via onSaveConversation.
+//
+// Each test is a TRUE regression test: if the corresponding persist call were
+// removed from ChatPage.tsx, the test would fail.
+//
+// The tests reuse the same hoisted module mocks as the S1/F1 tests above
+// (RAGOrchestrator, llm-factory, inference, readiness-gate, auth). They only
+// re-establish per-describe mock implementations because vi.restoreAllMocks()
+// in the prior describe's afterEach strips the factory implementations.
+// ============================================================================
+
+/**
+ * Shared helpers for the PR #38 persistence-of-partial-turn tests.
+ *
+ * The lifted-view <Harness> pattern (inline in each test) mounts the REAL
+ * ChatPage so the test can flip currentConversationId / messages / browserEngine
+ * to simulate the parent (App) switching conversations or engines mid-stream.
+ *
+ * `flushRafFrames` advances real timers enough for jsdom's requestAnimationFrame
+ * polyfill to fire, so tokens buffered in TokenStreamManager reach the onToken
+ * callback (and thus messagesRef). We use REAL timers (not fake) here because
+ * the persistence assertions must observe messagesRef populated by a real RAF
+ * flush — the production code relies on the RAF flush contract.
+ *
+ * `waitForPartialContent` POLLs the lifted view's messages for a token,
+ * interleaving microtask flushes (advances the async orchestrator loop) with
+ * RAF flushes (delivers buffered tokens to messagesRef). This eliminates the
+ * brittle microtask-count + RAF race: it returns as soon as the partial
+ * assistant content is observable, regardless of how loaded the event loop is.
+ * Bounded iteration count keeps it deterministic (fails fast if the token never
+ * arrives rather than hanging).
+ */
+function flushRafFrames(frames = 3): Promise<void> {
+  // jsdom polyfills requestAnimationFrame via setTimeout(~16ms). Advancing the
+  // event loop with a handful of zero-delay macrotasks lets the queued RAF
+  // callbacks fire. Wrapped so callers can `await flushRafFrames()` inside act.
+  return new Promise<void>((resolve) => {
+    let remaining = frames;
+    const tick = () => {
+      remaining -= 1;
+      if (remaining <= 0) resolve();
+      else setTimeout(tick, 0);
+    };
+    setTimeout(tick, 0);
+  });
+}
+
+/**
+ * Poll `getMessages()` (the lifted view's current messages) until an assistant
+ * message contains `partialToken`, flushing microtasks + RAF each iteration.
+ * Throws after `maxIters` if the token never appears (deterministic failure
+ * rather than a hang). Use this instead of a fixed microtask count so the test
+ * is robust to event-loop load (the orchestrator's async loop + RAF scheduling
+ * race under the default vitest pool).
+ */
+async function waitForPartialContent(
+  getMessages: () => ChatMessage[],
+  partialToken: string,
+  maxIters = 40
+): Promise<void> {
+  for (let i = 0; i < maxIters; i++) {
+    await Promise.resolve();
+    await Promise.resolve();
+    await flushRafFrames(2);
+    const msgs = getMessages();
+    const has = msgs.some(
+      (m) => m.role === 'assistant' && typeof m.content === 'string' && m.content.includes(partialToken)
+    );
+    if (has) return;
+  }
+  throw new Error(
+    `waitForPartialContent: token "${partialToken}" never appeared in messages after ${maxIters} iterations`
+  );
+}
+
+/**
+ * A deferred-gate AsyncGenerator that:
+ *   - yields a token immediately (so partial content is non-empty),
+ *   - PARKS on `gate` (the stream stays open, NOT completed),
+ *   - (the test never resolves the gate — we test the INTERRUPTED case).
+ *
+ * This parks the stream so tokenStreamManagerRef.current stays non-null and
+ * `cancel()` is never invoked by the orchestrator completing — the only way
+ * the partial turn gets persisted is the explicit persist path under test.
+ */
+function makeParkingStream(
+  gate: { promise: Promise<void>; resolve: () => void },
+  token: string
+): () => AsyncGenerator<RAGEvent> {
+  return async function* (): AsyncGenerator<RAGEvent> {
+    yield { type: 'token', data: token };
+    await gate.promise;
+    // Unreachable in the interrupted tests — the gate is never resolved.
+    yield { type: 'complete', data: { answer: token, sources: [], chunks: [] } };
+  };
+}
+
+describe('ChatPage PRR-001: switch mid-stream PERSISTS the partial turn to the owning conversation A', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Re-establish the factory mocks (see F1 describe for rationale).
+    vi.mocked(llmFactoryModule.getLLMService).mockImplementation(() => ({
+      initialize: vi.fn().mockResolvedValue(undefined),
+      interrupt: vi.fn(),
+      supportsImages: vi.fn().mockReturnValue(false),
+    }) as unknown as ReturnType<typeof llmFactoryModule.getLLMService>);
+    vi.mocked(inferenceModule.useInferenceMode).mockReturnValue({
+      mode: 'browser-local',
+      browserEngine: 'wllama',
+      ragPreset: 'balanced',
+      isModelReady: true,
+      isServerConnected: true,
+      modelLoadingProgress: 0,
+      modeError: null,
+      serverUrl: '',
+      setMode: vi.fn(),
+      setBrowserEngine: vi.fn(),
+      setRagPreset: vi.fn(),
+      setServerUrl: vi.fn(),
+      checkServerConnectivity: vi.fn(() => Promise.resolve(false)),
+      setModelReady: vi.fn(),
+      setModelLoadingProgress: vi.fn(),
+    } as unknown as ReturnType<typeof inferenceModule.useInferenceMode>);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('a mid-stream switch to B triggers a save targeting OWNING A with the partial assistant content (isStreaming stripped)', async () => {
+    const gate = makeDeferred();
+    const PARTIAL_TOKEN = 'PARTIAL-A-';
+
+    const orchestrator = { query: vi.fn() };
+    vi.mocked(ragModule.RAGOrchestrator).mockImplementation(
+      () => orchestrator as unknown as ragModule.RAGOrchestrator
+    );
+    orchestrator.query.mockImplementation(makeParkingStream(gate, PARTIAL_TOKEN));
+
+    const onSaveConversation = vi.fn();
+    const setCurrentConversationId = vi.fn();
+
+    const aUserMsg = makeMessage('user', 'A-QUESTION');
+    const bUserMsg = makeMessage('user', 'B-QUESTION');
+
+    type View = { convId: string; messages: ChatMessage[] };
+    let view: View = { convId: 'A', messages: [aUserMsg] };
+
+    function Harness() {
+      return (
+        <ChatPage
+          messages={view.messages}
+          onMessagesChange={(next) => {
+            view = {
+              ...view,
+              messages:
+                typeof next === 'function'
+                  ? (next as (p: ChatMessage[]) => ChatMessage[])(view.messages)
+                  : next,
+            };
+          }}
+          onSaveConversation={onSaveConversation}
+          currentConversationId={view.convId}
+          setCurrentConversationId={setCurrentConversationId}
+          onNewChat={() => {}}
+          onOpenSettings={() => {}}
+        />
+      );
+    }
+
+    const { rerender } = render(<Harness />);
+
+    // --- Step 1: send a message in A; the stream parks after one token ------
+    const textarea = screen.getByRole('textbox');
+    const sendButton = screen.getByRole('button', { name: /send message/i });
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: 'A-QUESTION' } });
+      fireEvent.click(sendButton);
+    });
+
+    // Let initialize() resolve and the orchestrator yield the token + park.
+    // POLL for the partial token to reach the lifted view's messages (via the
+    // real RAF flush path) instead of a fixed microtask count — robust to
+    // event-loop load under the vitest pool.
+    await act(async () => {
+      await waitForPartialContent(() => view.messages, PARTIAL_TOKEN);
+    });
+
+    // Clear send-time noise so the SWITCH save is cleanly isolated below.
+    onSaveConversation.mockClear();
+    setCurrentConversationId.mockClear();
+
+    // --- Step 2: switch to B WITHOUT completing the stream ------------------
+    // The PRR-001 switch effect (ChatPage.tsx ~146-174) finalizes the OWNING
+    // conversation's partial turn (read from owningMessagesRef, the send-time
+    // snapshot) and calls onSaveConversation(owningId=A, finalized, ...) before
+    // canceling the stream. This is the PRR-001 fix: previously the switch only
+    // canceled, dropping the partial turn (cancel() never fires onDone/onError).
+    //
+    // Regression proof: if the switch effect's `onSaveConversation(owningId, ...)`
+    // line is removed, this test FAILS (no save targets A) — verified by
+    // temporarily deleting that line. (The unmount-cleanup effect is now
+    // unmount-only via its `[]` dep, so it no longer masks the switch path on a
+    // conversation switch.)
+    await act(async () => {
+      view = { convId: 'B', messages: [bUserMsg] };
+      rerender(<Harness />);
+    });
+    // Flush the switch effect + any tail microtasks/frames.
+    await act(async () => {
+      await flushRafFrames(2);
+      await Promise.resolve();
+    });
+
+    // === PRR-001 ASSERTIONS =================================================
+
+    // (1) A save targeting the OWNING conversation A must have fired. If the
+    //     switch effect's `onSaveConversation(owningId, finalized, ...)` line
+    //     were removed, NO save would target A here (cancel alone never saves).
+    const saveToA = onSaveConversation.mock.calls.filter(([id]) => id === 'A');
+    expect(
+      saveToA.length,
+      'switch mid-stream MUST persist the partial turn to owning conversation A (PRR-001)'
+    ).toBeGreaterThanOrEqual(1);
+
+    // (2) The persisted messages must contain the PARTIAL assistant content
+    //     (the token that streamed before the switch), with isStreaming
+    //     stripped. This proves the partial answer was not lost.
+    const lastSaveToA = saveToA[saveToA.length - 1];
+    const savedMessages = lastSaveToA[1] as ChatMessage[];
+    const assistantMsgs = savedMessages.filter((m) => m.role === 'assistant');
+    expect(assistantMsgs.length, 'an assistant message must be present in the persisted turn').toBeGreaterThanOrEqual(1);
+    const partialAssistant = assistantMsgs.find((m) => m.content.includes(PARTIAL_TOKEN));
+    expect(
+      partialAssistant,
+      `persisted assistant content must include the streamed partial token "${PARTIAL_TOKEN}"`
+    ).toBeDefined();
+    expect(
+      partialAssistant!.isStreaming,
+      'persisted partial assistant message must have isStreaming stripped (no blinking cursor persisted)'
+    ).toBeFalsy();
+
+    // (3) No save may target B (the switched-TO conversation) for the partial
+    //     turn — the partial belongs to A, the conversation that produced it.
+    const saveToB = onSaveConversation.mock.calls.filter(([id]) => id === 'B');
+    expect(
+      saveToB.length,
+      'partial turn from A must NOT be persisted to B (the switched-TO conversation)'
+    ).toBe(0);
+  });
+});
+
+/**
+ * PRR-005 regression: handleCancel must persist the cancel-flushed tail tokens.
+ *
+ * The bug was that handleCancel snapshotted messagesRef BEFORE calling
+ * cancelActiveStream(). TokenStreamManager.cancel() flushes the token buffer
+ * synchronously (S4) via onToken → which appends to messagesRef — so a
+ * pre-cancel snapshot missed every token still buffered at cancel time (up to
+ * a RAF frame, far more in a background tab). The fix reads messagesRef AFTER
+ * cancelActiveStream().
+ *
+ * Timing approach (deterministic, no brittle microtask counts):
+ *   - We use FAKE TIMERS so the RAF that TokenStreamManager.pushToken schedules
+ *     does NOT auto-fire. Tokens therefore stay buffered in tokenBuffer and
+ *     never reach onToken/messagesRef during streaming.
+ *   - We push several tokens (they buffer).
+ *   - We click Stop. handleCancel → cancelActiveStream() →
+ *     TokenStreamManager.cancel() → flushBuffer() → onToken(joined) fires
+ *     SYNCHRONOUSLY, appending ALL buffered tokens to messagesRef. THEN
+ *     handleCancel reads messagesRef.current (post-fix) and persists.
+ *   - If handleCancel still snapshotted before cancel (the bug), the persisted
+ *     content would contain ZERO streamed tokens (the buffer was never flushed
+ *     into messagesRef before cancel ran).
+ *
+ * Fake timers do NOT block Promise microtasks, so the async orchestrator loop
+ * still advances and calls pushToken; only the macrotask-driven RAF is gated.
+ */
+describe('ChatPage PRR-005: handleCancel preserves cancel-flushed tail tokens', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(llmFactoryModule.getLLMService).mockImplementation(() => ({
+      initialize: vi.fn().mockResolvedValue(undefined),
+      interrupt: vi.fn(),
+      supportsImages: vi.fn().mockReturnValue(false),
+    }) as unknown as ReturnType<typeof llmFactoryModule.getLLMService>);
+    vi.mocked(inferenceModule.useInferenceMode).mockReturnValue({
+      mode: 'browser-local',
+      browserEngine: 'wllama',
+      ragPreset: 'balanced',
+      isModelReady: true,
+      isServerConnected: true,
+      modelLoadingProgress: 0,
+      modeError: null,
+      serverUrl: '',
+      setMode: vi.fn(),
+      setBrowserEngine: vi.fn(),
+      setRagPreset: vi.fn(),
+      setServerUrl: vi.fn(),
+      checkServerConnectivity: vi.fn(() => Promise.resolve(false)),
+      setModelReady: vi.fn(),
+      setModelLoadingProgress: vi.fn(),
+    } as unknown as ReturnType<typeof inferenceModule.useInferenceMode>);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('Stop persists the FULL streamed content including tokens that were buffered (unflushed) at cancel time', async () => {
+    vi.useFakeTimers();
+
+    // Three tokens pushed in sequence; all stay buffered (RAF never fires under
+    // fake timers), so messagesRef's assistant content is EMPTY until cancel()
+    // flushes the buffer.
+    const TOKENS = ['T1-', 'T2-', 'T3-TAIL'];
+    const FULL = TOKENS.join('');
+
+    const orchestrator = { query: vi.fn() };
+    vi.mocked(ragModule.RAGOrchestrator).mockImplementation(
+      () => orchestrator as unknown as ragModule.RAGOrchestrator
+    );
+    orchestrator.query.mockImplementation(async function* (): AsyncGenerator<RAGEvent> {
+      for (const t of TOKENS) {
+        yield { type: 'token', data: t };
+      }
+      // Park forever — the user cancels before completion. The stream is
+      // intentionally never completed so the ONLY persist path is handleCancel.
+      await new Promise<void>(() => {});
+    });
+
+    const onSaveConversation = vi.fn();
+    const setCurrentConversationId = vi.fn();
+
+    const userMsg = makeMessage('user', 'Q');
+    type View = { convId: string; messages: ChatMessage[] };
+    let view: View = { convId: 'A', messages: [userMsg] };
+
+    function Harness() {
+      return (
+        <ChatPage
+          messages={view.messages}
+          onMessagesChange={(next) => {
+            view = {
+              ...view,
+              messages:
+                typeof next === 'function'
+                  ? (next as (p: ChatMessage[]) => ChatMessage[])(view.messages)
+                  : next,
+            };
+          }}
+          onSaveConversation={onSaveConversation}
+          currentConversationId={view.convId}
+          setCurrentConversationId={setCurrentConversationId}
+          onNewChat={() => {}}
+          onOpenSettings={() => {}}
+        />
+      );
+    }
+
+    render(<Harness />);
+
+    const textarea = screen.getByRole('textbox');
+    const sendButton = screen.getByRole('button', { name: /send message/i });
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: 'Q' } });
+      fireEvent.click(sendButton);
+    });
+
+    // Advance microtasks (NOT macrotimers) so initialize() resolves and the
+    // orchestrator yields all three tokens into the TokenStreamManager buffer.
+    // Fake timers do not block Promise microtask resolution, so the for-await
+    // loop advances. We do NOT advance fake timers, so the scheduled RAF never
+    // fires — tokens remain buffered and messagesRef's assistant content is
+    // still empty.
+    await act(async () => {
+      for (let i = 0; i < 12; i++) await Promise.resolve();
+    });
+
+    // Isolate the CANCEL save from the send-time save.
+    onSaveConversation.mockClear();
+
+    // --- Click Stop ----------------------------------------------------------
+    // handleCancel: captures owningId, calls cancelActiveStream() (which calls
+    // TokenStreamManager.cancel() → flushBuffer() → onToken(FULL) synchronously,
+    // appending ALL buffered tokens to messagesRef), THEN reads
+    // messagesRef.current (post-fix) to build `finalized` and persists.
+    const stopButton = screen.getByRole('button', { name: /stop generation/i });
+    await act(async () => {
+      fireEvent.click(stopButton);
+    });
+    // Flush React commit + any trailing microtasks.
+    await act(async () => {
+      for (let i = 0; i < 4; i++) await Promise.resolve();
+    });
+
+    vi.useRealTimers();
+
+    // === PRR-005 ASSERTIONS =================================================
+
+    // (1) handleCancel persisted exactly one save targeting the owning A.
+    const cancelSaves = onSaveConversation.mock.calls.filter(([id]) => id === 'A');
+    expect(
+      cancelSaves.length,
+      'handleCancel must persist the finalized turn to owning A'
+    ).toBeGreaterThanOrEqual(1);
+    const lastCancel = cancelSaves[cancelSaves.length - 1];
+    const persistedMessages = lastCancel[1] as ChatMessage[];
+
+    // (2) The persisted assistant content MUST contain the FULL streamed
+    //     content, INCLUDING the tail token "T3-TAIL" that was buffered
+    //     (unflushed) at cancel time. Under the PRR-005 bug, messagesRef was
+    //     snapshotted BEFORE cancel flushed the buffer, so NONE of the buffered
+    //     tokens (the entire content, since the RAF never fired under fake
+    //     timers) would appear — the assertion would fail.
+    const assistantMsgs = persistedMessages.filter((m) => m.role === 'assistant');
+    expect(assistantMsgs.length, 'an assistant message must be persisted').toBeGreaterThanOrEqual(1);
+    const persistedContent = assistantMsgs.map((m) => m.content).join('');
+    expect(
+      persistedContent,
+      'persisted assistant content must include the cancel-flushed tail token "T3-TAIL" (PRR-005)'
+    ).toContain('T3-TAIL');
+    expect(
+      persistedContent,
+      'persisted assistant content must equal the FULL streamed content (all buffered tokens flushed during cancel)'
+    ).toBe(FULL);
+
+    // (3) The persisted assistant message has isStreaming stripped.
+    expect(
+      assistantMsgs.every((m) => !m.isStreaming),
+      'persisted partial assistant message must have isStreaming stripped'
+    ).toBe(true);
+  });
+});
+
+/**
+ * PRR-006a regression: unmounting ChatPage mid-stream must persist the finalized
+ * partial turn. The unmount-cleanup effect (ChatPage.tsx ~247-271) checks
+ * tokenStreamManagerRef.current !== null, finalizes messagesRef (strips
+ * isStreaming), and persists via persistOnUnmountRef. If that persist branch
+ * were removed, the partial turn would be silently dropped on unmount (e.g.
+ * navigating away mid-generation).
+ */
+describe('ChatPage PRR-006a: unmount mid-stream PERSISTS the finalized partial turn', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(llmFactoryModule.getLLMService).mockImplementation(() => ({
+      initialize: vi.fn().mockResolvedValue(undefined),
+      interrupt: vi.fn(),
+      supportsImages: vi.fn().mockReturnValue(false),
+    }) as unknown as ReturnType<typeof llmFactoryModule.getLLMService>);
+    vi.mocked(inferenceModule.useInferenceMode).mockReturnValue({
+      mode: 'browser-local',
+      browserEngine: 'wllama',
+      ragPreset: 'balanced',
+      isModelReady: true,
+      isServerConnected: true,
+      modelLoadingProgress: 0,
+      modeError: null,
+      serverUrl: '',
+      setMode: vi.fn(),
+      setBrowserEngine: vi.fn(),
+      setRagPreset: vi.fn(),
+      setServerUrl: vi.fn(),
+      checkServerConnectivity: vi.fn(() => Promise.resolve(false)),
+      setModelReady: vi.fn(),
+      setModelLoadingProgress: vi.fn(),
+    } as unknown as ReturnType<typeof inferenceModule.useInferenceMode>);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('unmount triggers an onSaveConversation call with the finalized partial content (isStreaming stripped)', async () => {
+    const gate = makeDeferred();
+    const PARTIAL_TOKEN = 'UNMOUNT-PARTIAL-';
+
+    const orchestrator = { query: vi.fn() };
+    vi.mocked(ragModule.RAGOrchestrator).mockImplementation(
+      () => orchestrator as unknown as ragModule.RAGOrchestrator
+    );
+    orchestrator.query.mockImplementation(makeParkingStream(gate, PARTIAL_TOKEN));
+
+    const onSaveConversation = vi.fn();
+    const setCurrentConversationId = vi.fn();
+
+    const userMsg = makeMessage('user', 'Q');
+    type View = { convId: string; messages: ChatMessage[] };
+    let view: View = { convId: 'A', messages: [userMsg] };
+
+    function Harness() {
+      return (
+        <ChatPage
+          messages={view.messages}
+          onMessagesChange={(next) => {
+            view = {
+              ...view,
+              messages:
+                typeof next === 'function'
+                  ? (next as (p: ChatMessage[]) => ChatMessage[])(view.messages)
+                  : next,
+            };
+          }}
+          onSaveConversation={onSaveConversation}
+          currentConversationId={view.convId}
+          setCurrentConversationId={setCurrentConversationId}
+          onNewChat={() => {}}
+          onOpenSettings={() => {}}
+        />
+      );
+    }
+
+    const { unmount } = render(<Harness />);
+
+    // Send + let the token flush into messagesRef, then park.
+    const textarea = screen.getByRole('textbox');
+    const sendButton = screen.getByRole('button', { name: /send message/i });
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: 'Q' } });
+      fireEvent.click(sendButton);
+    });
+    await act(async () => {
+      await waitForPartialContent(() => view.messages, PARTIAL_TOKEN);
+    });
+
+    // Clear the send-time save so the UNMOUNT save is isolated.
+    onSaveConversation.mockClear();
+
+    // --- Unmount mid-stream -------------------------------------------------
+    await act(async () => {
+      unmount();
+    });
+
+    // === PRR-006a ASSERTIONS ================================================
+
+    // (1) onSaveConversation fired on unmount with finalized content. If the
+    //     unmount-cleanup's persist branch were removed, this would be empty.
+    expect(
+      onSaveConversation.mock.calls.length,
+      'unmount mid-stream MUST persist the finalized partial turn (PRR-006a)'
+    ).toBeGreaterThanOrEqual(1);
+
+    const lastCall = onSaveConversation.mock.calls[onSaveConversation.mock.calls.length - 1];
+    const [unmountId, unmountMessages] = lastCall;
+
+    // (2) The persisted messages contain the partial assistant content (the
+    //     token that streamed before unmount), with isStreaming stripped.
+    const assistantMsgs = (unmountMessages as ChatMessage[]).filter((m) => m.role === 'assistant');
+    expect(assistantMsgs.length, 'an assistant message must be persisted on unmount').toBeGreaterThanOrEqual(1);
+    const partial = assistantMsgs.find((m) => m.content.includes(PARTIAL_TOKEN));
+    expect(
+      partial,
+      `persisted assistant content must include the streamed partial token "${PARTIAL_TOKEN}"`
+    ).toBeDefined();
+    expect(
+      partial!.isStreaming,
+      'persisted partial assistant message must have isStreaming stripped on unmount'
+    ).toBeFalsy();
+
+    // (3) The unmount save targets the owning conversation A.
+    expect(unmountId, 'unmount persist must target the owning conversation A').toBe('A');
+  });
+});
+
+/**
+ * PRR-006b regression: switching the browser engine mid-stream must persist the
+ * finalized partial turn. The engine-switch effect (ChatPage.tsx ~201-228)
+ * detects prev !== browserEngine while a stream is active, finalizes
+ * messagesRef (strips isStreaming), and persists via onSaveConversation. If that
+ * persist branch were removed, the partial turn would be lost on engine switch.
+ */
+describe('ChatPage PRR-006b: engine switch mid-stream PERSISTS the finalized partial turn to the owning conversation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(llmFactoryModule.getLLMService).mockImplementation(() => ({
+      initialize: vi.fn().mockResolvedValue(undefined),
+      interrupt: vi.fn(),
+      supportsImages: vi.fn().mockReturnValue(false),
+    }) as unknown as ReturnType<typeof llmFactoryModule.getLLMService>);
+    vi.mocked(inferenceModule.useInferenceMode).mockReturnValue({
+      mode: 'browser-local',
+      browserEngine: 'wllama',
+      ragPreset: 'balanced',
+      isModelReady: true,
+      isServerConnected: true,
+      modelLoadingProgress: 0,
+      modeError: null,
+      serverUrl: '',
+      setMode: vi.fn(),
+      setBrowserEngine: vi.fn(),
+      setRagPreset: vi.fn(),
+      setServerUrl: vi.fn(),
+      checkServerConnectivity: vi.fn(() => Promise.resolve(false)),
+      setModelReady: vi.fn(),
+      setModelLoadingProgress: vi.fn(),
+    } as unknown as ReturnType<typeof inferenceModule.useInferenceMode>);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('switching browserEngine to web-llm mid-stream triggers a save with the finalized partial content targeting owning A', async () => {
+    const gate = makeDeferred();
+    const PARTIAL_TOKEN = 'ENGINE-SWITCH-PARTIAL-';
+
+    const orchestrator = { query: vi.fn() };
+    vi.mocked(ragModule.RAGOrchestrator).mockImplementation(
+      () => orchestrator as unknown as ragModule.RAGOrchestrator
+    );
+    orchestrator.query.mockImplementation(makeParkingStream(gate, PARTIAL_TOKEN));
+
+    const onSaveConversation = vi.fn();
+    const setCurrentConversationId = vi.fn();
+
+    const userMsg = makeMessage('user', 'Q');
+    // The lifted view starts in wllama mode; we flip browserEngine to web-llm
+    // below to simulate an engine switch while streaming.
+    type View = { convId: string; messages: ChatMessage[]; engine: 'wllama' | 'web-llm' };
+    let view: View = { convId: 'A', messages: [userMsg], engine: 'wllama' };
+
+    function Harness() {
+      // useInferenceMode is module-mocked, so we override its return value per
+      // render to reflect the lifted engine. This mirrors how the real
+      // InferenceModeContext would surface an engine change to ChatPage.
+      vi.mocked(inferenceModule.useInferenceMode).mockReturnValue({
+        mode: 'browser-local',
+        browserEngine: view.engine,
+        ragPreset: 'balanced',
+        isModelReady: true,
+        isServerConnected: true,
+        modelLoadingProgress: 0,
+        modeError: null,
+        serverUrl: '',
+        setMode: vi.fn(),
+        setBrowserEngine: vi.fn(),
+        setRagPreset: vi.fn(),
+        setServerUrl: vi.fn(),
+        checkServerConnectivity: vi.fn(() => Promise.resolve(false)),
+        setModelReady: vi.fn(),
+        setModelLoadingProgress: vi.fn(),
+      } as unknown as ReturnType<typeof inferenceModule.useInferenceMode>);
+
+      return (
+        <ChatPage
+          messages={view.messages}
+          onMessagesChange={(next) => {
+            view = {
+              ...view,
+              messages:
+                typeof next === 'function'
+                  ? (next as (p: ChatMessage[]) => ChatMessage[])(view.messages)
+                  : next,
+            };
+          }}
+          onSaveConversation={onSaveConversation}
+          currentConversationId={view.convId}
+          setCurrentConversationId={setCurrentConversationId}
+          onNewChat={() => {}}
+          onOpenSettings={() => {}}
+        />
+      );
+    }
+
+    const { rerender } = render(<Harness />);
+
+    // Send + flush token + park.
+    const textarea = screen.getByRole('textbox');
+    const sendButton = screen.getByRole('button', { name: /send message/i });
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: 'Q' } });
+      fireEvent.click(sendButton);
+    });
+    await act(async () => {
+      await waitForPartialContent(() => view.messages, PARTIAL_TOKEN);
+    });
+
+    // Clear send-time save so the ENGINE-SWITCH save is isolated.
+    onSaveConversation.mockClear();
+
+    // --- Switch the engine to web-llm mid-stream ----------------------------
+    // The engine-switch effect (ChatPage.tsx ~201-228) sees prev='wllama' !==
+    // 'web-llm', finalizes messagesRef, and persists via onSaveConversation.
+    await act(async () => {
+      view = { ...view, engine: 'web-llm' };
+      rerender(<Harness />);
+    });
+    await act(async () => {
+      await flushRafFrames(2);
+      await Promise.resolve();
+    });
+
+    // === PRR-006b ASSERTIONS ================================================
+
+    // (1) A save targeting the owning conversation A fired after the engine
+    //     switch. If the engine-switch effect's persist branch were removed,
+    //     this would be empty (the abort alone never fires onDone).
+    const switchSaves = onSaveConversation.mock.calls.filter(([id]) => id === 'A');
+    expect(
+      switchSaves.length,
+      'engine switch mid-stream MUST persist the finalized partial turn to owning A (PRR-006b)'
+    ).toBeGreaterThanOrEqual(1);
+
+    // (2) The persisted messages contain the partial assistant content with
+    //     isStreaming stripped.
+    const lastSwitch = switchSaves[switchSaves.length - 1];
+    const switchMessages = lastSwitch[1] as ChatMessage[];
+    const assistantMsgs = switchMessages.filter((m) => m.role === 'assistant');
+    expect(assistantMsgs.length, 'an assistant message must be persisted on engine switch').toBeGreaterThanOrEqual(1);
+    const partial = assistantMsgs.find((m) => m.content.includes(PARTIAL_TOKEN));
+    expect(
+      partial,
+      `persisted assistant content must include the streamed partial token "${PARTIAL_TOKEN}"`
+    ).toBeDefined();
+    expect(
+      partial!.isStreaming,
+      'persisted partial assistant message must have isStreaming stripped on engine switch'
+    ).toBeFalsy();
+  });
+});

--- a/web_ui/src/pages/ChatPage.streaming-persistence.test.tsx
+++ b/web_ui/src/pages/ChatPage.streaming-persistence.test.tsx
@@ -1,0 +1,331 @@
+/**
+ * ChatPage.streaming-persistence.test.tsx
+ *
+ * BLOCKING acceptance test for issue #36 / S1 fix: switch-mid-stream MUST NOT
+ * corrupt conversation history.
+ *
+ * Scenario under test:
+ *   1. Conversation A is selected. User sends a message; a browser-local
+ *      (wllama) RAG stream begins and parks (the orchestrator awaits a gate).
+ *   2. The parent re-renders ChatPage with currentConversationId="B" and B's
+ *      messages (a conversation switch mid-stream).
+ *   3. The in-flight stream then completes: the orchestrator yields `complete`
+ *      and TokenStreamManager.complete() fires onDone synchronously.
+ *
+ * The S1 bug (now fixed) was that onDone/onError read the LIVE messagesRef
+ * (which the switch had reassigned to B's messages) and a stale owning-id
+ * closure (undefined on a first turn) — so A's persisted history was
+ * overwritten with B's messages, AND a duplicate conversation was created.
+ *
+ * The fix threads an owning conversation id (owningConversationIdRef, captured
+ * at send time) and an owning messages snapshot (local to runGeneration)
+ * through to onDone/onError, so they NEVER read the live messagesRef.
+ *
+ * This test exercises the REAL ChatPage component and the REAL
+ * TokenStreamManager (so the complete()→flushBuffer()→onDone path is real).
+ * Only the LLM/RAG pipeline is mocked, with a deferred the test resolves to
+ * control stream timing.
+ *
+ * Assertions (the S1 contract):
+ *   - The completion (onDone) save targets conversation id "A" (the OWNING
+ *     id), NOT "B" and NOT undefined.
+ *   - The messages passed to that save contain A's user message (NOT B's).
+ *   - No save call ever passes undefined as the conversation id (which would
+ *     create a duplicate conversation).
+ *   - setCurrentConversationId is NOT called to re-point back to A (the
+ *     no-re-point-on-switch guard).
+ */
+
+import React from 'react';
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import type { ChatMessage } from '../types/chat';
+import type { RAGEvent } from '../lib/rag/rag-orchestrator';
+
+// --- Module mocks (hoisted before the ChatPage import below) ----------------
+
+// Mock the RAG orchestrator. The instance's `query` is configured per-test.
+// We use a deferred-controlled AsyncGenerator so the test can park the stream
+// across a conversation switch and then release completion.
+vi.mock('../lib/rag/rag-orchestrator', () => ({
+  RAGOrchestrator: vi.fn().mockImplementation(function () {
+    return { query: vi.fn() };
+  }),
+}));
+
+// Mock the LLM factory so initialize() resolves immediately and interrupt()
+// is a harmless no-op (the cancel-on-switch effect calls interrupt()).
+vi.mock('../lib/llm/llm-factory', () => ({
+  getLLMService: vi.fn().mockImplementation(() => ({
+    initialize: vi.fn().mockResolvedValue(undefined),
+    interrupt: vi.fn(),
+    supportsImages: vi.fn().mockReturnValue(false),
+  })),
+  DEFAULT_BROWSER_ENGINE: 'wllama',
+  disposeBrowserEngine: vi.fn(),
+  getPreferredBrowserEngine: vi.fn().mockReturnValue('wllama'),
+}));
+
+// Mock useInferenceMode so ChatPage renders in browser-local / wllama mode
+// with the model already ready (no blocking overlay, no real context needed).
+vi.mock('../lib/inference', () => ({
+  InferenceModeProvider: ({ children }: { children: React.ReactNode }) => children,
+  useInferenceMode: vi.fn(),
+}));
+
+// Mock the readiness gate so its module-level side effects don't run.
+vi.mock('../lib/llm/readiness-gate', () => ({
+  ensureReadinessGateChecked: vi.fn().mockResolvedValue(null),
+  getReadinessResultSnapshot: vi.fn().mockReturnValue(null),
+  resetReadinessCache: vi.fn(),
+}));
+
+// Mock auth token getter (server-mode only; harmless in browser-local mode).
+vi.mock('../lib/api/auth', () => ({
+  getToken: vi.fn().mockReturnValue(null),
+}));
+
+// IMPORTANT: `../lib/streaming` is intentionally NOT mocked. We exercise the
+// REAL TokenStreamManager so complete()→flushBuffer()→onDone is the real path.
+import { ChatPage } from './ChatPage';
+import * as ragModule from '../lib/rag/rag-orchestrator';
+import * as inferenceModule from '../lib/inference';
+
+// --- Test helpers -----------------------------------------------------------
+
+/** Build a deterministic chat message. */
+function makeMessage(role: 'user' | 'assistant', content: string, extra: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: `${role}-${content.replace(/\s+/g, '-').slice(0, 12)}-${Math.random().toString(36).slice(2, 6)}`,
+    role,
+    content,
+    timestamp: Date.now(),
+    ...extra,
+  };
+}
+
+function makeDeferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+/**
+ * Build a deferred-controlled AsyncGenerator that:
+ *   - yields one token immediately,
+ *   - PARKS on `gate` until the test resolves it,
+ *   - then yields a `complete` event.
+ *
+ * The orchestrator's real abort-signal check happens at the top of each
+ * for-await iteration. By releasing the gate inside the same act() batch as
+ * the conversation switch — and flushing microtasks before React flushes the
+ * cancel-on-switch effect — we let the loop resume, yield `complete`, and
+ * trigger TokenStreamManager.complete()→onDone BEFORE cancel() runs. onDone
+ * then observes currentConversationId="B" (already flipped) but must save to
+ * the OWNING id "A" with A's messages — the precise S1 regression scenario.
+ */
+function makeDeferredStream(gate: { promise: Promise<void>; resolve: () => void }): () => AsyncGenerator<RAGEvent> {
+  return async function* (): AsyncGenerator<RAGEvent> {
+    yield { type: 'token', data: 'A-token-' };
+    await gate.promise;
+    yield {
+      type: 'complete',
+      data: { answer: 'A-answer', sources: ['doc-a'], chunks: [] },
+    };
+  };
+}
+
+// --- Test suite -------------------------------------------------------------
+
+describe('ChatPage S1: switch-mid-stream does not corrupt conversation history', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(inferenceModule.useInferenceMode).mockReturnValue({
+      mode: 'browser-local',
+      browserEngine: 'wllama',
+      ragPreset: 'balanced',
+      isModelReady: true,
+      isServerConnected: true,
+      modelLoadingProgress: 0,
+      modeError: null,
+      serverUrl: '',
+      setMode: vi.fn(),
+      setBrowserEngine: vi.fn(),
+      setRagPreset: vi.fn(),
+      setServerUrl: vi.fn(),
+      checkServerConnectivity: vi.fn(() => Promise.resolve(false)),
+      setModelReady: vi.fn(),
+      setModelLoadingProgress: vi.fn(),
+    } as unknown as ReturnType<typeof inferenceModule.useInferenceMode>);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('onDone save targets owning conversation A with A messages (not B), no undefined id, no re-point', async () => {
+    const gate = makeDeferred();
+
+    const orchestrator = { query: vi.fn() };
+    vi.mocked(ragModule.RAGOrchestrator).mockImplementation(
+      () => orchestrator as unknown as ragModule.RAGOrchestrator
+    );
+    orchestrator.query.mockImplementation(makeDeferredStream(gate));
+
+    const onSaveConversation = vi.fn();
+    const setCurrentConversationId = vi.fn();
+
+    // Conversation A starts with one existing user message; B is a different
+    // conversation with its own user message.
+    const aUserMsg = makeMessage('user', 'A-QUESTION');
+    const bUserMsg = makeMessage('user', 'B-QUESTION');
+
+    // Lifted-view harness so the test can flip currentConversationId + messages
+    // to simulate the parent (App) switching conversations mid-stream.
+    type View = { convId: string; messages: ChatMessage[] };
+    let view: View = { convId: 'A', messages: [aUserMsg] };
+    let forceRerender: () => void = () => {};
+
+    function Harness() {
+      const [, force] = React.useReducer((c: number) => c + 1, 0);
+      React.useEffect(() => {
+        forceRerender = () => force();
+      });
+      return (
+        <ChatPage
+          messages={view.messages}
+          onMessagesChange={(next) => {
+            view = {
+              ...view,
+              messages:
+                typeof next === 'function'
+                  ? (next as (p: ChatMessage[]) => ChatMessage[])(view.messages)
+                  : next,
+            };
+          }}
+          onSaveConversation={onSaveConversation}
+          currentConversationId={view.convId}
+          setCurrentConversationId={setCurrentConversationId}
+          onNewChat={() => {}}
+          onOpenSettings={() => {}}
+        />
+      );
+    }
+
+    render(<Harness />);
+
+    // --- Step 1: send a message in conversation A ---------------------------
+    const textarea = screen.getByRole('textbox');
+    const sendButton = screen.getByRole('button', { name: /send message/i });
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: 'A-QUESTION' } });
+      fireEvent.click(sendButton);
+    });
+
+    // Flush microtasks so initialize() resolves and the orchestrator loop
+    // starts, emits the token, and parks on the gate.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Sanity: the send-time save fired synchronously in handleSend, targeting A.
+    expect(onSaveConversation).toHaveBeenCalled();
+    const sendTimeCall = onSaveConversation.mock.calls[0];
+    expect(sendTimeCall[0]).toBe('A');
+
+    // Sanity: the orchestrator query was issued with A's question.
+    expect(orchestrator.query).toHaveBeenCalledWith(
+      'A-QUESTION',
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+
+    // The stream is now parked on `gate`. Clear the mock so we can cleanly
+    // isolate the COMPLETION save from the send-time save below.
+    onSaveConversation.mockClear();
+    setCurrentConversationId.mockClear();
+
+    // --- Step 2 + 3: switch to B AND release the gate in the same act -------
+    // Within this act():
+    //   (a) flip the lifted view to B (schedules the cancel-on-switch effect),
+    //   (b) release the gate so the orchestrator resumes,
+    //   (c) flush microtasks so the async loop yields `complete`, which calls
+    //       TokenStreamManager.complete() → flushBuffer() → onDone()
+    //       SYNCHRONOUSLY. Because microtasks run before React's effect flush,
+    //       onDone fires BEFORE cancelActiveStream() — so onDone observes
+    //       currentConversationId="B" (flipped) but must save to owning "A".
+    await act(async () => {
+      view = { convId: 'B', messages: [bUserMsg] };
+      forceRerender();
+      gate.resolve();
+      // Flush the orchestrator's async loop to completion.
+      for (let i = 0; i < 8; i++) {
+        await Promise.resolve();
+      }
+    });
+
+    // Final flush of any remaining microtasks / React commits.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // === S1 ASSERTIONS =====================================================
+
+    // The completion (onDone) save MUST have fired. onDone is the only path
+    // that saves with the finalized assistant message carrying `sources`.
+    const completionCalls = onSaveConversation.mock.calls.filter(([, messages]) => {
+      // The completion save carries an assistant message with sources set.
+      return (messages as ChatMessage[]).some(
+        (m) => m.role === 'assistant' && Array.isArray(m.sources)
+      );
+    });
+    expect(
+      completionCalls.length,
+      'completion (onDone) save must fire after the stream completes'
+    ).toBeGreaterThanOrEqual(1);
+
+    const lastCompletion = completionCalls[completionCalls.length - 1];
+    const [completionId, completionMessages] = lastCompletion;
+
+    // (1) The completion save targets the OWNING conversation A — NOT B and
+    //     NOT undefined. This is the precise S1 regression: before the fix,
+    //     onDone read owningConversationId===undefined (first turn) or the
+    //     live-flipped id, and saved to B / created a duplicate.
+    expect(completionId, 'completion save must target owning A, not B').toBe('A');
+    expect(completionId, 'completion save must never use undefined id').toBeDefined();
+
+    // (2) The saved messages must contain A's user message, NOT B's. This is
+    //     the heart of S1: A's history is not overwritten with B's messages.
+    const savedUserContents = (completionMessages as ChatMessage[])
+      .filter((m) => m.role === 'user')
+      .map((m) => m.content);
+    expect(savedUserContents, 'saved messages must contain A user question').toContain('A-QUESTION');
+    expect(
+      savedUserContents,
+      'saved messages must NOT contain B user question (would mean B overwrote A)'
+    ).not.toContain('B-QUESTION');
+
+    // (3) NO save call across the whole interaction passed undefined as the
+    //     conversation id (would create a duplicate conversation — the second
+    //     half of the S1 bug).
+    for (const [id] of onSaveConversation.mock.calls) {
+      expect(id, 'no save may pass undefined conversation id').toBeDefined();
+      expect(id, 'no save may target B (the switched-to conversation)').not.toBe('B');
+    }
+
+    // (4) No re-point-on-switch: setCurrentConversationId must NOT have been
+    //     called to flip the active conversation back to A as a side effect of
+    //     the in-flight stream completing.
+    const rePointToA = setCurrentConversationId.mock.calls.filter(([id]) => id === 'A');
+    expect(
+      rePointToA.length,
+      'setCurrentConversationId must not re-point back to owning A'
+    ).toBe(0);
+  });
+});

--- a/web_ui/src/pages/ChatPage.test.tsx
+++ b/web_ui/src/pages/ChatPage.test.tsx
@@ -59,6 +59,10 @@ describe('ChatPage', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -71,6 +75,10 @@ describe('ChatPage', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -83,6 +91,10 @@ describe('ChatPage', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -97,6 +109,10 @@ describe('ChatPage', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -115,6 +131,10 @@ describe('ChatPage', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -133,6 +153,10 @@ describe('ChatPage', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -152,6 +176,10 @@ describe('ChatPage', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -179,6 +207,10 @@ describe('ChatPage', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -214,6 +246,10 @@ describe('ChatPage', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -245,6 +281,10 @@ describe('ChatPage', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -268,6 +308,10 @@ describe('ChatPage', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -299,6 +343,10 @@ describe('ChatPage', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -323,6 +371,10 @@ describe('ChatPage', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -349,6 +401,10 @@ describe('ChatPage', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -383,6 +439,10 @@ describe('ChatPage', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -417,6 +477,10 @@ describe('ChatPage', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -435,6 +499,10 @@ describe('ChatPage', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -463,6 +531,10 @@ describe('ChatPage', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -481,6 +553,10 @@ describe('ChatPage', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -503,6 +579,10 @@ describe('ChatPage', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -532,6 +612,10 @@ describe('ChatPage', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 

--- a/web_ui/src/pages/ChatPage.tsx
+++ b/web_ui/src/pages/ChatPage.tsx
@@ -3,7 +3,7 @@
  * Displays messages, renders markdown, and supports streaming responses.
  */
 
-import { useState, useCallback, useRef, useEffect, type CSSProperties } from 'react';
+import { useState, useCallback, useRef, useEffect, useMemo, type CSSProperties } from 'react';
 import type { ChatMessage } from '../types/chat';
 import { ChatMessageList } from '../components/ChatMessageList';
 import { ChatInput } from '../components/ChatInput';
@@ -34,11 +34,27 @@ function generateId(): string {
 export interface ChatPageProps {
   messages: ChatMessage[];
   onMessagesChange: React.Dispatch<React.SetStateAction<ChatMessage[]>>;
-  onSaveConversation: (messages: ChatMessage[], mode: 'server' | 'wllama', modelUsed: string) => void;
+  /** Persist `messages` into the conversation identified by `conversationId`.
+   *  The owning id is captured at send time (S1) so an in-flight stream can
+   *  never write to a conversation other than the one that produced it. */
+  onSaveConversation: (
+    conversationId: string | undefined,
+    messages: ChatMessage[],
+    mode: 'server' | 'wllama',
+    modelUsed: string,
+    onCreate?: (newId: string) => void
+  ) => void;
+  /** The active conversation id (lifted state from useConversations). */
+  currentConversationId: string | undefined;
+  /** Set the active conversation id (also updates the ref mirror). Exposed so
+   *  a send-time-created conversation becomes the owning + active id. */
+  setCurrentConversationId: (id: string | undefined) => void;
   onNewChat: () => void;
   /** Navigate to the Settings page (wired from App). Used by the model-block
    *  overlay's "Open Settings" button and the Ctrl+, shortcut. */
   onOpenSettings: () => void;
+  /** U4: navigate to the Documents page (zero-doc empty-state CTA). */
+  onNavigateToDocuments?: () => void;
 }
 
 export function ChatPage(props: ChatPageProps) {
@@ -57,8 +73,7 @@ const exportButtonStyle: CSSProperties = {
   transition: 'all 0.15s ease',
 };
 
-function ChatPageInner({ messages: messagesProp, onMessagesChange, onSaveConversation, onNewChat, onOpenSettings }: ChatPageProps) {
-  const MAX_MESSAGES = 200;
+function ChatPageInner({ messages: messagesProp, onMessagesChange, onSaveConversation, currentConversationId, setCurrentConversationId, onNewChat, onOpenSettings, onNavigateToDocuments }: ChatPageProps) {
   const { mode, browserEngine, ragPreset, isModelReady, isServerConnected, modelLoadingProgress, serverUrl, setModelLoadingProgress } = useInferenceMode();
   const messages = messagesProp;
   const setMessages = onMessagesChange;
@@ -73,18 +88,87 @@ function ChatPageInner({ messages: messagesProp, onMessagesChange, onSaveConvers
   // send it without ChatPage owning the textarea state.
   const draftRef = useRef('');
 
-  // Mirror of the current messages so async callbacks (onDone/onError) can read
-  // the latest array without placing side effects inside a state updater.
+  // Mirror of the current messages so async callbacks (onToken) can read the
+  // latest array without placing side effects inside a state updater. NOTE
+  // (S1): onDone/onError do NOT read this ref — they read the owningMessages
+  // snapshot captured at send time, so switching conversations mid-stream
+  // cannot overwrite the switched-FROM conversation with the switched-TO
+  // conversation's messages.
   const messagesRef = useRef<ChatMessage[]>(messages);
   useEffect(() => {
     messagesRef.current = messages;
   }, [messages]);
 
+  // S1: cancel any in-flight stream when the active conversation changes (a
+  // non-empty→non-empty switch). This is ADDITIVE to the existing
+  // non-empty→empty New-Chat guard below; both must be preserved.
+  const prevConversationIdRef = useRef(currentConversationId);
+  // F1 (reviewer): owning-conversation-id ref for the in-flight stream. Set
+  // synchronously at send time and updated synchronously in the send-time
+  // save's onCreate callback, so runGeneration's onDone/onError read the
+  // CURRENT owning id (which may have just been created) rather than a stale
+  // closure value. Without this, a first-turn send captures
+  // owningConversationId===undefined and onDone later saves with undefined →
+  // a DUPLICATE conversation is created.
+  const owningConversationIdRef = useRef<string | undefined>(currentConversationId);
+  const cancelActiveStream = useCallback(() => {
+    if (tokenStreamManagerRef.current) {
+      tokenStreamManagerRef.current.cancel();
+      tokenStreamManagerRef.current = null;
+    }
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort();
+      abortControllerRef.current = null;
+    }
+    // S7: also interrupt the LLM engine directly. web-llm's `signal` field is
+    // inert at runtime (web-llm-service wires an abort→interruptGenerate
+    // listener as the real mechanism), so the AbortController above is not
+    // sufficient for WebGPU generation. WllamaService.interrupt aborts its real
+    // internal controller (harmless + desired). interrupt() is on the
+    // LLMService interface (types/llm.ts) and both services implement it.
+    try {
+      getLLMService(browserEngine).interrupt();
+    } catch (err) {
+      console.warn('[ChatPage] LLM interrupt failed during stream cancel', err);
+    }
+    setIsLoading(false);
+  }, [browserEngine]);
+
+  useEffect(() => {
+    if (prevConversationIdRef.current !== currentConversationId && tokenStreamManagerRef.current) {
+      // A conversation switch happened while a stream is active. Finalize the
+      // in-flight assistant message (S3: clear isStreaming so no blinking
+      // cursor) and cancel the stream. We do NOT persist here — the in-flight
+      // stream's own onDone/onError will persist to the OWNING conversation
+      // id (captured at send time), not the switched-to one.
+      const finalized = messagesRef.current.map((msg) =>
+        msg.isStreaming ? { ...msg, isStreaming: false } : msg
+      );
+      messagesRef.current = finalized;
+      setMessages(finalized);
+      cancelActiveStream();
+    }
+    prevConversationIdRef.current = currentConversationId;
+  }, [currentConversationId, cancelActiveStream, setMessages]);
+
   const isBrowserMode = mode === 'browser-local';
   const isModelBlocked = isBrowserMode && !isModelReady;
   const isInputDisabled = isLoading || isModelBlocked;
-  // Image upload is supported by the multimodal wllama engine in browser-local mode.
-  const canAttachImages = isBrowserMode && browserEngine === 'wllama' && isModelReady;
+  // U8c: image upload requires the multimodal wllama engine AND the loaded
+  // model's actual image-modality support. The previous check only verified
+  // engine name + readiness, so a wllama build with a packaged GGUF but a
+  // missing/broken mmproj would allow image attach then fail at generate().
+  // supportsImages() consults wllama's supportInputModality('image'). Guarded
+  // with try/catch because the service singleton may not be initialized yet.
+  const engineSupportsImages = useMemo(() => {
+    if (!isBrowserMode || browserEngine !== 'wllama' || !isModelReady) return false;
+    try {
+      const svc = getLLMService(browserEngine);
+      return typeof svc.supportsImages === 'function' ? svc.supportsImages() : false;
+    }
+    catch { return false; }
+  }, [isBrowserMode, browserEngine, isModelReady]);
+  const canAttachImages = engineSupportsImages;
 
   // Abort any in-flight generation on a genuine engine switch — NOT on unmount.
   // Disposal of the OLD engine singleton itself now lives in
@@ -112,6 +196,19 @@ function ChatPageInner({ messages: messagesProp, onMessagesChange, onSaveConvers
     const prev = prevEngineRef.current;
     prevEngineRef.current = browserEngine;
     if (mode === 'browser-local' && prev !== browserEngine) {
+      // S2/S3: finalize the in-flight assistant message and persist the
+      // partial turn before aborting, so an engine switch doesn't discard
+      // minutes of generation or leave a blinking cursor.
+      const owningId = currentConversationId;
+      const snapshot = messagesRef.current;
+      const finalized = snapshot.map((msg) =>
+        msg.isStreaming ? { ...msg, isStreaming: false } : msg
+      );
+      if (snapshot.some((m) => m.isStreaming)) {
+        messagesRef.current = finalized;
+        setMessages(finalized);
+        onSaveConversation(owningId, finalized, 'wllama', prev);
+      }
       if (abortControllerRef.current) {
         abortControllerRef.current.abort();
         abortControllerRef.current = null;
@@ -122,7 +219,7 @@ function ChatPageInner({ messages: messagesProp, onMessagesChange, onSaveConvers
       }
       setIsLoading(false);
     }
-  }, [browserEngine, mode]);
+  }, [browserEngine, mode, currentConversationId, onSaveConversation, setMessages]);
 
   // Evaluate model readiness for the selected engine when entering browser-local
   // mode or switching engines. This drives `isModelReady` (and the input gate)
@@ -134,9 +231,25 @@ function ChatPageInner({ messages: messagesProp, onMessagesChange, onSaveConvers
     }
   }, [mode, browserEngine]);
 
-  // Cleanup on unmount
+  // Cleanup on unmount — finalize + persist the in-flight turn (S2/S3) before
+  // releasing resources. Reads from refs (not closure state) so the latest
+  // values are used even though the effect has an empty dep array.
+  const persistOnUnmountRef = useRef<(messages: ChatMessage[], owningId: string | undefined) => void>(() => {});
+  persistOnUnmountRef.current = (messages, owningId) => {
+    onSaveConversation(owningId, messages, mode === 'api' ? 'server' : 'wllama', browserEngine);
+  };
   useEffect(() => {
     return () => {
+      // S2/S3: if a stream was in flight, finalize flags + persist so unmount
+      // (e.g. navigating away mid-generation) doesn't discard the turn or leave
+      // a blinking cursor persisted.
+      if (tokenStreamManagerRef.current !== null) {
+        const owningId = currentConversationId;
+        const finalized = messagesRef.current.map((msg) =>
+          msg.isStreaming ? { ...msg, isStreaming: false } : msg
+        );
+        persistOnUnmountRef.current(finalized, owningId);
+      }
       if (clearTimeoutRef.current !== null) {
         clearTimeout(clearTimeoutRef.current);
       }
@@ -149,19 +262,33 @@ function ChatPageInner({ messages: messagesProp, onMessagesChange, onSaveConvers
         tokenStreamManagerRef.current = null;
       }
     };
-  }, []);
+  }, [currentConversationId]);
 
   // Run a query for an existing assistant placeholder message. Shared by send +
   // regenerate. `images` carry the raw bytes (not stored on ChatMessage), so
   // regenerate captures them via lastTurnRef.
+  //
+  // S1 fix: `owningConversationId` + `owningMessages` are captured at send
+  // time and threaded through so onDone/onError read from the SNAPSHOT, never
+  // from the live messagesRef (which reassigns on a conversation switch). This
+  // is what prevents a mid-stream switch from overwriting the switched-FROM
+  // conversation with the switched-TO conversation's messages.
   const runGeneration = useCallback((
     text: string,
     images: AttachedImage[] | undefined,
-    assistantMessageId: string
+    assistantMessageId: string,
+    _owningConversationId: string | undefined,
+    owningMessages: ChatMessage[]
   ) => {
     // Create TokenStreamManager for this request
     const streamManager = new TokenStreamManager();
     tokenStreamManagerRef.current = streamManager;
+
+    // A local accumulator for the owning snapshot. onToken writes to BOTH the
+    // live messagesRef (for live UI updates of the active conversation) AND
+    // this snapshot (so onDone/onError persist the correct messages even if
+    // the user switched conversations mid-stream).
+    let snapshot = owningMessages;
 
     // Wire token callback - append tokens to assistant message.
     // Compute the next array from messagesRef (the always-current mirror),
@@ -175,14 +302,17 @@ function ChatPageInner({ messages: messagesProp, onMessagesChange, onSaveConvers
       );
       messagesRef.current = next;
       setMessages(next);
+      // Mirror into the snapshot so the final save reflects every token.
+      snapshot = next;
     });
 
     // Wire done callback - finalize message with sources.
     // TokenStreamManager.complete() flushes the token buffer (firing onToken)
-    // and then invokes onDone synchronously in the same call stack, so
-    // messagesRef.current already reflects every streamed token here.
+    // and then invokes onDone synchronously in the same call stack, so the
+    // snapshot already reflects every streamed token here. Read from the
+    // snapshot (NOT messagesRef) so a mid-stream switch cannot mis-target.
     streamManager.onDone((data) => {
-      const updated = messagesRef.current.map((msg) =>
+      const updated = snapshot.map((msg) =>
         msg.id === assistantMessageId
           ? {
               ...msg,
@@ -205,10 +335,20 @@ function ChatPageInner({ messages: messagesProp, onMessagesChange, onSaveConvers
             }
           : msg
       );
-      messagesRef.current = updated;
-      setMessages(updated);
-      // Save to Dexie after stream completes
-      onSaveConversation(updated, mode === 'api' ? 'server' : 'wllama', browserEngine);
+      snapshot = updated;
+      // F1: read the owning id from the REF (updated synchronously by the
+      // send-time save's onCreate callback when a first-turn conversation is
+      // created), NOT the captured `owningConversationId` param — which is
+      // undefined on a first turn and would cause a duplicate conversation.
+      const liveOwningId = owningConversationIdRef.current;
+      // Only update live UI state if the user is still on the owning
+      // conversation; otherwise leave the switched-to view untouched.
+      if (currentConversationId === liveOwningId) {
+        messagesRef.current = updated;
+        setMessages(updated);
+      }
+      // Save to Dexie — always to the OWNING id (S1).
+      onSaveConversation(liveOwningId, updated, mode === 'api' ? 'server' : 'wllama', browserEngine);
       if (tokenStreamManagerRef.current === streamManager) {
         setIsLoading(false);
         tokenStreamManagerRef.current = null;
@@ -216,15 +356,23 @@ function ChatPageInner({ messages: messagesProp, onMessagesChange, onSaveConvers
     });
 
     // Wire error callback. Like onDone, onError fires synchronously after
-    // flushBuffer() inside TokenStreamManager.error(), so read from the ref.
+    // flushBuffer() inside TokenStreamManager.error(), so read from snapshot.
+    // S6: set the structured `error` field instead of injecting into content.
     streamManager.onError((errorMessage) => {
-      const updated = messagesRef.current.map((msg) =>
+      const updated = snapshot.map((msg) =>
         msg.id === assistantMessageId
-          ? { ...msg, content: msg.content + `\n[Error: ${errorMessage}]`, isStreaming: false }
+          ? { ...msg, error: errorMessage, isStreaming: false }
           : msg
       );
-      messagesRef.current = updated;
-      setMessages(updated);
+      snapshot = updated;
+      const liveOwningId = owningConversationIdRef.current;
+      if (currentConversationId === liveOwningId) {
+        messagesRef.current = updated;
+        setMessages(updated);
+      }
+      // S2: persist the errored turn to the OWNING id so the partial answer +
+      // user question survive (the save layer strips isStreaming — S3).
+      onSaveConversation(liveOwningId, updated, mode === 'api' ? 'server' : 'wllama', browserEngine);
       if (tokenStreamManagerRef.current === streamManager) {
         setIsLoading(false);
         tokenStreamManagerRef.current = null;
@@ -328,7 +476,7 @@ function ChatPageInner({ messages: messagesProp, onMessagesChange, onSaveConvers
         }
       })();
     }
-  }, [mode, serverUrl, browserEngine, ragPreset, onSaveConversation, setModelLoadingProgress]);
+  }, [mode, serverUrl, browserEngine, ragPreset, onSaveConversation, setModelLoadingProgress, currentConversationId, setMessages]);
 
   const handleSend = useCallback((text: string, attachedImages?: AttachedImage[]) => {
     // Prevent overlapping streams
@@ -359,23 +507,43 @@ function ChatPageInner({ messages: messagesProp, onMessagesChange, onSaveConvers
       isStreaming: true,
     };
 
+    // S5: keep the FULL history in state (windowing is render-only, handled in
+    // ChatMessageList). Previously this pruned to MAX_MESSAGES at send time,
+    // which then got persisted wholesale — deleting old messages from
+    // IndexedDB. Persistence now always sees the full array.
     const appended = [...messagesRef.current, userMessage, assistantMessage];
-    if (appended.length > MAX_MESSAGES) {
-      const pruned = appended.slice(appended.length - MAX_MESSAGES);
-      const indicator: ChatMessage = {
-        id: 'hidden-messages-indicator',
-        role: 'system',
-        content: `Earlier messages have been hidden (max ${MAX_MESSAGES} shown).`,
-        timestamp: Date.now(),
-      };
-      messagesRef.current = [indicator, ...pruned];
-    } else {
-      messagesRef.current = appended;
-    }
-    setMessages(messagesRef.current);
+    messagesRef.current = appended;
+    setMessages(appended);
     setIsLoading(true);
-    runGeneration(text, attachedImages, assistantMessageId);
-  }, [runGeneration]);
+
+    // S1+S2: capture the owning conversation id + snapshot at send time, and
+    // persist the user message + placeholder immediately so the turn survives
+    // any later interruption (Stop, error, close, switch). For a first turn
+    // with no current conversation, create one and adopt its id as the owning
+    // id (H4 + F1: prevents a duplicate conversation when onDone later saves).
+    //
+    // F1: owningConversationIdRef is set SYNCHRONOUSLY here and updated
+    // synchronously in onCreate, so runGeneration's onDone/onError read the
+    // current owning id (which may have just been created) rather than a stale
+    // closure value.
+    owningConversationIdRef.current = currentConversationId;
+    onSaveConversation(
+      currentConversationId,
+      appended,
+      mode === 'api' ? 'server' : 'wllama',
+      browserEngine,
+      (newId) => {
+        // First-turn creation: adopt the new id as both the owning id (for
+        // this stream's saves, via the ref) and the active conversation.
+        if (currentConversationId === undefined) {
+          owningConversationIdRef.current = newId;
+          setCurrentConversationId(newId);
+        }
+      }
+    );
+
+    runGeneration(text, attachedImages, assistantMessageId, currentConversationId, appended);
+  }, [runGeneration, onSaveConversation, mode, browserEngine, currentConversationId, setCurrentConversationId]);
 
   // Re-run the most recent user turn, replacing the last assistant response.
   const handleRegenerate = useCallback(() => {
@@ -394,34 +562,28 @@ function ChatPageInner({ messages: messagesProp, onMessagesChange, onSaveConvers
     messagesRef.current = regenerated;
     setMessages(regenerated);
     setIsLoading(true);
-    runGeneration(last.text, last.images, assistantMessageId);
-  }, [runGeneration]);
-
-  // Cancel any in-flight stream and release its resources. Shared by the
-  // explicit Cancel button, Clear Chat, and the external New Chat path
-  // (sidebar) which clears messages without going through ChatPage.
-  const cancelActiveStream = useCallback(() => {
-    if (tokenStreamManagerRef.current) {
-      tokenStreamManagerRef.current.cancel();
-      tokenStreamManagerRef.current = null;
-    }
-    if (abortControllerRef.current) {
-      abortControllerRef.current.abort();
-      abortControllerRef.current = null;
-    }
-    setIsLoading(false);
-  }, []);
+    // F1: regenerate re-uses the current conversation; set the owning ref so
+    // runGeneration's saves target it.
+    owningConversationIdRef.current = currentConversationId;
+    runGeneration(last.text, last.images, assistantMessageId, currentConversationId, regenerated);
+  }, [runGeneration, currentConversationId]);
 
   const handleCancel = useCallback(() => {
+    // Capture owning id+snapshot BEFORE cancel (cancel nulls the refs).
+    const owningId = currentConversationId;
+    const snapshot = messagesRef.current;
+
     cancelActiveStream();
 
-    // Mark any streaming messages as complete
-    const finalized = messagesRef.current.map((msg) =>
+    // Mark any streaming messages as complete (S3) and persist the partial
+    // turn so Stop doesn't discard minutes of generation (S2).
+    const finalized = snapshot.map((msg) =>
       msg.isStreaming ? { ...msg, isStreaming: false } : msg
     );
     messagesRef.current = finalized;
     setMessages(finalized);
-  }, [cancelActiveStream]);
+    onSaveConversation(owningId, finalized, mode === 'api' ? 'server' : 'wllama', browserEngine);
+  }, [cancelActiveStream, currentConversationId, onSaveConversation, mode, browserEngine]);
 
   // If messages are cleared while a stream is in flight (e.g. the sidebar
   // "New Chat" button calls newChat() in App, which empties currentMessages
@@ -588,16 +750,23 @@ function ChatPageInner({ messages: messagesProp, onMessagesChange, onSaveConvers
         isStreaming={isLoading}
         onRegenerate={!isLoading && lastTurnRef.current ? handleRegenerate : undefined}
         onSuggestedPrompt={(prompt) => handleSend(prompt)}
+        onNavigateToDocuments={onNavigateToDocuments}
       />
 
-      {/* Streaming Indicator */}
+      {/* Streaming Indicator — U1: during a cold model load (multi-minute on
+          target CPU hardware), show a determinate progress bar instead of the
+          indeterminate "Generating" cursor so the load is visible. */}
       <div
         style={{
           padding: 'var(--spacing-xs) var(--spacing-lg)',
           minHeight: '28px',
         }}
       >
-        <StreamingIndicator isVisible={isLoading} />
+        <StreamingIndicator
+          isVisible={isLoading}
+          modelLoadProgress={isLoading && modelLoadingProgress > 0 && modelLoadingProgress < 100 ? modelLoadingProgress : undefined}
+          modelLoadLabel="Loading the AI model — one-time, may take a few minutes…"
+        />
       </div>
 
       {/* Input */}

--- a/web_ui/src/pages/ChatPage.tsx
+++ b/web_ui/src/pages/ChatPage.tsx
@@ -478,7 +478,7 @@ function ChatPageInner({ messages: messagesProp, onMessagesChange, onSaveConvers
     }
   }, [mode, serverUrl, browserEngine, ragPreset, onSaveConversation, setModelLoadingProgress, currentConversationId, setMessages]);
 
-  const handleSend = useCallback((text: string, attachedImages?: AttachedImage[]) => {
+  const handleSend = useCallback(async (text: string, attachedImages?: AttachedImage[]) => {
     // Prevent overlapping streams
     if (tokenStreamManagerRef.current) return;
 
@@ -522,27 +522,38 @@ function ChatPageInner({ messages: messagesProp, onMessagesChange, onSaveConvers
     // with no current conversation, create one and adopt its id as the owning
     // id (H4 + F1: prevents a duplicate conversation when onDone later saves).
     //
-    // F1: owningConversationIdRef is set SYNCHRONOUSLY here and updated
-    // synchronously in onCreate, so runGeneration's onDone/onError read the
-    // current owning id (which may have just been created) rather than a stale
-    // closure value.
+    // F1 (corrected): the send-time save is AWAITED so the owning id ref is
+    // set BEFORE runGeneration starts. The prior approach set the ref
+    // synchronously and relied on saveMessages' onCreate callback to update
+    // it — but onCreate fires inside the async saveMessages after two awaits
+    // (a microtask), so on a fast-complete first turn (warm model / zero-doc
+    // abstain) onDone fired before onCreate resolved, read undefined, and
+    // created a duplicate conversation. Awaiting the save guarantees ordering.
     owningConversationIdRef.current = currentConversationId;
-    onSaveConversation(
-      currentConversationId,
-      appended,
-      mode === 'api' ? 'server' : 'wllama',
-      browserEngine,
-      (newId) => {
-        // First-turn creation: adopt the new id as both the owning id (for
-        // this stream's saves, via the ref) and the active conversation.
-        if (currentConversationId === undefined) {
-          owningConversationIdRef.current = newId;
-          setCurrentConversationId(newId);
+    let resolvedOwningId = currentConversationId;
+    try {
+      await onSaveConversation(
+        currentConversationId,
+        appended,
+        mode === 'api' ? 'server' : 'wllama',
+        browserEngine,
+        (newId) => {
+          // First-turn creation: adopt the new id as both the owning id (for
+          // this stream's saves, via the ref) and the active conversation.
+          if (currentConversationId === undefined) {
+            resolvedOwningId = newId;
+          }
         }
-      }
-    );
+      );
+    } catch (err) {
+      console.error('[ChatPage] Send-time persistence failed; streaming will proceed without a guaranteed owning id.', err);
+    }
+    if (resolvedOwningId !== currentConversationId) {
+      owningConversationIdRef.current = resolvedOwningId;
+      setCurrentConversationId(resolvedOwningId);
+    }
 
-    runGeneration(text, attachedImages, assistantMessageId, currentConversationId, appended);
+    runGeneration(text, attachedImages, assistantMessageId, resolvedOwningId, appended);
   }, [runGeneration, onSaveConversation, mode, browserEngine, currentConversationId, setCurrentConversationId]);
 
   // Re-run the most recent user turn, replacing the last assistant response.

--- a/web_ui/src/pages/ChatPage.tsx
+++ b/web_ui/src/pages/ChatPage.tsx
@@ -111,6 +111,15 @@ function ChatPageInner({ messages: messagesProp, onMessagesChange, onSaveConvers
   // owningConversationId===undefined and onDone later saves with undefined →
   // a DUPLICATE conversation is created.
   const owningConversationIdRef = useRef<string | undefined>(currentConversationId);
+  // PRR-001: owning-messages ref for the in-flight stream. Mirrors runGeneration's
+  // local `snapshot` (the owning conversation's messages, updated on each token)
+  // so the switch / unmount / engine-switch effects can read the OWNING
+  // conversation's partial turn — NOT the live `messagesRef`, which a mid-stream
+  // conversation switch reassigns to the switched-TO conversation's messages
+  // (and which the messagesRef-mirror passive effect clobbers before the switch
+  // effect's create runs). Parallels owningConversationIdRef. nulled when the
+  // stream finalizes so stale data can't be re-persisted after completion.
+  const owningMessagesRef = useRef<ChatMessage[] | null>(null);
   const cancelActiveStream = useCallback(() => {
     if (tokenStreamManagerRef.current) {
       tokenStreamManagerRef.current.cancel();
@@ -138,18 +147,31 @@ function ChatPageInner({ messages: messagesProp, onMessagesChange, onSaveConvers
     if (prevConversationIdRef.current !== currentConversationId && tokenStreamManagerRef.current) {
       // A conversation switch happened while a stream is active. Finalize the
       // in-flight assistant message (S3: clear isStreaming so no blinking
-      // cursor) and cancel the stream. We do NOT persist here — the in-flight
-      // stream's own onDone/onError will persist to the OWNING conversation
-      // id (captured at send time), not the switched-to one.
-      const finalized = messagesRef.current.map((msg) =>
+      // cursor), PERSIST the partial turn to the OWNING conversation id
+      // (PRR-001: previously this did not save, and cancel() never fires
+      // onDone/onError, so the partial answer was irrecoverably lost), then
+      // cancel the stream. The owning id is read from the ref (captured at
+      // send time) so the save targets the conversation that produced the
+      // turn, NOT the switched-to one. Mirrors handleCancel + the engine-
+      // switch effect.
+      const owningId = owningConversationIdRef.current;
+      // PRR-001: read the OWNING conversation's messages from the owning
+      // snapshot ref (captured at send time, updated per token) — NOT the live
+      // messagesRef, which a mid-stream switch has already reassigned to the
+      // switched-TO conversation's messages.
+      const owningMessages = owningMessagesRef.current ?? messagesRef.current;
+      const finalized = owningMessages.map((msg) =>
         msg.isStreaming ? { ...msg, isStreaming: false } : msg
       );
       messagesRef.current = finalized;
       setMessages(finalized);
+      onSaveConversation(owningId, finalized, mode === 'api' ? 'server' : 'wllama', browserEngine);
+      // Clear the owning snapshot so a later switch can't re-persist it.
+      owningMessagesRef.current = null;
       cancelActiveStream();
     }
     prevConversationIdRef.current = currentConversationId;
-  }, [currentConversationId, cancelActiveStream, setMessages]);
+  }, [currentConversationId, cancelActiveStream, setMessages, onSaveConversation, mode, browserEngine]);
 
   const isBrowserMode = mode === 'browser-local';
   const isModelBlocked = isBrowserMode && !isModelReady;
@@ -198,16 +220,23 @@ function ChatPageInner({ messages: messagesProp, onMessagesChange, onSaveConvers
     if (mode === 'browser-local' && prev !== browserEngine) {
       // S2/S3: finalize the in-flight assistant message and persist the
       // partial turn before aborting, so an engine switch doesn't discard
-      // minutes of generation or leave a blinking cursor.
-      const owningId = currentConversationId;
-      const snapshot = messagesRef.current;
-      const finalized = snapshot.map((msg) =>
+      // minutes of generation or leave a blinking cursor. PRR-001: read the
+      // OWNING conversation's id + messages from the send-time refs so an
+      // engine switch mid-stream persists the turn that was actually in flight
+      // (the live currentConversationId / messagesRef are the engine-switch
+      // view, which is correct here because an engine switch doesn't change the
+      // active conversation, but using the owning refs is consistent with the
+      // switch + unmount paths and resilient to ordering).
+      const owningId = owningConversationIdRef.current ?? currentConversationId;
+      const owningMessages = owningMessagesRef.current ?? messagesRef.current;
+      const finalized = owningMessages.map((msg) =>
         msg.isStreaming ? { ...msg, isStreaming: false } : msg
       );
-      if (snapshot.some((m) => m.isStreaming)) {
+      if (owningMessages.some((m) => m.isStreaming)) {
         messagesRef.current = finalized;
         setMessages(finalized);
         onSaveConversation(owningId, finalized, 'wllama', prev);
+        owningMessagesRef.current = null;
       }
       if (abortControllerRef.current) {
         abortControllerRef.current.abort();
@@ -238,14 +267,25 @@ function ChatPageInner({ messages: messagesProp, onMessagesChange, onSaveConvers
   persistOnUnmountRef.current = (messages, owningId) => {
     onSaveConversation(owningId, messages, mode === 'api' ? 'server' : 'wllama', browserEngine);
   };
+  // S2/S3 + PRR-001 unblock: dep array is `[]` so the cleanup fires ONLY on a
+  // genuine unmount, NOT on every conversation switch. Previously the dep was
+  // `[currentConversationId]`; because React runs pending effect DESTROYS
+  // before CREATES on a dep change, that cleanup ran BEFORE the switch
+  // effect's create on an A->B switch — nulling `tokenStreamManagerRef.current`
+  // first and making the PRR-001 switch-effect persist line unreachable (dead
+  // code). With `[]`, the switch effect owns mid-stream persistence on a
+  // conversation switch; this cleanup owns only true unmount. Reads from refs
+  // (owningConversationIdRef + owningMessagesRef, both kept fresh) so the `[]`
+  // dep is safe — no stale closure values.
   useEffect(() => {
     return () => {
       // S2/S3: if a stream was in flight, finalize flags + persist so unmount
       // (e.g. navigating away mid-generation) doesn't discard the turn or leave
       // a blinking cursor persisted.
       if (tokenStreamManagerRef.current !== null) {
-        const owningId = currentConversationId;
-        const finalized = messagesRef.current.map((msg) =>
+        const owningId = owningConversationIdRef.current;
+        const owningMessages = owningMessagesRef.current ?? messagesRef.current;
+        const finalized = owningMessages.map((msg) =>
           msg.isStreaming ? { ...msg, isStreaming: false } : msg
         );
         persistOnUnmountRef.current(finalized, owningId);
@@ -262,7 +302,7 @@ function ChatPageInner({ messages: messagesProp, onMessagesChange, onSaveConvers
         tokenStreamManagerRef.current = null;
       }
     };
-  }, [currentConversationId]);
+  }, []);
 
   // Run a query for an existing assistant placeholder message. Shared by send +
   // regenerate. `images` carry the raw bytes (not stored on ChatMessage), so
@@ -287,8 +327,13 @@ function ChatPageInner({ messages: messagesProp, onMessagesChange, onSaveConvers
     // A local accumulator for the owning snapshot. onToken writes to BOTH the
     // live messagesRef (for live UI updates of the active conversation) AND
     // this snapshot (so onDone/onError persist the correct messages even if
-    // the user switched conversations mid-stream).
+    // the user switched conversations mid-stream). PRR-001: the snapshot is
+    // ALSO mirrored onto owningMessagesRef so the switch / unmount / engine-
+    // switch effects can read the OWNING conversation's partial turn (the live
+    // messagesRef is clobbered by a mid-stream switch + the messagesRef-mirror
+    // passive effect before those effects' create runs).
     let snapshot = owningMessages;
+    owningMessagesRef.current = snapshot;
 
     // Wire token callback - append tokens to assistant message.
     // Compute the next array from messagesRef (the always-current mirror),
@@ -304,6 +349,7 @@ function ChatPageInner({ messages: messagesProp, onMessagesChange, onSaveConvers
       setMessages(next);
       // Mirror into the snapshot so the final save reflects every token.
       snapshot = next;
+      owningMessagesRef.current = snapshot;
     });
 
     // Wire done callback - finalize message with sources.
@@ -336,6 +382,10 @@ function ChatPageInner({ messages: messagesProp, onMessagesChange, onSaveConvers
           : msg
       );
       snapshot = updated;
+      // PRR-001: keep the ref in sync, then null it once the turn is finalized
+      // so a later switch/unmount/engine-switch can't re-persist a completed
+      // turn (the stream manager ref is also nulled below).
+      owningMessagesRef.current = snapshot;
       // F1: read the owning id from the REF (updated synchronously by the
       // send-time save's onCreate callback when a first-turn conversation is
       // created), NOT the captured `owningConversationId` param — which is
@@ -352,6 +402,7 @@ function ChatPageInner({ messages: messagesProp, onMessagesChange, onSaveConvers
       if (tokenStreamManagerRef.current === streamManager) {
         setIsLoading(false);
         tokenStreamManagerRef.current = null;
+        owningMessagesRef.current = null;
       }
     });
 
@@ -365,6 +416,7 @@ function ChatPageInner({ messages: messagesProp, onMessagesChange, onSaveConvers
           : msg
       );
       snapshot = updated;
+      owningMessagesRef.current = snapshot;
       const liveOwningId = owningConversationIdRef.current;
       if (currentConversationId === liveOwningId) {
         messagesRef.current = updated;
@@ -376,6 +428,7 @@ function ChatPageInner({ messages: messagesProp, onMessagesChange, onSaveConvers
       if (tokenStreamManagerRef.current === streamManager) {
         setIsLoading(false);
         tokenStreamManagerRef.current = null;
+        owningMessagesRef.current = null;
       }
     });
 
@@ -580,20 +633,25 @@ function ChatPageInner({ messages: messagesProp, onMessagesChange, onSaveConvers
   }, [runGeneration, currentConversationId]);
 
   const handleCancel = useCallback(() => {
-    // Capture owning id+snapshot BEFORE cancel (cancel nulls the refs).
+    // Capture owning id BEFORE cancel (it's from state, survives cancel).
     const owningId = currentConversationId;
-    const snapshot = messagesRef.current;
 
     cancelActiveStream();
 
-    // Mark any streaming messages as complete (S3) and persist the partial
-    // turn so Stop doesn't discard minutes of generation (S2).
-    const finalized = snapshot.map((msg) =>
+    // PRR-005: read messagesRef.current AFTER cancelActiveStream so the
+    // cancel-flushed tail tokens (S4: cancel() flushes the buffer via onToken
+    // before clearing) are included. Previously the snapshot was captured
+    // before cancel, so finalized was derived from a stale array and the
+    // cancel-flushed tokens were lost from both UI and persistence.
+    const finalized = messagesRef.current.map((msg) =>
       msg.isStreaming ? { ...msg, isStreaming: false } : msg
     );
     messagesRef.current = finalized;
     setMessages(finalized);
     onSaveConversation(owningId, finalized, mode === 'api' ? 'server' : 'wllama', browserEngine);
+    // PRR-001: the in-flight turn is finalized; clear the owning snapshot so a
+    // later switch/unmount/engine-switch can't re-persist it.
+    owningMessagesRef.current = null;
   }, [cancelActiveStream, currentConversationId, onSaveConversation, mode, browserEngine]);
 
   // If messages are cleared while a stream is in flight (e.g. the sidebar

--- a/web_ui/src/pages/ChatPage.verification-3.3.test.tsx
+++ b/web_ui/src/pages/ChatPage.verification-3.3.test.tsx
@@ -153,6 +153,10 @@ describe('Task 3.3 Verification - Inference Mode Architecture', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -199,6 +203,10 @@ describe('Task 3.3 Verification - Inference Mode Architecture', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -236,6 +244,10 @@ describe('Task 3.3 Verification - Inference Mode Architecture', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 
@@ -338,6 +350,10 @@ describe('Task 3.3 Verification - Inference Mode Architecture', () => {
   onMessagesChange={() => {}}
   onSaveConversation={() => {}}
   onNewChat={() => {}}
+  currentConversationId={undefined}
+
+  setCurrentConversationId={() => {}}
+
   onOpenSettings={() => {}}
 />);
 

--- a/web_ui/src/pages/DocumentsPage.indexing.test.tsx
+++ b/web_ui/src/pages/DocumentsPage.indexing.test.tsx
@@ -2,7 +2,18 @@
  * Tests for DocumentsPage search index integration (Task 8.2)
  */
 
-import { describe, test, expect, beforeEach, vi } from 'vitest';
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
+import React from 'react';
+// U3b: DocumentsPage now calls useToast(), which requires a ToastProvider.
+import { ToastProvider } from '../components/ToastProvider';
+// RTL auto-cleanup does not register reliably when @testing-library/react is
+// loaded via dynamic import inside each test (the afterEach hook is registered
+// too late). Several tests below bail on a failed assertion BEFORE reaching
+// their explicit `unmount()`, which would leak the mounted component into the
+// shared jsdom document and cause later tests' `document.querySelector` to hit
+// a STALE DropZone input from an earlier test. Importing `cleanup` and calling
+// it in afterEach guarantees every render is torn down between tests.
+import { cleanup } from '@testing-library/react';
 
 // Mock the embedding service
 const mockEmbeddingService = {
@@ -110,6 +121,14 @@ describe('DocumentsPage search index integration', () => {
     mockEnsureEmbeddingServiceReady.mockResolvedValue(true);
     mockVectorIndex.initialize.mockClear();
     mockVectorIndex.initialize.mockResolvedValue(undefined);
+  });
+
+  // Tear down any mounted component between tests. Critical because several
+  // tests bail on a failed assertion before their explicit `unmount()`, and a
+  // leaked DocumentsPage leaves its DropZone input in the shared document,
+  // sending later tests' file-drop events to the wrong instance.
+  afterEach(() => {
+    cleanup();
   });
 
   describe('processFile indexing flow', () => {
@@ -255,7 +274,7 @@ describe('DocumentsPage search index integration', () => {
       // ensureEmbeddingServiceReady resolves false → ingestion must error.
       mockEnsureEmbeddingServiceReady.mockResolvedValue(false);
 
-      const { unmount } = render(<DocumentsPage />);
+      const { unmount } = render(<ToastProvider><DocumentsPage /></ToastProvider>);
 
       // Wait for the initial load to finish, then drop a file.
       await waitFor(() => expect(mockLoadDocuments).toHaveBeenCalled());
@@ -321,7 +340,7 @@ describe('DocumentsPage search index integration', () => {
       mockVectorIndex.isReady.mockReturnValue(true);
       mockEmbeddingService.encodeBatch.mockResolvedValue([new Array(384).fill(0)]);
 
-      const { unmount } = render(<DocumentsPage />);
+      const { unmount } = render(<ToastProvider><DocumentsPage /></ToastProvider>);
       await waitFor(() => expect(mockLoadDocuments).toHaveBeenCalled());
 
       const file = new File(['in-flight content'], 'inflight.txt', { type: 'text/plain' });
@@ -344,7 +363,9 @@ describe('DocumentsPage search index integration', () => {
       // Trigger deletion of the still-processing document. handleDelete should
       // await the in-flight processFile, so it stays pending while extraction
       // is blocked. We don't await the delete here; we fire it and let it hang.
-      // Find the delete button for the row (aria-label="Delete <filename>").
+      // U5: DocumentList uses a two-step inline confirmation — first click the
+      // "Delete <filename>" trigger to arm the confirm, then click "Confirm
+      // delete <filename>" to actually fire onDelete (which awaits processFile).
       await waitFor(() => {
         const btns = document.querySelectorAll('button[aria-label^="Delete "]');
         expect(btns.length).toBeGreaterThan(0);
@@ -352,6 +373,14 @@ describe('DocumentsPage search index integration', () => {
       const deleteButton = document.querySelector('button[aria-label^="Delete "]') as HTMLButtonElement;
       await act(async () => {
         deleteButton.click();
+      });
+      // Arm step done; now fire the actual confirm to trigger handleDelete.
+      await waitFor(() => {
+        expect(document.querySelector('button[aria-label^="Confirm delete "]')).toBeTruthy();
+      });
+      const confirmButton = document.querySelector('button[aria-label^="Confirm delete "]') as HTMLButtonElement;
+      await act(async () => {
+        confirmButton.click();
       });
 
       // The delete is now in flight and waiting on processFile. removeByDocId
@@ -410,7 +439,7 @@ describe('DocumentsPage search index integration', () => {
       mockVectorIndex.isReady.mockReturnValue(true);
       mockEmbeddingService.encodeBatch.mockResolvedValue([new Array(384).fill(0)]);
 
-      const { unmount, container } = render(<DocumentsPage />);
+      const { unmount, container } = render(<ToastProvider><DocumentsPage /></ToastProvider>);
       await waitFor(() => expect(mockLoadDocuments).toHaveBeenCalled());
 
       // Drop a file with the same name+size as the existing document.
@@ -442,16 +471,26 @@ describe('DocumentsPage search index integration', () => {
       mockVectorIndex.isReady.mockReturnValue(true);
       mockKeywordIndex.isReady.mockReturnValue(true);
 
-      const { unmount } = render(<DocumentsPage />);
+      const { unmount } = render(<ToastProvider><DocumentsPage /></ToastProvider>);
       await waitFor(() => expect(mockLoadDocuments).toHaveBeenCalled());
 
       // Click delete on the ready document.
+      // U5: DocumentList uses a two-step inline confirmation — click the
+      // "Delete <filename>" trigger to arm, then "Confirm delete <filename>"
+      // to actually fire onDelete (which cancels the stale debounced save and
+      // re-arms it with the post-delete list).
       await waitFor(() => {
         expect(document.querySelector('button[aria-label^="Delete "]')).toBeTruthy();
       });
       const saveCountBefore = mockSaveDocuments.mock.calls.length;
       await act(async () => {
         (document.querySelector('button[aria-label^="Delete "]') as HTMLButtonElement).click();
+      });
+      await waitFor(() => {
+        expect(document.querySelector('button[aria-label^="Confirm delete "]')).toBeTruthy();
+      });
+      await act(async () => {
+        (document.querySelector('button[aria-label^="Confirm delete "]') as HTMLButtonElement).click();
       });
 
       // After delete settles, the most recent save must NOT contain the deleted doc.
@@ -474,7 +513,7 @@ describe('DocumentsPage search index integration', () => {
       // upload that mutates state within the 500ms debounce window, then
       // immediately unmount — the pending save should flush.
       mockEnsureEmbeddingServiceReady.mockResolvedValue(false); // error fast, no encode
-      const { unmount } = render(<DocumentsPage />);
+      const { unmount } = render(<ToastProvider><DocumentsPage /></ToastProvider>);
       await waitFor(() => expect(mockLoadDocuments).toHaveBeenCalled());
 
       const file = new File(['flush-test'], 'flush.txt', { type: 'text/plain' });

--- a/web_ui/src/pages/DocumentsPage.indexing.test.tsx
+++ b/web_ui/src/pages/DocumentsPage.indexing.test.tsx
@@ -4,7 +4,23 @@
 
 import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
 import React from 'react';
-// U3b: DocumentsPage now calls useToast(), which requires a ToastProvider.
+
+// PRR-009: mock the ToastProvider module so we can spy on `showToast` calls
+// precisely (rather than asserting on rendered toast DOM). The factory keeps a
+// pass-through ToastProvider that just renders its children, so every existing
+// test that wraps a render in <ToastProvider> continues to work unchanged —
+// the only difference is no real toast DOM is rendered (none of the existing
+// tests assert on toast text in the DOM; they assert on DocumentsPage-rendered
+// notices or on persisted state).
+const showToastSpy = vi.fn();
+vi.mock('../components/ToastProvider', () => ({
+  // Pass-through provider: render children, ignore toasts (we assert via spy).
+  ToastProvider: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+  useToast: () => ({ showToast: showToastSpy }),
+}));
+// Bind the mocked ToastProvider for JSX usage in renders below. (vi.mock is
+// hoisted above imports, so this resolves to the pass-through factory above.)
 import { ToastProvider } from '../components/ToastProvider';
 // RTL auto-cleanup does not register reliably when @testing-library/react is
 // loaded via dynamic import inside each test (the afterEach hook is registered
@@ -121,6 +137,8 @@ describe('DocumentsPage search index integration', () => {
     mockEnsureEmbeddingServiceReady.mockResolvedValue(true);
     mockVectorIndex.initialize.mockClear();
     mockVectorIndex.initialize.mockResolvedValue(undefined);
+    // PRR-009: reset the shared toast spy between tests.
+    showToastSpy.mockClear();
   });
 
   // Tear down any mounted component between tests. Critical because several
@@ -538,6 +556,254 @@ describe('DocumentsPage search index integration', () => {
         return docs?.some((d) => d.fileName === 'flush.txt');
       });
       expect(sawFlushEntry).toBe(true);
+    });
+  });
+
+  describe('PRR-008a: per-document indexing cancel (U2)', () => {
+    test('cancel mid-indexing aborts the AbortController and sets a terminal "Indexing cancelled" error', async () => {
+      const { render, waitFor, act } = await import('@testing-library/react');
+      const { DocumentsPage } = await import('./DocumentsPage');
+
+      // Park vectorIndex.save() on a deferred we control. save() is called at
+      // the end of the embedding try-block (DocumentsPage.tsx:293); while it is
+      // parked, the run is MID-indexing (status 'processing', encodeBatch
+      // already completed). We cancel here, then release save() so the run
+      // proceeds to keyword indexing and hits the next throwIfCancelled()
+      // checkpoint (line 323), which throws 'Indexing cancelled' -> the outer
+      // catch records terminal error state. This faithfully exercises the
+      // cancel path: abort() is called while indexing, and the checkpoint the
+      // source actually uses to terminate the run raises.
+      const releaseSave: Array<() => void> = [];
+      const saveEntered = new Promise<void>((resolve) => {
+        releaseSave.push(resolve);
+      });
+      const saveBlocked = new Promise<void>((resolve) => {
+        releaseSave.push(resolve);
+      });
+      let encodeCalled = false;
+      mockEmbeddingService.isReady.mockReturnValue(true);
+      mockVectorIndex.isReady.mockReturnValue(true);
+      mockEnsureEmbeddingServiceReady.mockResolvedValue(true);
+      mockEmbeddingService.encodeBatch.mockImplementation(
+        async (texts: string[]) => {
+          encodeCalled = true;
+          return texts.map(() => new Array(384).fill(0));
+        }
+      );
+      mockVectorIndex.save.mockImplementation(async () => {
+        releaseSave[0](); // signal save was reached (run is mid-indexing)
+        await saveBlocked; // park until the test releases
+      });
+
+      const { unmount } = render(<ToastProvider><DocumentsPage /></ToastProvider>);
+      await waitFor(() => expect(mockLoadDocuments).toHaveBeenCalled());
+
+      const file = new File(['cancel me'], 'cancel.txt', { type: 'text/plain' });
+      const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+      await act(async () => {
+        Object.defineProperty(input, 'files', { value: [file], writable: false, configurable: true });
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+      });
+
+      // Wait until the run has reached vectorIndex.save() — i.e. encodeBatch
+      // completed and we are genuinely mid-indexing.
+      await waitFor(() => expect(encodeCalled).toBe(true));
+      await saveEntered;
+
+      // The Cancel button is rendered by DocumentList during 'processing' with
+      // aria-label "Cancel indexing <filename>".
+      await waitFor(() => {
+        expect(
+          document.querySelector('button[aria-label^="Cancel indexing "]')
+        ).toBeTruthy();
+      });
+
+      // Fire cancel. handleCancelIndexing calls controller.abort(); releasing
+      // save() lets the run reach the throwIfCancelled() checkpoint after the
+      // keyword-index phase, which raises 'Indexing cancelled'.
+      const cancelButton = document.querySelector(
+        'button[aria-label^="Cancel indexing "]'
+      ) as HTMLButtonElement;
+      await act(async () => {
+        cancelButton.click();
+      });
+      // Release the parked save so the run can advance to the checkpoint.
+      releaseSave[1]();
+
+      // The document must reach a terminal 'error' state with the cancellation
+      // message. Verified via the persisted saveDocuments payload (the source
+      // of truth for terminal state).
+      await waitFor(() => {
+        const calls = mockSaveDocuments.mock.calls;
+        const last = calls[calls.length - 1]?.[0] as
+          | Array<{ fileName: string; status: string; errorMessage?: string }>
+          | undefined;
+        const doc = last?.find((d) => d.fileName === 'cancel.txt');
+        expect(doc?.status).toBe('error');
+        expect(doc?.errorMessage).toBe('Indexing cancelled');
+      });
+
+      // Cancellation is user-initiated: the source intentionally does NOT fire
+      // an error toast (the terminal 'Indexing cancelled' state is sufficient).
+      expect(
+        showToastSpy.mock.calls.some(([, type]) => type === 'error')
+      ).toBe(false);
+
+      unmount();
+    });
+  });
+
+  describe('PRR-008b: embedding progress maps to the 78->95 band', () => {
+    test('encodeBatch onProgress(5,10) updates the progressbar aria-valuenow to 78 + round(5/10*17) = 87', async () => {
+      const { render, waitFor, act } = await import('@testing-library/react');
+      const { DocumentsPage } = await import('./DocumentsPage');
+
+      // Capture the onProgress callback passed to encodeBatch (2nd arg). Park
+      // the encode so we can drive onProgress ourselves and observe the mapped
+      // progress in the DOM before the run completes.
+      let capturedOnProgress: ((processed: number, total: number) => void) | undefined;
+      const releaseEncode: Array<() => void> = [];
+      const encodeEntered = new Promise<void>((resolve) => {
+        releaseEncode.push(resolve);
+      });
+      mockEmbeddingService.isReady.mockReturnValue(true);
+      mockVectorIndex.isReady.mockReturnValue(true);
+      mockEnsureEmbeddingServiceReady.mockResolvedValue(true);
+      mockEmbeddingService.encodeBatch.mockImplementation(
+        async (_texts: string[], onProgress?: (processed: number, total: number) => void) => {
+          capturedOnProgress = onProgress;
+          releaseEncode[0]();
+          await new Promise<void>(() => {
+            /* park forever; test drives progress via capturedOnProgress */
+          });
+          return [];
+        }
+      );
+
+      const { unmount } = render(<ToastProvider><DocumentsPage /></ToastProvider>);
+      await waitFor(() => expect(mockLoadDocuments).toHaveBeenCalled());
+
+      const file = new File(['progress mapping'], 'progress.txt', { type: 'text/plain' });
+      const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+      await act(async () => {
+        Object.defineProperty(input, 'files', { value: [file], writable: false, configurable: true });
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+      });
+
+      await waitFor(() => expect(mockEmbeddingService.encodeBatch).toHaveBeenCalled());
+      await encodeEntered;
+      await waitFor(() => expect(capturedOnProgress).toBeDefined());
+
+      // Drive the captured onProgress with (processed=5, total=10). The source
+      // maps this to 78 + round((5/10) * 17) = 78 + 9 = 87.
+      await act(async () => {
+        capturedOnProgress!(5, 10);
+      });
+
+      // The processing row renders a progressbar with aria-valuenow reflecting
+      // the mapped value. Wait for React to flush the state update.
+      await waitFor(() => {
+        const bar = document.querySelector(
+          'div[role="progressbar"]'
+        ) as HTMLElement | null;
+        expect(bar).toBeTruthy();
+        expect(bar?.getAttribute('aria-valuenow')).toBe('87');
+      });
+
+      // Explicitly assert the mapped value equals the documented formula.
+      const bar = document.querySelector('div[role="progressbar"]') as HTMLElement;
+      const expected = 78 + Math.round((5 / 10) * 17);
+      expect(expected).toBe(87);
+      expect(Number(bar.getAttribute('aria-valuenow'))).toBe(expected);
+      // And that it falls within the reserved embedding band [78, 95].
+      expect(Number(bar.getAttribute('aria-valuenow'))).toBeGreaterThanOrEqual(78);
+      expect(Number(bar.getAttribute('aria-valuenow'))).toBeLessThanOrEqual(95);
+
+      unmount();
+    });
+  });
+
+  describe('PRR-009: showToast call sites (U3b)', () => {
+    test('delete-success fires showToast("Document deleted", "success")', async () => {
+      const { render, waitFor, act } = await import('@testing-library/react');
+      const { DocumentsPage } = await import('./DocumentsPage');
+
+      // Seed a ready document so handleDelete can run its full path.
+      mockLoadDocuments.mockResolvedValueOnce([
+        {
+          id: 'del-toast-1',
+          fileName: 'toastdel.txt',
+          fileSize: 42,
+          fileType: '.txt',
+          status: 'ready',
+          progress: 100,
+          uploadedAt: 1000,
+        },
+      ]);
+      mockVectorIndex.isReady.mockReturnValue(true);
+      mockKeywordIndex.isReady.mockReturnValue(true);
+
+      const { unmount } = render(<ToastProvider><DocumentsPage /></ToastProvider>);
+      await waitFor(() => expect(mockLoadDocuments).toHaveBeenCalled());
+
+      // U5: two-step inline delete confirmation.
+      await waitFor(() => {
+        expect(document.querySelector('button[aria-label^="Delete "]')).toBeTruthy();
+      });
+      await act(async () => {
+        (document.querySelector('button[aria-label^="Delete "]') as HTMLButtonElement).click();
+      });
+      await waitFor(() => {
+        expect(document.querySelector('button[aria-label^="Confirm delete "]')).toBeTruthy();
+      });
+      await act(async () => {
+        (document.querySelector('button[aria-label^="Confirm delete "]') as HTMLButtonElement).click();
+      });
+
+      // handleDelete's success path calls showToast('Document deleted', 'success').
+      await waitFor(() => {
+        expect(showToastSpy).toHaveBeenCalledWith('Document deleted', 'success');
+      });
+
+      unmount();
+    });
+
+    test('a vector-index addBatch failure fires a showToast with type "error" (semantic-search failure path)', async () => {
+      const { render, waitFor, act } = await import('@testing-library/react');
+      const { DocumentsPage } = await import('./DocumentsPage');
+
+      // Make addBatch reject. processFile catches it inside the vector-index
+      // try and calls showToast('Failed to index document for semantic search.', 'error')
+      // (source line ~300), then continues. The doc still reaches 'ready'.
+      mockEmbeddingService.isReady.mockReturnValue(true);
+      mockVectorIndex.isReady.mockReturnValue(true);
+      mockEnsureEmbeddingServiceReady.mockResolvedValue(true);
+      mockEmbeddingService.encodeBatch.mockResolvedValue([new Array(384).fill(0)]);
+      mockVectorIndex.addBatch.mockRejectedValueOnce(new Error('vector index write failed'));
+
+      const { unmount } = render(<ToastProvider><DocumentsPage /></ToastProvider>);
+      await waitFor(() => expect(mockLoadDocuments).toHaveBeenCalled());
+
+      const file = new File(['toast fail'], 'toastfail.txt', { type: 'text/plain' });
+      const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+      await act(async () => {
+        Object.defineProperty(input, 'files', { value: [file], writable: false, configurable: true });
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+      });
+
+      // Assert the specific semantic-search failure toast fired with type error.
+      await waitFor(() => {
+        expect(showToastSpy).toHaveBeenCalledWith(
+          'Failed to index document for semantic search.',
+          'error'
+        );
+      });
+      // And at least one error-type toast fired overall.
+      expect(
+        showToastSpy.mock.calls.some(([, type]) => type === 'error')
+      ).toBe(true);
+
+      unmount();
     });
   });
 

--- a/web_ui/src/pages/DocumentsPage.tsx
+++ b/web_ui/src/pages/DocumentsPage.tsx
@@ -6,6 +6,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { DropZone } from '../components/DropZone';
 import { DocumentList } from '../components/DocumentList';
 import { LoadingSkeleton } from '../components/LoadingSkeleton';
+import { useToast } from '../components/ToastProvider';
 import type { DocumentEntry } from '../types/document';
 import { extractDocument, SUPPORTED_EXTENSIONS } from '../lib/processing/extractor-factory';
 import { TextChunker } from '../lib/processing/text-chunker';
@@ -21,6 +22,8 @@ function generateId(): string {
 }
 
 export function DocumentsPage() {
+  // U3b: surface user-facing failures (and delete success) as toasts.
+  const { showToast } = useToast();
   const [documents, setDocuments] = useState<DocumentEntry[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [deletingId, setDeletingId] = useState<string | null>(null);
@@ -37,6 +40,10 @@ export function DocumentsPage() {
   // F3: in-flight processFile promises keyed by docId, so handleDelete can wait
   // for processing to settle before removing chunks (avoids orphan chunks).
   const processingPromisesRef = useRef<Map<string, Promise<void>>>(new Map());
+  // U2: per-document AbortControllers keyed by docId. processFile arms one at
+  // start and checks controller.signal between stages; the UI Cancel button
+  // calls controller.abort() so the next check throws (caught -> terminal error).
+  const cancelControllersRef = useRef<Map<string, AbortController>>(new Map());
 
   // F9: surface the re-index requirement once. The flag is set by VectorIndex
   // on version mismatch; cleared here on dismiss so the user sees it once.
@@ -90,6 +97,7 @@ export function DocumentsPage() {
         setDocuments(recovered);
       } catch (error) {
         console.error('Failed to load documents:', error);
+        showToast('Failed to load documents. Please reload the page.', 'error');
       } finally {
         if (!cancelled) setIsLoading(false);
       }
@@ -122,6 +130,7 @@ export function DocumentsPage() {
         await saveDocuments(latestDocumentsRef.current);
       } catch (error) {
         console.error('Failed to save documents:', error);
+        showToast('Failed to save document changes. They may not persist after reload.', 'error');
       }
     }, 500);
 
@@ -156,6 +165,18 @@ export function DocumentsPage() {
     const run = async () => {
       const chunker = new TextChunker();
 
+      // U2: arm a per-document AbortController so the UI Cancel button can stop
+      // indexing before the next batch. Replaced on every processFile invocation.
+      const controller = new AbortController();
+      cancelControllersRef.current.set(docId, controller);
+      // Helper: if the user cancelled, mark the doc terminal and throw so the
+      // outer catch records a single 'Indexing cancelled' error.
+      const throwIfCancelled = () => {
+        if (controller.signal.aborted) {
+          throw new Error('Indexing cancelled');
+        }
+      };
+
     try {
       // Update status to processing
       setDocuments((prev) =>
@@ -166,6 +187,7 @@ export function DocumentsPage() {
 
       // Extract text from document
       const extractionResult = await extractDocument(file);
+      throwIfCancelled(); // U2: check cancel after extraction
 
       setDocuments((prev) =>
         prev.map((doc) =>
@@ -191,6 +213,7 @@ export function DocumentsPage() {
           doc.id === docId ? { ...doc, progress: 75 } : doc
         )
       );
+      throwIfCancelled(); // U2: check cancel before model init
 
       // F2: ensure BOTH the embedding service and the vector index are ready
       // before deciding whether to vector-index. The embedding model is
@@ -230,9 +253,34 @@ export function DocumentsPage() {
       // source (filename) and page so vector search results carry real text and
       // citation metadata (F1/F7). NOTE: this minimal metadata capture overlaps
       // with PR-4 (#23), which owns broader ingestion work.
+      //
+      // U2: the embedding loop is the long pole. encodeBatch already supports an
+      // onProgress callback (embedding-service.ts:225), so map its (processed,
+      // total) onto the indexing band of the progress bar. Earlier milestones
+      // reserved 30 (start) / 60 (extracted) / 75 (chunked) / 78 (model ready).
+      // Embedding runs the bar from 78 up to 95; the post-embedding keyword +
+      // finalize stages fill 90-100 below. Stage label is surfaced via the
+      // existing errorMessage field (used creatively as in-flight status text)
+      // WITHOUT changing the DocumentEntry type; cleared on success.
+      setDocuments((prev) =>
+        prev.map((doc) =>
+          doc.id === docId
+            ? { ...doc, errorMessage: 'Generating embeddings\u2026' }
+            : doc
+        )
+      );
       try {
         const texts = chunks.map((c) => c.text);
-        const vectors = await embeddingService.encodeBatch(texts);
+        const vectors = await embeddingService.encodeBatch(texts, (processed, total) => {
+          if (total <= 0) return;
+          // Map embedding progress onto the 78 -> 95 band.
+          const embeddingProgress = 78 + Math.round((processed / total) * 17);
+          setDocuments((prev) =>
+            prev.map((doc) =>
+              doc.id === docId ? { ...doc, progress: embeddingProgress } : doc
+            )
+          );
+        });
         const entries = chunks.map((chunk, i) => ({
           docId: chunk.docId!,
           chunkIndex: chunk.chunkIndex,
@@ -245,11 +293,25 @@ export function DocumentsPage() {
         await vectorIndex.save();
       } catch (indexError) {
         console.error('Failed to add to vector index:', indexError);
+        // U2: a cancel surfaces here as an abort; rethrow so the outer handler
+        // records the terminal 'Indexing cancelled' state rather than silently
+        // continuing to keyword indexing.
+        if (controller.signal.aborted) throw indexError;
+        showToast('Failed to index document for semantic search.', 'error');
         // Continue so keyword indexing can proceed
       }
 
       // Keyword index: add text chunks
       if (keywordIndex.isReady()) {
+        // U2: stage label for the keyword-indexing phase (reuses errorMessage
+        // creatively; cleared on success below).
+        setDocuments((prev) =>
+          prev.map((doc) =>
+            doc.id === docId
+              ? { ...doc, errorMessage: 'Indexing keywords\u2026' }
+              : doc
+          )
+        );
         try {
           keywordIndex.addDocuments(chunks);
           await keywordIndex.save();
@@ -258,11 +320,14 @@ export function DocumentsPage() {
           // Continue so document is still marked as processed
         }
       }
+      throwIfCancelled(); // U2: check cancel before finalize
 
-      // Update progress to 90 after indexing
+      // Update progress to 90 after indexing and clear the in-flight status text.
       setDocuments((prev) =>
         prev.map((doc) =>
-          doc.id === docId ? { ...doc, progress: 90 } : doc
+          doc.id === docId
+            ? { ...doc, progress: 90, errorMessage: undefined }
+            : doc
         )
       );
 
@@ -274,6 +339,7 @@ export function DocumentsPage() {
                 status: 'ready',
                 progress: 100,
                 chunkCount: chunks.length,
+                errorMessage: undefined,
               }
             : doc
         )
@@ -285,6 +351,7 @@ export function DocumentsPage() {
           : typeof error === 'object' && error !== null && 'error' in error
           ? String((error as Record<string, unknown>).error)
           : 'Unknown error occurred';
+      const wasCancelled = controller.signal.aborted;
       console.error('Failed to process document:', error);
 
       setDocuments((prev) =>
@@ -294,6 +361,17 @@ export function DocumentsPage() {
             : doc
         )
       );
+      // U3b: surface indexing/quota/init failures as a toast. Cancellation is
+      // user-initiated, so it stays silent here (the doc already shows the
+      // terminal 'Indexing cancelled' state).
+      if (!wasCancelled) {
+        showToast(`Failed to process "${file.name}": ${errorMessage}`, 'error');
+      }
+    } finally {
+      // U2: drop this run's AbortController unless a newer run replaced it.
+      if (cancelControllersRef.current.get(docId) === controller) {
+        cancelControllersRef.current.delete(docId);
+      }
     }
     }; // end run()
 
@@ -375,6 +453,17 @@ export function DocumentsPage() {
     return () => clearTimeout(t);
   }, [duplicateNotice]);
 
+  // U2: per-document indexing cancel. Aborts the AbortController armed in
+  // processFile; the next throwIfCancelled() checkpoint (or the embedding batch
+  // boundary) records the terminal 'Indexing cancelled' state. No-op if the
+  // document isn't currently being indexed.
+  const handleCancelIndexing = useCallback((docId: string) => {
+    const controller = cancelControllersRef.current.get(docId);
+    if (controller) {
+      controller.abort();
+    }
+  }, []);
+
   // Handle document deletion.
   // F3: if the document is still being processed, await the in-flight
   // processFile first so its addBatch/save either completes (and is then
@@ -429,8 +518,11 @@ export function DocumentsPage() {
 
       // Remove from state
       setDocuments((prev) => prev.filter((doc) => doc.id !== docId));
+      // U3b: confirm the deletion to the user.
+      showToast('Document deleted', 'success');
     } catch (error) {
       console.error('Failed to delete document:', error);
+      showToast('Failed to delete document. Please try again.', 'error');
     } finally {
       setDeletingId(null);
     }
@@ -569,6 +661,13 @@ export function DocumentsPage() {
         <DropZone
           onFilesSelected={handleFilesSelected}
           accept={SUPPORTED_EXTENSIONS.join(',')}
+          onFilesRejected={(fileNames) => {
+            // U7a: surface skipped filenames so the user knows files were
+            // discarded (previously DropZone filtered silently).
+            const preview = fileNames.slice(0, 3).join(', ');
+            const extra = fileNames.length > 3 ? ` and ${fileNames.length - 3} more` : '';
+            showToast(`Unsupported file type: ${preview}${extra}`, 'error');
+          }}
         />
       </div>
 
@@ -578,6 +677,7 @@ export function DocumentsPage() {
           documents={documents}
           onDelete={handleDelete}
           deletingId={deletingId}
+          onCancelIndexing={handleCancelIndexing}
         />
       </div>
     </div>

--- a/web_ui/src/styles/tokens.css
+++ b/web_ui/src/styles/tokens.css
@@ -24,9 +24,11 @@
   --color-primary-rgb: 26, 115, 232;
   --color-text-primary: #1a1a2e;
   /* AA-compliant toast/surface tokens (white text, both themes). Verified
-     via the WCAG relative-luminance formula: success 5.02:1, info 5.93:1. */
+     via the WCAG relative-luminance formula: success 5.02:1, info 5.93:1,
+     warning 4.97:1 on the light bubble-assistant surface. */
   --color-success-strong: #15803d;
   --color-info-strong: #0369a1;
+  --color-warning-strong: #a16207;
   --color-surface-elevated: #ffffff;
 
   /* Type scale — font family + sizes */
@@ -96,4 +98,18 @@
 @keyframes blink {
   0%, 100% { opacity: 1; }
   50% { opacity: 0; }
+}
+
+/* U6d: respect prefers-reduced-motion. Disable the spin/blink/shimmer loops
+   for users who request reduced motion. StreamingIndicator already guards
+   itself; this covers the boot overlay spinner, the streaming cursor, and
+   LoadingSkeleton's shimmer. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+  }
 }

--- a/web_ui/src/types/chat.ts
+++ b/web_ui/src/types/chat.ts
@@ -39,7 +39,12 @@ export interface ChatMessage {
   abstainReason?: 'insufficient_evidence' | 'retrieval_degraded';
   /** True when retrieval ran keyword-only because semantic search was unavailable (F4). */
   retrievalDegraded?: boolean;
+  /** Structured error string when generation failed mid-stream (S6). Rendered
+   *  as a styled error card instead of being injected into `content`. */
+  error?: string;
   timestamp: number;
+  /** Transient UI flag — stripped before persistence (S3). Drives the
+   *  streaming cursor; never persisted to IndexedDB. */
   isStreaming?: boolean;
   /** Images the user attached to this message (multimodal). */
   images?: ChatImage[];

--- a/web_ui/src/types/llm.ts
+++ b/web_ui/src/types/llm.ts
@@ -110,6 +110,10 @@ export interface LLMService {
   isReady(): boolean;
   /** Interrupt an in-progress generation. */
   interrupt(): void;
+  /** U8c: true when the loaded model accepts image inputs (multimodal).
+   *  Optional — WebLLMService returns false; WllamaService consults
+   *  wllama.supportInputModality('image'). */
+  supportsImages?(): boolean;
   /** Release resources held by the engine. */
   dispose(): void;
 }

--- a/web_ui/src/utils/relativeTime.ts
+++ b/web_ui/src/utils/relativeTime.ts
@@ -1,5 +1,12 @@
-export function formatRelativeTime(timestamp: string | number): string {
-  const now = Date.now();
+/**
+ * Format a timestamp as a relative-time label ("Just now", "3m ago", …).
+ *
+ * @param timestamp - The reference time (ms epoch, or an ISO/parsable string).
+ * @param now - Optional override for "now" (ms epoch). Used by ChatMessageList's
+ *   60s ticker (S8) so a re-render with a new `now` recomputes the label even
+ *   though ChatMessageBubble is React.memo'd. Defaults to Date.now().
+ */
+export function formatRelativeTime(timestamp: string | number, now: number = Date.now()): string {
   const then = typeof timestamp === 'string' ? new Date(timestamp).getTime() : timestamp;
   if (!then || isNaN(then)) return '';
   const diff = now - then;

--- a/web_ui/vitest.config.ts
+++ b/web_ui/vitest.config.ts
@@ -55,14 +55,12 @@ export default defineConfig({
       'src/pages/ChatPage.rag.test.tsx',
       'src/pages/ChatPage.server-mode.test.tsx',
       'src/pages/ChatPage.shortcuts.test.tsx',
-      'src/lib/streaming/TokenStreamManager.test.ts',
       'src/lib/inference/InferenceModeContext.test.tsx',
       // Extractor return-shape drift (asserts string, code returns object) and
       // stale model-id expectations. Owned by document-ingestion PR #23.
       'src/lib/processing/docx-extractor.test.ts',
       'src/lib/processing/xlsx-extractor.test.ts',
       'src/lib/processing/pptx-extractor.test.ts',
-      'src/lib/llm/web-llm-service.test.ts',
       'src/lib/llm/webgpu-watchdog.test.ts',
       // Allocates multi-GB page fixtures for TextChunker stress/verification;
       // exceeds the per-fork memory limit under the tuned pool. Owned by


### PR DESCRIPTION
Closes #36

> **Update (swarm-pr-feedback):** commit `76fab69` addresses the swarm-pr-review findings (PRR-001 BLOCKER + PRR-005 + 4 HIGH test gaps). See the closure ledger comment below.

## Summary

PR-A: chat correctness & UX overhaul for `web_ui/`. Replaces the hand-rolled markdown renderer with `react-markdown` + `remark-gfm`, fixes the CRITICAL mid-stream conversation-switch data corruption (S1) and the broader streaming/persistence defect class (S2–S8), and remediates the UX/accessibility backlog (U1–U8). Frontend-only — no vector re-index required; the only `rag-orchestrator.ts` touch is the U8a abstain-with-image guard (documented seam with #37).

**Part 1 — Renderer.** `MarkdownRenderer.tsx` rewritten on react-markdown + remark-gfm (pure-JS, air-gap-safe). Custom `urlTransform` rejects scheme-less/relative/scheme-relative URLs. No `rehype-raw` (zero-HTML-injection preserved). Code blocks get language chips + copy buttons. 100ms streaming throttle. Closes A1, N2, N3, A2, A3, A4, A5, A6, A8, N9, N10, N11, N12, A7.

**Part 2 — Streaming & persistence integrity.**
- **S1 (CRITICAL):** thread owning conversation id + messages snapshot captured at send time through `runGeneration`; `handleSend` awaits the send-time save so the owning id is resolved before streaming starts; cancel stream on conversation switch; `saveMessages` takes explicit `conversationId`. Gold-standard + first-turn regression tests prove no overwrite and no duplicate.
- **S2:** persist on send/cancel/error/unmount/engine-switch. **S3:** strip `isStreaming` before persistence; finalize flags on cleanup. **S4:** `cancel()` flushes buffered tokens before clearing; overflow flushes (no splice); hidden-tab setTimeout fallback. **S5:** render-only windowing in `ChatMessageList` (full history persists). **S6:** structured `error` field + styled error card. **S7:** WebLLM interrupt wired (abort→`interruptGenerate` listener; `cancelActiveStream` calls `interrupt()`). **S8:** thread `now` prop so timestamps recompute. Dead `appendMessage` removed.
- **PRR-001 (swarm-pr-review BLOCKER, fixed in `76fab69`):** the conversation-switch effect now PERSISTS the partial assistant turn to the owning conversation id before cancelling (previously lost — `cancel()` never fires onDone/onError). The unmount-cleanup effect is now unmount-only (`[]` dep) after discovering React runs effect destroys before creates on a dep change, which had made the prior switch-effect persist line dead code. A new `owningMessagesRef` (mirrored per-token) lets the switch/unmount/engine-switch effects read the owning conversation's partial turn instead of the live `messagesRef`.
- **PRR-005:** `handleCancel` now reads `messagesRef.current` AFTER cancel so the cancel-flushed tail tokens are persisted.

**Part 3 — UX / accessibility.** U1 determinate cold-load bar; U2 real per-batch indexing progress + cancel; U3 wired the zero-call-site toast system + persistent init-error banner; U4 document-count-aware empty state (`useDocumentCount`); U5 two-step delete confirm; U6 `--color-warning-strong` + AA labels, sidebar focus/kebab a11y, dropped `aria-live` from scroll container, `prefers-reduced-motion`; U7 DropZone feedback, mode-toggle gated on `serverUrl`, Ctrl+L→Ctrl+Shift+L; U8a image-on-empty-corpus reaches VLM, U8c `canAttachImages` consults `supportsImages()`.

## Invariant audit

- **No vector re-index:** frontend-only; single `rag-orchestrator.ts` line (U8a abstain guard). ✅
- **Zero `dangerouslySetInnerHTML` / no `rehype-raw`:** grep confirms none added. ✅
- **Scheme allowlist + tests:** `urlTransform` allows `http|https|mailto|tel`; rejects scheme-less/relative/`javascript:`/`data:`/`blob:`/`file:`. Tests assert `//evil.com/x`, `/settings`, `not-a-url` → no `<a>`. ✅
- **Auto-scroll behavior preserved:** windowing is render-only; full-array last-message + scroll heuristics intact. ✅
- **New-Chat non-empty→empty guard preserved:** `ChatPage.tsx` cancel-on-switch effect is additive. ✅
- **IME/Enter handling untouched:** only placeholder text changed. ✅
- **wllama abort path untouched:** only WebLLM `generate()` gained the abort listener. ✅
- **Air-gap packaging:** react-markdown + remark-gfm are pure-JS ESM, no runtime fetch; `validate-build.mjs` greps no CDN hostnames; `offline-env.ts` `allowRemoteModels=false` governs. ✅

## Test plan

All run from `web_ui/`:
- `npm run typecheck:all` → **0 errors** (both tsconfigs).
- `npm test` → **1117 passed, 2 skipped** (63 files). Includes the S1 switch-mid-stream + first-turn regression tests, the un-excluded `TokenStreamManager.test.ts` + `web-llm-service.test.ts` (S4/S7 contracts), and the swarm-pr-feedback additions: persist-on-switch/cancel/unmount/engine-switch, indexing cancel + progress, toast assertions, and the image-on-empty-corpus abstain guard.
- `npm run build` → **success** (only the pre-existing chunk-size warning from ML libs/weights).
- Each new regression test was verified to FAIL when its fix is reverted.

## Notes / deferred

- **U7c** (duplicate-upload "Replace" flow) deferred to PR-B (#37) — it owns the re-index flow; adding a shared helper here would expand the seam surface.
- **U7f** (regenerate persistence) logged as an accepted limitation — `lastTurnRef` is session-ephemeral by design; persisting last-turn inputs would add schema complexity for marginal benefit.
- **WASM-blocked test un-exclusions** (`DocumentsPage.test.tsx`, `ChatPage.verification-3.3.test.tsx`, etc.) remain excluded — owned by #22/#37. New tests for this PR's work live in standalone non-excluded files.
- **Cross-model review note:** the `swarm-reviewer` (Kimi K2.7) agent type was unavailable this session (requires a session restart to load its custom agent definition). The independent implementation reviewer, final critic, and PR reviewers all ran on GLM-5.2 with this limitation disclosed.