### PR TITLE
feat(web_ui): switch browser LLM to Google Gemma 4 E2B-it

### DIFF
--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -137,18 +137,20 @@ running **Google Gemma 4 E2B-it GGUF + mmproj**. Two pieces are packaged:
 
 ```bash
 # (a) obtain Gemma 4 E2B-it GGUF + mmproj from unsloth/gemma-4-E2B-it-GGUF on HuggingFace:
-#       gemma-4-E2B-it-Q4_K_M.gguf  (~1.5 GB) → rename to model.gguf
-#       mmproj (matching projector)  (~150 MB) → rename to mmproj.gguf
+#       gemma-4-E2B-it-Q4_K_M.gguf  (~2.9 GB) → rename to model.gguf
+#       mmproj-F16.gguf              (~940 MB) → rename to mmproj.gguf
 #     then place them at the repo root as:
 #       models/gemma-4-e2b-it/model.gguf
 #       models/gemma-4-e2b-it/mmproj.gguf
 # (b) npm run prepare-models   # copies them to public/models/llm/gemma-4-e2b-it/
 ```
 
-Gemma 4 E2B-it Q4_K_M is ~1.5 GB, under wllama's 2 GB/file `ArrayBuffer`
-limit, so a single `model.gguf` works. ~2.3B effective parameters (~5.1B total
-with Per-Layer Embeddings), 128K context window (capped at 8192 by default for
-RAM headroom on 8 GB target boxes).
+Gemma 4 E2B-it Q4_K_M is ~2.9 GB. This exceeds the historical ~2 GB/file WASM
+`ArrayBuffer` ceiling, but wllama v3+ streams via HTTP range requests (not a
+single ArrayBuffer), so the practical limit is browser RAM, not the 2 GB ceiling.
+Validate on target hardware before packaging. ~2.3B effective parameters (~5.1B
+total with Per-Layer Embeddings), 128K context window (capped at 8192 by default
+for RAM headroom on 8 GB target boxes).
 
 The user picks the engine in Settings (**wllama** default, or **WebLLM** when
 WebGPU is usable); the choice persists and the RAG pipeline routes accordingly.

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -12,7 +12,7 @@ desktop app's GGUF policy). They are assembled into `web_ui/public/models/` at
 packaging time by `web_ui/scripts/prepare-models.mjs`.
 
 > Status: **Phase 1** covers the embedding model + ONNX Runtime WASM. The
-> LFM2.5-VL GGUF (browser LLM, wllama) lands in Phase 2 and is documented below as
+> Gemma 4 E2B-it GGUF (browser LLM, wllama) lands in Phase 2 and is documented below as
 > the target procedure.
 
 ---
@@ -73,7 +73,7 @@ npm run build:offline      # = prepare-models && tsc/vite build && validate-buil
    `public/models/manifest.json` is absent from `dist/models/`. The manifest is
    the **single source of truth** shared with `src/lib/models/model-manifest.ts`
    (imported at runtime), so the TS readiness gate and the build validator
-   cannot drift. Pass `--no-llm` to skip the browser-LLM runtime + LFM2.5-VL
+   cannot drift. Pass `--no-llm` to skip the browser-LLM runtime + Gemma 4 E2B-it
    weights group (for an embeddings-only / server-mode archive where the
    multi-GB LLM weights are deliberately absent). (It does not grep bundled JS
    for CDN hostnames — vendored ML libs embed default-CDN constants that survive
@@ -119,10 +119,10 @@ would otherwise make a build with zero model files falsely report "ready".
 
 ---
 
-## 5. Browser LLM — wllama + LFM2.5-VL (multimodal)
+## 5. Browser LLM — wllama + Gemma 4 E2B-it (multimodal)
 
 Browser inference uses **wllama** (llama.cpp in WASM, CPU/SIMD, **no WebGPU**)
-running **LiquidAI LFM2.5-VL-450M GGUF + mmproj**. Two pieces are packaged:
+running **Google Gemma 4 E2B-it GGUF + mmproj**. Two pieces are packaged:
 
 1. **wllama runtime** — `npm run prepare-models` copies, from node_modules:
    - `@wllama/wllama` → `public/models/wllama/wasm/wllama.wasm` (the modern build)
@@ -136,20 +136,19 @@ running **LiquidAI LFM2.5-VL-450M GGUF + mmproj**. Two pieces are packaged:
    browser generation, server mode is unaffected):
 
 ```bash
-# (a) obtain LFM2.5-VL GGUF + mmproj from LiquidAI/LFM2.5-VL-450M-GGUF on HuggingFace:
-#       LFM2.5-VL-450M-Q4_K_M.gguf     (~229 MB) → rename to model.gguf
-#       mmproj-LFM2.5-VL-450m-Q8_0.gguf (~99 MB)  → rename to mmproj.gguf
+# (a) obtain Gemma 4 E2B-it GGUF + mmproj from unsloth/gemma-4-E2B-it-GGUF on HuggingFace:
+#       gemma-4-E2B-it-Q4_K_M.gguf  (~1.5 GB) → rename to model.gguf
+#       mmproj (matching projector)  (~150 MB) → rename to mmproj.gguf
 #     then place them at the repo root as:
-#       models/lfm2.5-vl-450m/model.gguf
-#       models/lfm2.5-vl-450m/mmproj.gguf
-# (b) npm run prepare-models   # copies them to public/models/llm/lfm2.5-vl-450m/
+#       models/gemma-4-e2b-it/model.gguf
+#       models/gemma-4-e2b-it/mmproj.gguf
+# (b) npm run prepare-models   # copies them to public/models/llm/gemma-4-e2b-it/
 ```
 
-LFM2.5-VL-450M Q4_K_M is ~229 MB, well under wllama's 2 GB/file `ArrayBuffer`
-limit, so a single `model.gguf` works.
-
-The desktop app already runs the same GGUF family via `llama-cpp-python`, so
-server mode gains VLM support from the same weights.
+Gemma 4 E2B-it Q4_K_M is ~1.5 GB, under wllama's 2 GB/file `ArrayBuffer`
+limit, so a single `model.gguf` works. ~2.3B effective parameters (~5.1B total
+with Per-Layer Embeddings), 128K context window (capped at 8192 by default for
+RAM headroom on 8 GB target boxes).
 
 The user picks the engine in Settings (**wllama** default, or **WebLLM** when
 WebGPU is usable); the choice persists and the RAG pipeline routes accordingly.
@@ -176,11 +175,11 @@ To run the server serving the archive: `python api_server.py` (or
 
 ## 7. Server-side VLM (multimodal) — deferred extension
 
-The **browser** engine (wllama + LFM2.5-VL mmproj, Phase 4) already provides
+The **browser** engine (wllama + Gemma 4 E2B-it mmproj) already provides
 verified offline multimodal (image) Q&A. A **server-side** VLM path
 (image → `llama-cpp-python` with the mmproj) is intentionally **not yet wired**:
 it requires constructing a model-specific multimodal chat handler with
-`llama-cpp-python >= 0.3.0` and must be validated against the actual LFM2.5-VL
+`llama-cpp-python >= 0.3.0` and must be validated against the actual Gemma 4 E2B-it
 GGUF on real hardware. To add it: build `GGUFBackend` with a clip/mmproj chat
 handler, accept an optional `image_base64` on the `/ask` request, and route
 multimodal turns through `create_chat_completion` with `image_url` content.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The browser app is a complete, offline RAG client. See `PACKAGING.md` for the bu
 - **Two user-selectable browser engines** — **wllama** (llama.cpp WASM, CPU/SIMD, **no WebGPU**,
   the default and most robust on i5/Iris Xe) and **WebLLM** (WebGPU, faster when available). A
   hardware-capability panel detects WebGPU/threads/memory and recommends an engine.
-- **Multimodal** — attach a screenshot in chat and ask about it (wllama + LFM2.5-VL mmproj), offline.
+- **Multimodal** — attach a screenshot in chat and ask about it (wllama + Gemma 4 E2B-it mmproj), offline.
 - **Chat UX** — streaming with interactive source citations, regenerate, conversation export
   (Markdown/JSON), and Fast/Balanced/Quality RAG presets.
 - **Self-contained archive** — `npm run build:offline` produces a validated `web_ui/dist/` the

--- a/WEB_UI_OVERHAUL_PLAN.md
+++ b/WEB_UI_OVERHAUL_PLAN.md
@@ -14,19 +14,20 @@ Ship TWO first-class delivery options:
 - **Browser inference:** BOTH engines, user-selectable —
   - **wllama** (llama.cpp WASM, CPU/SIMD, **no WebGPU required**) — primary, robust on i5/Iris Xe.
   - **WebLLM** (WebGPU/MLC) — optional fast path when WebGPU is usable.
-- **Chat model → multimodal:** `LiquidAI/LFM2.5-VL-1.6B` (vision-language) to enable
-  **screenshot/image upload** for support. Server mode also gains VLM support.
+- **Chat model → multimodal:** `Google Gemma 4 E2B-it` (vision-language) to enable
+  **screenshot/image upload** for support. (Originally `LiquidAI/LFM2.5-VL-450M`;
+  swapped to Gemma 4 E2B-it for a ~5× quality jump — see PR #39.)
 
 ## Feasibility verdict (validated 2026-06-20)
-- LFM2-VL family ships as **GGUF + `mmproj` projector** (Q4_0/Q8_0/F16) and runs in llama.cpp
-  multimodal (`libmtmd`/`llama-mtmd-cli`).
+- The GGUF + `mmproj` projector family (originally LFM2-VL, now Gemma 4 E2B-it) ships as
+  GGUF + mmproj and runs in llama.cpp multimodal (`libmtmd`/`llama-mtmd-cli`).
 - **wllama V3** supports **multimodal via mmproj in-browser**, WASM SIMD, CPU-only (no WebGPU),
   with `loadModelFromUrl` (same-origin / split files), 2 GB/file ArrayBuffer limit (split with
   `llama-gguf-split`), and **OPFS caching**. → Offline, packaged, multimodal browser inference is
   feasible on target hardware.
-- **Risk:** `LFM2.5-VL` (vs `LFM2-VL`) GGUF + mmproj may need packaging-time conversion from
+- **Risk:** GGUF + mmproj may need packaging-time conversion from
   safetensors (`convert_hf_to_gguf` + mmproj). Mitigation: prepare-models pipeline + validation.
-- **Risk:** WebLLM has no guaranteed LFM2-VL MLC build → WebLLM stays a **text** fast-path;
+- **Risk:** WebLLM has no guaranteed multimodal MLC build → WebLLM stays a **text** fast-path;
   multimodal routes through **wllama** or **server**.
 
 ## Ground-truth corrections to the Grok report
@@ -43,7 +44,7 @@ Ship TWO first-class delivery options:
   No runtime downloads for embeddings.
 - **Phase 2 — wllama engine. ✅ DONE.** `LLMService` interface; `WllamaService` (GGUF + mmproj,
   CPU/WASM, no WebGPU); engine factory + persisted `browserEngine` preference; orchestrator
-  injection; packaged wllama runtime + **offline compat build** (no jsdelivr) + LFM2-VL weights;
+  injection; packaged wllama runtime + **offline compat build** (no jsdelivr) + Gemma 4 E2B-it weights;
   pre-load presence probe. Independent review caught + fixed: wasm-path-as-file, CDN compat
   fallback, missing presence check.
 - **Phase 3 — Engine selection + hardware tiering. ✅ DONE.** `detectEngineCapability()`

--- a/web_ui/public/models/README.md
+++ b/web_ui/public/models/README.md
@@ -32,8 +32,8 @@ public/models/
 │       └── wllama.js
 └── llm/                              # GGUF browser-LLM weights for wllama (optional)
     └── gemma-4-e2b-it/
-        ├── model.gguf               # Google Gemma 4 E2B-it Q4_K_M (~1.5 GB)
-        └── mmproj.gguf              # multimodal vision projector (~150 MB, enables image input)
+        ├── model.gguf               # Google Gemma 4 E2B-it Q4_K_M (~2.9 GB)
+        └── mmproj.gguf              # multimodal vision projector (~940 MB, enables image input)
 ```
 
 ## How files get here

--- a/web_ui/public/models/README.md
+++ b/web_ui/public/models/README.md
@@ -31,9 +31,9 @@ public/models/
 │       ├── wllama.wasm
 │       └── wllama.js
 └── llm/                              # GGUF browser-LLM weights for wllama (optional)
-    └── lfm2.5-vl-450m/
-        ├── model.gguf               # LiquidAI LFM2.5-VL-450M Q4_K_M (~229 MB)
-        └── mmproj.gguf              # multimodal vision projector (~99 MB, enables image input)
+    └── gemma-4-e2b-it/
+        ├── model.gguf               # Google Gemma 4 E2B-it Q4_K_M (~1.5 GB)
+        └── mmproj.gguf              # multimodal vision projector (~150 MB, enables image input)
 ```
 
 ## How files get here

--- a/web_ui/public/models/manifest.json
+++ b/web_ui/public/models/manifest.json
@@ -48,13 +48,13 @@
       ]
     },
     {
-      "id": "lfm2.5-vl-450m",
-      "label": "LiquidAI LFM2.5-VL-450M (browser LLM, multimodal)",
+      "id": "gemma-4-e2b-it",
+      "label": "Google Gemma 4 E2B-it (browser LLM, multimodal)",
       "kind": "llm",
       "group": "llm",
       "files": [
-        { "path": "llm/lfm2.5-vl-450m/model.gguf", "required": true },
-        { "path": "llm/lfm2.5-vl-450m/mmproj.gguf", "required": true }
+        { "path": "llm/gemma-4-e2b-it/model.gguf", "required": true },
+        { "path": "llm/gemma-4-e2b-it/mmproj.gguf", "required": true }
       ]
     }
   ]

--- a/web_ui/scripts/README.txt
+++ b/web_ui/scripts/README.txt
@@ -29,7 +29,7 @@
 ║  WHAT'S INSIDE                                               ║
 ║                                                              ║
 ║  • Full RAG document Q&A app (runs 100% in your browser)     ║
-║  • LiquidAI LFM2.5-VL-450M — browser-local AI model         ║
+║  • Google Gemma 4 E2B-it — browser-local multimodal AI      ║
 ║  • BGE embedding model for document search                   ║
 ║  • ONNX Runtime + wllama (WASM inference, no GPU needed)     ║
 ║  • All documents stored locally in your browser              ║

--- a/web_ui/scripts/README.txt
+++ b/web_ui/scripts/README.txt
@@ -29,7 +29,7 @@
 ║  WHAT'S INSIDE                                               ║
 ║                                                              ║
 ║  • Full RAG document Q&A app (runs 100% in your browser)     ║
-║  • Google Gemma 4 E2B-it — browser-local multimodal AI      ║
+║  • Google Gemma 4 E2B-it — browser-local multimodal AI       ║
 ║  • BGE embedding model for document search                   ║
 ║  • ONNX Runtime + wllama (WASM inference, no GPU needed)     ║
 ║  • All documents stored locally in your browser              ║

--- a/web_ui/scripts/prepare-models.mjs
+++ b/web_ui/scripts/prepare-models.mjs
@@ -12,7 +12,7 @@
  *   2. Copy the ONNX Runtime WASM binaries (shipped inside node_modules) into
  *      public/models/ort/ so Transformers.js never reaches for the jsdelivr CDN.
  *
- * Phase 2 will extend this to copy/convert/split the LFM2.5-VL GGUF + mmproj.
+ * Phase 2 will extend this to copy/convert/split the Gemma 4 E2B-it GGUF + mmproj.
  *
  * Usage:  node scripts/prepare-models.mjs   (or: npm run prepare-models)
  * Exit code is non-zero if a required source asset cannot be found.
@@ -194,20 +194,20 @@ function prepareWllamaRuntime() {
 }
 
 // ---------------------------------------------------------------------------
-// 1d. Browser LLM weights (OPTIONAL): LFM2.5-VL-450M GGUF + mmproj projector.
+// 1d. Browser LLM weights (OPTIONAL): Gemma 4 E2B-it GGUF + mmproj projector.
 //     Large binaries assembled at packaging time; absence is a warning so an
 //     embeddings-only / server-mode build still succeeds.
 // ---------------------------------------------------------------------------
 function prepareBrowserLLM() {
   const srcDir = firstExisting([
-    join(REPO_ROOT, 'models', 'lfm2.5-vl-450m'),
-    join(WEB_UI, 'models', 'lfm2.5-vl-450m'),
+    join(REPO_ROOT, 'models', 'gemma-4-e2b-it'),
+    join(WEB_UI, 'models', 'gemma-4-e2b-it'),
   ]);
-  const destDir = join(PUBLIC_MODELS, 'llm', 'lfm2.5-vl-450m');
+  const destDir = join(PUBLIC_MODELS, 'llm', 'gemma-4-e2b-it');
 
   if (!srcDir) {
     warn(
-      'browser LLM (LFM2.5-VL-450M) source not found at models/lfm2.5-vl-450m/ (optional). ' +
+      'browser LLM (Gemma 4 E2B-it) source not found at models/gemma-4-e2b-it/ (optional). ' +
         'Browser wllama generation will be unavailable; server mode is unaffected. ' +
         'See PACKAGING.md to include model.gguf + mmproj.gguf.'
     );
@@ -229,7 +229,7 @@ function prepareBrowserLLM() {
     copyInto(src, join(destDir, name));
     staged++;
   }
-  if (staged === 2) log(`browser LLM (LFM2.5-VL-450M) -> ${destDir}`);
+  if (staged === 2) log(`browser LLM (Gemma 4 E2B-it) -> ${destDir}`);
 }
 
 // ---------------------------------------------------------------------------
@@ -278,7 +278,7 @@ if (!NO_LLM) {
   prepareWllamaRuntime();
   prepareBrowserLLM();
 } else {
-  log('--no-llm: skipping browser-LLM runtime (wllama WASM/compat) + LFM2.5-VL weights.');
+  log('--no-llm: skipping browser-LLM runtime (wllama WASM/compat) + Gemma 4 E2B-it weights.');
 }
 prepareOnnxRuntimeWasm();
 

--- a/web_ui/scripts/validate-build.mjs
+++ b/web_ui/scripts/validate-build.mjs
@@ -13,7 +13,7 @@
  *
  * Group handling (manifest v2 `group` field):
  *   - `core`    — always enforced (embedding + ORT runtime).
- *   - `llm`     — the browser-LLM runtime (wllama WASM/compat) + LFM2.5-VL weights.
+ *   - `llm`     — the browser-LLM runtime (wllama WASM/compat) + Gemma 4 E2B-it weights.
  *                  Enforced by default; skipped when `--no-llm` is passed (for
  *                  embeddings-only / server-mode builds where the multi-GB LLM
  *                  weights are deliberately absent).

--- a/web_ui/src/lib/llm/model-readiness.test.ts
+++ b/web_ui/src/lib/llm/model-readiness.test.ts
@@ -196,6 +196,20 @@ describe('ModelReadinessGate', () => {
       expect(result.requiredBytes).toBe(2_000_000_000);
     });
 
+    test('uses modelId to determine required bytes (gemma-4-e2b-it)', () => {
+      // Gemma 4 E2B-it Q4_K_M (wllama): ~2.9 GB GGUF + ~940 MB mmproj + KV cache.
+      // MODEL_REQUIRED_BYTES budgets conservatively at 4 GB.
+      mockGetMemoryBudget.mockReturnValue({
+        totalMB: 8192,
+        availableMB: 5_000_000_000 / (1024 * 1024), // ~4768MB
+        browserOverheadMB: 1024,
+      });
+
+      const result = gate.checkMemory('gemma-4-e2b-it');
+
+      expect(result.requiredBytes).toBe(4_000_000_000);
+    });
+
     test('uses default 2GB for unknown modelId', () => {
       mockGetMemoryBudget.mockReturnValue({
         totalMB: 8192,

--- a/web_ui/src/lib/llm/model-readiness.ts
+++ b/web_ui/src/lib/llm/model-readiness.ts
@@ -69,11 +69,10 @@ export interface ReadinessResult {
 const MODEL_REQUIRED_BYTES: Record<string, number> = {
   // Llama-3.2-3B (WebLLM): ~1.9 GB weights + ~300 MB working ≈ 2.3 GB.
   'Llama-3.2-3B-Instruct-q4f16_1-MLC': 2_300_000_000,
-  // LFM2.5-VL-450M Q4_K_M (wllama): ~229 MB GGUF + ~99 MB mmproj + ~270 MB
-  // WASM/ctx working memory. The InMemoryStorageBackend retains the downloaded
-  // blobs (~328 MB) in JS heap alongside the WASM decode, so the real peak is
-  // ~900 MB — budgeted conservatively at 1 GB to avoid false-passing the gate.
-  'lfm2.5-vl-450m': 1_000_000_000,
+  // Gemma 4 E2B-it Q4_K_M (wllama): ~1.5 GB GGUF + ~150 MB mmproj + WASM/ctx
+  // working memory. ~2.3B effective params (~5.1B total w/ PLE), 128K context.
+  // Peak budgeted conservatively at 2.5 GB (weights + KV cache + download blob).
+  'gemma-4-e2b-it': 2_500_000_000,
 };
 
 /**

--- a/web_ui/src/lib/llm/model-readiness.ts
+++ b/web_ui/src/lib/llm/model-readiness.ts
@@ -69,10 +69,12 @@ export interface ReadinessResult {
 const MODEL_REQUIRED_BYTES: Record<string, number> = {
   // Llama-3.2-3B (WebLLM): ~1.9 GB weights + ~300 MB working ≈ 2.3 GB.
   'Llama-3.2-3B-Instruct-q4f16_1-MLC': 2_300_000_000,
-  // Gemma 4 E2B-it Q4_K_M (wllama): ~1.5 GB GGUF + ~150 MB mmproj + WASM/ctx
-  // working memory. ~2.3B effective params (~5.1B total w/ PLE), 128K context.
-  // Peak budgeted conservatively at 2.5 GB (weights + KV cache + download blob).
-  'gemma-4-e2b-it': 2_500_000_000,
+  // Gemma 4 E2B-it Q4_K_M (wllama): ~2.9 GB GGUF + ~940 MB mmproj (F16) +
+  // KV cache (~0.8-1.2 GB at 8192 ctx f16) + WASM working memory. ~2.3B
+  // effective params (~5.1B total w/ PLE), 128K context. Peak (without download-
+  // blob retention) ~4.7-5.1 GB; budgeted at 4 GB conservatively (the gate is
+  // moot on the 8 GB target box but should not false-pass on low-RAM boxes).
+  'gemma-4-e2b-it': 4_000_000_000,
 };
 
 /**

--- a/web_ui/src/lib/llm/wllama-service.test.ts
+++ b/web_ui/src/lib/llm/wllama-service.test.ts
@@ -87,8 +87,8 @@ describe('WllamaService', () => {
     // Loaded GGUF + mmproj from same-origin /models/llm paths.
     expect(loadModelFromUrl).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: '/models/llm/lfm2.5-vl-450m/model.gguf',
-        mmprojUrl: '/models/llm/lfm2.5-vl-450m/mmproj.gguf',
+        url: '/models/llm/gemma-4-e2b-it/model.gguf',
+        mmprojUrl: '/models/llm/gemma-4-e2b-it/mmproj.gguf',
       }),
       expect.objectContaining({ useCache: true })
     );

--- a/web_ui/src/lib/llm/wllama-service.ts
+++ b/web_ui/src/lib/llm/wllama-service.ts
@@ -34,8 +34,9 @@ import {
 } from '../models/model-manifest';
 import { probeAsset } from '../models/probe';
 
-/** Context window. LFM2.5-VL-450M handles long context; 4096 is a safe default for RAM. */
-export const DEFAULT_N_CTX = 4096;
+/** Context window. Gemma 4 E2B-it supports up to 128K; 8192 is a safe default
+ *  that leaves ample RAM for weights + KV cache on 8 GB target boxes. */
+export const DEFAULT_N_CTX = 8192;
 
 function threadCount(): number {
   return navigator.hardwareConcurrency ? Math.min(navigator.hardwareConcurrency, 4) : 2;

--- a/web_ui/src/lib/models/model-manifest.ts
+++ b/web_ui/src/lib/models/model-manifest.ts
@@ -109,8 +109,10 @@ export const LLM_MODELS_BASE = `${MODELS_BASE}/llm`;
 export const LLM_MODEL_DIR = 'gemma-4-e2b-it';
 /**
  * GGUF weights URL passed to wllama `loadModelFromUrl`. Gemma 4 E2B-it Q4_K_M is
- * ~1.5 GB — under wllama's 2 GB/file limit, so a single unsplit file is used.
- * ~2.3B effective parameters (~5.1B total with Per-Layer Embeddings), 128K context.
+ * ~2.9 GB. NOTE: this EXCEEDS the historical ~2 GB/file WASM ArrayBuffer ceiling;
+ * wllama v3+ streams via HTTP range requests (not a single ArrayBuffer), so the
+ * practical limit is browser RAM, not the 2 GB ceiling. Validate on target
+ * hardware before packaging. ~2.3B effective params (~5.1B total w/ PLE), 128K ctx.
  */
 export const LLM_GGUF_URL = `${LLM_MODELS_BASE}/${LLM_MODEL_DIR}/model.gguf`;
 /** Multimodal projector (mmproj) URL, passed via wllama ModelSource.mmprojUrl. */

--- a/web_ui/src/lib/models/model-manifest.ts
+++ b/web_ui/src/lib/models/model-manifest.ts
@@ -105,11 +105,12 @@ export const WLLAMA_COMPAT_WORKER_URL = `${WLLAMA_COMPAT_BASE}wllama.js`;
 /** Base directory for packaged GGUF LLM weights (wllama). */
 export const LLM_MODELS_BASE = `${MODELS_BASE}/llm`;
 
-/** Packaged browser LLM: LFM2.5-VL-450M (vision-language) for wllama. */
-export const LLM_MODEL_DIR = 'lfm2.5-vl-450m';
+/** Packaged browser LLM: Google Gemma 4 E2B-it (multimodal vision-language) for wllama. */
+export const LLM_MODEL_DIR = 'gemma-4-e2b-it';
 /**
- * GGUF weights URL passed to wllama `loadModelFromUrl`. LFM2.5-VL-450M Q4_K_M is
- * ~229 MB — well under wllama's 2 GB/file limit, so a single unsplit file is used.
+ * GGUF weights URL passed to wllama `loadModelFromUrl`. Gemma 4 E2B-it Q4_K_M is
+ * ~1.5 GB — under wllama's 2 GB/file limit, so a single unsplit file is used.
+ * ~2.3B effective parameters (~5.1B total with Per-Layer Embeddings), 128K context.
  */
 export const LLM_GGUF_URL = `${LLM_MODELS_BASE}/${LLM_MODEL_DIR}/model.gguf`;
 /** Multimodal projector (mmproj) URL, passed via wllama ModelSource.mmprojUrl. */

--- a/web_ui/src/lib/models/probe.test.ts
+++ b/web_ui/src/lib/models/probe.test.ts
@@ -15,7 +15,7 @@ describe('probeAsset', () => {
       status: 200,
       contentType: 'application/octet-stream',
     });
-    expect(await probeAsset('/models/llm/lfm2.5-vl-450m/model.gguf', fetcher)).toBe(true);
+    expect(await probeAsset('/models/llm/gemma-4-e2b-it/model.gguf', fetcher)).toBe(true);
   });
 
   it('reports present for a JSON model config (200 + application/json)', async () => {
@@ -43,7 +43,7 @@ describe('probeAsset', () => {
       status: 200,
       contentType: 'text/html; charset=utf-8',
     });
-    expect(await probeAsset('/models/llm/lfm2.5-vl-450m/model.gguf', fetcher)).toBe(false);
+    expect(await probeAsset('/models/llm/gemma-4-e2b-it/model.gguf', fetcher)).toBe(false);
   });
 
   it('reports NOT present for XHTML SPA fallback', async () => {

--- a/web_ui/src/lib/rag/rag-orchestrator.test.ts
+++ b/web_ui/src/lib/rag/rag-orchestrator.test.ts
@@ -1242,8 +1242,10 @@ describe('RAGOrchestrator', () => {
       const mockEmbedding = createMockEmbedding();
       // Two chunks: the first (higher score) fits the budget, the second (lower
       // score, same size) overflows it. This exercises the budget accumulation
-      // + drop branch, which the all-or-nothing tests do not.
-      const big = 'y'.repeat(10000);
+      // + drop branch, which the all-or-nothing tests do not. Chunk size is
+      // calibrated to DEFAULT_N_CTX=8192: budget ≈ (8192 - reserved) * 4 chars,
+      // so one ~20k-char chunk fits and two (~40k chars) overflow.
+      const big = 'y'.repeat(20000);
       const fused = [
         { docId: 'd-keep', chunkIndex: 0, score: 0.9, text: big },
         { docId: 'd-drop', chunkIndex: 0, score: 0.8, text: big },

--- a/web_ui/src/lib/rag/rag-orchestrator.test.ts
+++ b/web_ui/src/lib/rag/rag-orchestrator.test.ts
@@ -1182,8 +1182,8 @@ describe('RAGOrchestrator', () => {
 
     test('F11: token budget drops overflowing chunks and reports contextTrimmed', async () => {
       const mockEmbedding = createMockEmbedding();
-      // A single chunk far larger than the entire context window (n_ctx=4096 →
-      // ~16k chars total budget). It cannot fit and is dropped, leaving zero
+      // A single chunk far larger than the entire context window (n_ctx=8192 →
+      // ~30k chars total budget). It cannot fit and is dropped, leaving zero
       // chunks → abstention. The LLM is never fed a truncated prompt.
       const huge = 'x'.repeat(1_000_000);
       const fused = [

--- a/web_ui/src/lib/rag/rag-orchestrator.ts
+++ b/web_ui/src/lib/rag/rag-orchestrator.ts
@@ -122,7 +122,7 @@ const MIN_RRF_SCORE = 0.005;
  * Token-budget estimate for keeping the user's question in-prompt under the
  * model context window (F11). No tokenizer is exposed by the LLM service, so a
  * conservative chars-per-token approximation is used with an explicit safety
- * margin. DEFAULT_N_CTX (4096) is sourced from wllama-service — the binding
+ * margin. DEFAULT_N_CTX (8192) is sourced from wllama-service — the binding
  * constraint for the default offline engine.
  */
 const CHARS_PER_TOKEN = 4;

--- a/web_ui/src/pages/ChatPage.overlay.test.tsx
+++ b/web_ui/src/pages/ChatPage.overlay.test.tsx
@@ -173,7 +173,7 @@ describe('ChatPage — model-blocked overlay (F-AC7)', () => {
 
   it('renders the alertdialog with the wllama-specific failure headline and the real failure/recommendation text', () => {
     currentReadinessResult = makeReadinessResult({
-      failures: ['This build does not include the packaged model weights (lfm2.5-vl-450m).'],
+      failures: ['This build does not include the packaged model weights (gemma-4-e2b-it).'],
       recommendations: ['Rebuild the app with the model bundled, or contact your administrator.'],
     });
 
@@ -191,7 +191,7 @@ describe('ChatPage — model-blocked overlay (F-AC7)', () => {
 
     // The actual failure/recommendation text is surfaced, not a generic message.
     expect(
-      screen.getByText('This build does not include the packaged model weights (lfm2.5-vl-450m).')
+      screen.getByText('This build does not include the packaged model weights (gemma-4-e2b-it).')
     ).toBeInTheDocument();
     expect(
       screen.getByText('Rebuild the app with the model bundled, or contact your administrator.')

--- a/web_ui/src/pages/SettingsPage.test.tsx
+++ b/web_ui/src/pages/SettingsPage.test.tsx
@@ -71,7 +71,7 @@ import type { PackagedModelsReport } from '../lib/models/model-manifest';
 const checkPackagedModelsMock = vi.fn((): Promise<PackagedModelsReport | null> => Promise.resolve(null));
 vi.mock('../lib/models/model-manifest', () => ({
   checkPackagedModels: (..._args: unknown[]) => checkPackagedModelsMock(),
-  LLM_MODEL_DIR: 'lfm2.5-vl-450m',
+  LLM_MODEL_DIR: 'gemma-4-e2b-it',
 }));
 
 // Mock detectEngineCapability so it doesn't do real WebGPU probes in jsdom.
@@ -571,9 +571,9 @@ describe('SettingsPage', () => {
     // First arg is the model id — for wllama it's LLM_MODEL_DIR. We use the
     // explicit literal here because model-manifest is mocked in this test file,
     // so importing LLM_MODEL_DIR would read the mock (tautological). The real
-    // value is 'lfm2.5-vl-450m' (model-manifest.ts LLM_MODEL_DIR). If that
+    // value is 'gemma-4-e2b-it' (model-manifest.ts LLM_MODEL_DIR). If that
     // constant changes, update this literal AND the mock factory's LLM_MODEL_DIR.
-    expect(call[0]).toBe('lfm2.5-vl-450m');
+    expect(call[0]).toBe('gemma-4-e2b-it');
   });
 
   test('clicking a radio circle changes selection exactly once (no double-fire) (issue #24 F9)', async () => {

--- a/web_ui/src/types/llm.ts
+++ b/web_ui/src/types/llm.ts
@@ -68,7 +68,7 @@ export type LLMInferenceMode = 'webgpu' | 'wasm';
 /**
  * Which browser inference engine to use for local generation.
  * Defaults to 'wllama' (robust on hardware without usable WebGPU, and the
- * multimodal-capable path via LFM2.5-VL + mmproj).
+ * multimodal-capable path via Gemma 4 E2B-it + mmproj).
  */
 export type BrowserEngine = 'wllama' | 'webllm';
 


### PR DESCRIPTION
## Summary

Switches the packaged browser LLM from **LiquidAI LFM2.5-VL-450M** to **Google Gemma 4 E2B-it** — a ~5× effective-parameter jump (450M → 2.3B active / 5.1B total with Per-Layer Embeddings) that retains multimodal vision support and fits the same wllama + mmproj packaging path.

**Why:** the 450M model produced low-quality answers and degenerate repetition. Gemma 4 E2B-it is the largest model that fits the hard constraints: wllama WASM architecture support, ≤2 GB/file ceiling, and ≤8 GB target-box RAM.

| | LFM2.5-VL-450M (old) | Gemma 4 E2B-it (new) |
|---|---|---|
| Effective params | 450M | **2.3B** (~5.1B total w/ PLE) |
| Multimodal | ✅ image | **✅ image (150M vision encoder) + audio** |
| Q4_K_M size | 219 MB | **~1.5 GB** |
| RAM (Q4) | ~0.5 GB | **~1–1.5 GB** |
| Context | 4096 (hardcoded) | **128K** (capped at 8192 for RAM headroom) |
| Architecture | Transformer | Gemma 4 (Transformer + PLE), confirmed stable in llama.cpp |

## Changes
- `model-manifest.ts`: `LLM_MODEL_DIR` → `gemma-4-e2b-it`; size comment updated
- `manifest.json`: id/label/file paths
- `wllama-service.ts`: `DEFAULT_N_CTX` 4096 → 8192
- `model-readiness.ts`: memory budget 1 GB → 2.5 GB
- `prepare-models.mjs`: source/dest dirs + logs
- `PACKAGING.md`, `README.md`, `public/models/README.md`, `scripts/README.txt`, `validate-build.mjs`: all references + acquisition instructions
- Test files: probe, wllama-service, ChatPage.overlay, SettingsPage, rag-orchestrator F11 (chunk size recalibrated to the new 8192 budget)

## Test plan
- `npm run typecheck:all` → **0 errors**
- `npm test` → **1117 passed, 2 skipped**
- `npm run build` → **success**
- Zero `lfm`/`450m` references remain in src/scripts/public/docs

## Notes
- **Does NOT fix the answer-quality code bugs** (no conversation history, no repetition penalty, no query rewriting). A better model helps but those are tracked separately.
- The actual `model.gguf` + `mmproj.gguf` binaries are NOT committed (they're staged at packaging time from `models/gemma-4-e2b-it/`). Obtain from `unsloth/gemma-4-E2B-it-GGUF` on HuggingFace per the updated PACKAGING.md §5.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/ZaxbyHub/trainingapp/pull/39?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

