### PR TITLE
fix(web_ui): thread conversation history, add repetition penalties, rewrite follow-up retrieval (Issue #40)

### DIFF
--- a/web_ui/src/lib/chat/history-snapshot.test.ts
+++ b/web_ui/src/lib/chat/history-snapshot.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Unit tests for buildHistorySnapshot (Issue #40 RC1).
+ *
+ * buildHistorySnapshot extracts the prior conversation turns from the send-time
+ * message snapshot and returns them as {role, content} pairs for the RAG
+ * orchestrator (browser mode) and the /ask/stream POST body (server mode). Pure
+ * and deterministic — tested here in isolation.
+ */
+
+import { describe, test, expect } from 'vitest';
+import { buildHistorySnapshot, MAX_HISTORY_TURNS } from './history-snapshot';
+import type { ChatMessage } from '../../types/chat';
+
+const user = (content: string, id = content): ChatMessage => ({
+  id,
+  role: 'user',
+  content,
+  timestamp: 0,
+});
+const assistant = (content: string, id = 'a-' + content): ChatMessage => ({
+  id,
+  role: 'assistant',
+  content,
+  timestamp: 0,
+});
+const emptyAssistant = (): ChatMessage => ({
+  id: 'placeholder',
+  role: 'assistant',
+  content: '',
+  timestamp: 0,
+});
+const errorAssistant = (): ChatMessage => ({
+  id: 'err',
+  role: 'assistant',
+  content: '',
+  error: 'boom',
+  timestamp: 0,
+});
+const abstainAssistant = (): ChatMessage => ({
+  id: 'abs',
+  role: 'assistant',
+  content: '',
+  abstain: true,
+  abstainReason: 'insufficient_evidence',
+  timestamp: 0,
+});
+
+describe('buildHistorySnapshot (Issue #40 RC1)', () => {
+  test('empty input → empty snapshot', () => {
+    expect(buildHistorySnapshot([])).toEqual([]);
+  });
+
+  test('drops the trailing empty assistant placeholder and the current user message', () => {
+    // owningMessages at send time: [priorUser, priorAssistant, currentUser, emptyAssistant]
+    const msgs = [
+      user('What is X?'),
+      assistant('X is a thing.'),
+      user('how do I fix it?'),
+      emptyAssistant(),
+    ];
+    const snap = buildHistorySnapshot(msgs);
+    // The current user turn + placeholder are dropped; the prior pair remains.
+    expect(snap).toEqual([
+      { role: 'user', content: 'What is X?' },
+      { role: 'assistant', content: 'X is a thing.' },
+    ]);
+  });
+
+  test('caps at MAX_HISTORY_TURNS (oldest truncated first)', () => {
+    // Build 8 prior user/assistant pairs (16 turns) + current user + placeholder.
+    const msgs: ChatMessage[] = [];
+    for (let i = 0; i < 8; i++) {
+      msgs.push(user(`q${i}`));
+      msgs.push(assistant(`a${i}`));
+    }
+    msgs.push(user('current'));
+    msgs.push(emptyAssistant());
+    const snap = buildHistorySnapshot(msgs);
+    expect(snap.length).toBe(MAX_HISTORY_TURNS);
+    // Oldest truncated: the surviving turns are the LAST MAX_HISTORY_TURNS,
+    // i.e. the most recent 3 pairs.
+    expect(snap[0].content).toBe('q5'); // 6th pair's user turn (0-indexed)
+    expect(snap[snap.length - 1].content).toBe('a7');
+  });
+
+  test('skips error assistant turns', () => {
+    const msgs = [user('q1'), errorAssistant(), user('q2'), emptyAssistant()];
+    const snap = buildHistorySnapshot(msgs);
+    // q1 → error (skipped) → q2 (current, dropped) → placeholder (dropped).
+    // After dropping current user + placeholder, only q1 remains; the error
+    // assistant is filtered out.
+    expect(snap).toEqual([{ role: 'user', content: 'q1' }]);
+  });
+
+  test('skips abstain assistant turns', () => {
+    const msgs = [user('q1'), abstainAssistant(), user('q2'), emptyAssistant()];
+    const snap = buildHistorySnapshot(msgs);
+    expect(snap).toEqual([{ role: 'user', content: 'q1' }]);
+  });
+
+  test('enforces role alternation (collapses consecutive same-role turns)', () => {
+    // A user who fired two messages in a row (e.g. the first errored) produces
+    // [user1, user2, assistant]. After alternation enforcement, only the LAST
+    // user turn before the assistant survives.
+    const msgs = [user('first'), user('second'), assistant('reply'), user('current'), emptyAssistant()];
+    const snap = buildHistorySnapshot(msgs);
+    expect(snap).toEqual([
+      { role: 'user', content: 'second' }, // 'first' collapsed away
+      { role: 'assistant', content: 'reply' },
+    ]);
+  });
+
+  test('produces a clean alternating sequence from a normal conversation', () => {
+    const msgs = [
+      user('turn1'),
+      assistant('answer1'),
+      user('turn2'),
+      assistant('answer2'),
+      user('turn3'),
+      emptyAssistant(),
+    ];
+    const snap = buildHistorySnapshot(msgs);
+    expect(snap.map((t) => t.role)).toEqual(['user', 'assistant', 'user', 'assistant']);
+    expect(snap.map((t) => t.content)).toEqual(['turn1', 'answer1', 'turn2', 'answer2']);
+  });
+
+  test('all roles map to user|assistant (never system)', () => {
+    const systemMsg: ChatMessage = { id: 'sys', role: 'system', content: 'sysprompt', timestamp: 0 };
+    const msgs = [systemMsg, user('q'), assistant('a'), user('current'), emptyAssistant()];
+    const snap = buildHistorySnapshot(msgs);
+    // system messages are not 'user' or 'assistant' in the substantive filter,
+    // but the role-mapping clamps any non-assistant to 'user'. System messages
+    // are not expected in the chat snapshot (they live in the orchestrator's
+    // system prompt), but we verify the mapping never leaks 'system' through.
+    for (const turn of snap) {
+      expect(turn.role === 'user' || turn.role === 'assistant').toBe(true);
+    }
+  });
+});

--- a/web_ui/src/lib/chat/history-snapshot.ts
+++ b/web_ui/src/lib/chat/history-snapshot.ts
@@ -1,0 +1,75 @@
+/**
+ * Issue #40 RC1: build the conversation-history snapshot threaded into the RAG
+ * orchestrator (browser mode) and the /ask/stream POST body (server mode).
+ *
+ * Extracted from ChatPage into a pure module so it is unit-testable without a
+ * React rendering harness. Pure: given a ChatMessage[] snapshot captured at
+ * send time, return the prior user/assistant turns as {role, content} pairs.
+ */
+
+import type { ChatMessage } from '../../types/chat';
+import type { RAGHistoryTurn } from '../rag/rag-orchestrator';
+
+/**
+ * Maximum number of prior turns to thread into the LLM prompt / retrieval
+ * contextualizer. Capped to bound token-budget impact (the orchestrator also
+ * charges history to the budget, but capping here keeps the snapshot small and
+ * matches the orchestrator's reservation math). ~3 user/assistant exchanges.
+ */
+export const MAX_HISTORY_TURNS = 6;
+
+/**
+ * Build the conversation-history snapshot for the orchestrator / server.
+ *
+ * `owningMessages` (the snapshot captured at send time) INCLUDES the current
+ * user turn and a trailing empty assistant placeholder. This helper drops both
+ * and returns the prior user/assistant turns as {role, content} pairs the LLM
+ * chat-template and the retrieval-contextualizing heuristic consume.
+ *
+ * Filtering rules (in order):
+ *  1. drop trailing empty assistant placeholder(s) (the current turn in flight);
+ *  2. drop the just-added user message (the orchestrator gets `text` separately);
+ *  3. keep only substantive turns — ALL user turns are kept (even empty ones,
+ *     since an empty user turn is rare and the caller already trimmed the
+ *     current one); assistant turns are kept only when they have content AND are
+ *     not error/abstention cards;
+ *  4. enforce role alternation — collapse consecutive same-role turns by keeping
+ *     only the last, so the chat template always sees user/assistant/user/...;
+ *  5. cap at the last MAX_HISTORY_TURNS messages (oldest truncated first).
+ */
+export function buildHistorySnapshot(owningMessages: ChatMessage[]): RAGHistoryTurn[] {
+  if (!Array.isArray(owningMessages) || owningMessages.length === 0) return [];
+  const trimmed = owningMessages.slice();
+  // 1. Drop trailing empty assistant placeholder(s) (the current turn in flight).
+  while (
+    trimmed.length > 0 &&
+    trimmed[trimmed.length - 1].role === 'assistant' &&
+    !(trimmed[trimmed.length - 1].content ?? '').trim()
+  ) {
+    trimmed.pop();
+  }
+  // 2. Drop the just-added user message (the orchestrator gets `text` separately).
+  if (trimmed.length > 0 && trimmed[trimmed.length - 1].role === 'user') {
+    trimmed.pop();
+  }
+  // 3. Keep only substantive turns.
+  const substantive = trimmed.filter(
+    (m) =>
+      m.role === 'user' ||
+      (m.role === 'assistant' && !m.error && !m.abstain && (m.content ?? '').trim().length > 0)
+  );
+  // 4. Enforce role alternation: collapse consecutive same-role turns (keep last).
+  const alternating: ChatMessage[] = [];
+  for (const m of substantive) {
+    if (alternating.length > 0 && alternating[alternating.length - 1].role === m.role) {
+      alternating[alternating.length - 1] = m; // replace
+    } else {
+      alternating.push(m);
+    }
+  }
+  // 5. Cap at the last MAX_HISTORY_TURNS (oldest truncated first).
+  return alternating.slice(-MAX_HISTORY_TURNS).map((m) => ({
+    role: m.role === 'assistant' ? 'assistant' : 'user',
+    content: m.content ?? '',
+  }));
+}

--- a/web_ui/src/lib/llm/web-llm-service.test.ts
+++ b/web_ui/src/lib/llm/web-llm-service.test.ts
@@ -394,6 +394,42 @@ describe('WebLLMService', () => {
     );
   });
 
+  test('Issue #40 RC2: forwards frequencyPenalty/presencePenalty as OpenAI-style penalties (no repeat_penalty — WebLLM lacks it)', async () => {
+    const mockResponse = {
+      choices: [{ message: { content: 'response' } }],
+    };
+
+    const mockEngine = createMockEngine({
+      chat: {
+        completions: {
+          create: vi.fn().mockResolvedValue(mockResponse),
+        },
+      },
+    });
+
+    mockCreateMLCEngine.mockResolvedValue(mockEngine);
+
+    const service = WebLLMService.getInstance();
+    await service.initialize();
+
+    await service.generateComplete([{ role: 'user', content: 'hi' }], {
+      frequencyPenalty: 0.3,
+      presencePenalty: 0.2,
+      repeatPenalty: 1.1, // WebLLM has no repeat_penalty equivalent — must be dropped.
+    });
+
+    expect(mockEngine.chat.completions.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        frequency_penalty: 0.3,
+        presence_penalty: 0.2,
+      })
+    );
+    // WebLLM (MLC) has NO repeat_penalty — confirm it is not forwarded.
+    const call = mockEngine.chat.completions.create.mock.calls[0][0] as Record<string, unknown>;
+    expect(call).not.toHaveProperty('repeat_penalty');
+    expect(call).not.toHaveProperty('penalty_repeat');
+  });
+
   // -------------------------------------------------------------------------
   // interrupt() calls engine.interruptGenerate()
   // -------------------------------------------------------------------------

--- a/web_ui/src/lib/llm/web-llm-service.ts
+++ b/web_ui/src/lib/llm/web-llm-service.ts
@@ -45,6 +45,12 @@ type MLCEngineChat = {
       max_tokens?: number;
       temperature?: number;
       top_p?: number;
+      // Issue #40 RC2: WebLLM (MLC) supports OpenAI-style frequency/presence
+      // penalty. It has NO repeat_penalty equivalent — wllama is the primary
+      // offline engine and carries the stronger anti-repetition coverage via
+      // penalty_repeat; on WebLLM only these two apply.
+      frequency_penalty?: number;
+      presence_penalty?: number;
       signal?: AbortSignal;
     }): AsyncIterable<{ choices?: Array<{ delta?: { content?: string } }> }>;
   };
@@ -369,6 +375,11 @@ export class WebLLMService implements LLMService {
         max_tokens: options?.maxTokens,
         temperature: options?.temperature,
         top_p: options?.topP,
+        // Issue #40 RC2: WebLLM (MLC) supports OpenAI-style frequency/presence
+        // penalty. It has NO repeat_penalty equivalent — wllama is the primary
+        // offline engine and carries the stronger anti-repetition coverage.
+        frequency_penalty: options?.frequencyPenalty,
+        presence_penalty: options?.presencePenalty,
         signal,
       });
 
@@ -415,6 +426,9 @@ export class WebLLMService implements LLMService {
       max_tokens: options?.maxTokens,
       temperature: options?.temperature,
       top_p: options?.topP,
+      // Issue #40 RC2: see generate() above.
+      frequency_penalty: options?.frequencyPenalty,
+      presence_penalty: options?.presencePenalty,
       signal: options?.signal,
     });
 

--- a/web_ui/src/lib/llm/wllama-service.test.ts
+++ b/web_ui/src/lib/llm/wllama-service.test.ts
@@ -180,6 +180,49 @@ describe('WllamaService', () => {
     );
   });
 
+  it('Issue #40 RC2: forwards repeatPenalty/frequencyPenalty/presencePenalty as wllama penalty_* with full-context lookback', async () => {
+    // Critical: wllama's chat path uses penalty_repeat/penalty_freq/penalty_present
+    // (SamplingParams names), NOT repeat_penalty/frequency_penalty. Using the
+    // wrong names silently no-ops the anti-repetition fix.
+    const svc = WllamaService.getInstance();
+    await svc.initialize();
+    await svc.generateComplete([{ role: 'user', content: 'hi' }], {
+      repeatPenalty: 1.1,
+      frequencyPenalty: 0.3,
+      presencePenalty: 0.0,
+    });
+    expect(createChatCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        penalty_repeat: 1.1,
+        penalty_freq: 0.3,
+        penalty_present: 0.0,
+        penalty_last_n: -1,
+      })
+    );
+  });
+
+  it('Issue #40 RC2: omits penalty fields entirely when none are supplied (unchanged default behavior)', async () => {
+    const svc = WllamaService.getInstance();
+    await svc.initialize();
+    await svc.generateComplete([{ role: 'user', content: 'hi' }]);
+    const call = (createChatCompletion.mock.calls.at(-1) as Record<string, unknown>[])[0];
+    expect(call).not.toHaveProperty('penalty_repeat');
+    expect(call).not.toHaveProperty('penalty_last_n');
+  });
+
+  it('Issue #40 RC2: streaming generate() also forwards penalty_* params', async () => {
+    const svc = WllamaService.getInstance();
+    await svc.initialize();
+    for await (const _ of svc.generate([{ role: 'user', content: 'hi' }], {
+      repeatPenalty: 1.1,
+    })) {
+      // consume
+    }
+    expect(createChatCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({ penalty_repeat: 1.1, penalty_last_n: -1 })
+    );
+  });
+
   it('supportsImages reflects the model modality', async () => {
     const svc = WllamaService.getInstance();
     await svc.initialize();

--- a/web_ui/src/lib/llm/wllama-service.ts
+++ b/web_ui/src/lib/llm/wllama-service.ts
@@ -58,6 +58,45 @@ function toWllamaMessages(
 }
 
 /**
+ * Issue #40 RC2: translate our camelCase LLMGenerateOptions penalty fields into
+ * wllama's SamplingParams names (penalty_*). Returns an empty object when no
+ * penalty is set, so callers that pass no penalties get unchanged default
+ * behavior (no penalty_last_n lookback window applied). When ANY penalty is set,
+ * penalty_last_n: -1 enables full-context lookback — appropriate for this small
+ * model / small context window.
+ *
+ * NOTE: wllama's createChatCompletion uses `penalty_repeat` / `penalty_freq` /
+ * `penalty_present` (from SamplingParams), NOT the OpenAI-style
+ * `repeat_penalty` / `frequency_penalty`. The latter exist only on
+ * RawCompletionParams, which this service does not use. Getting this wrong
+ * silently no-ops the anti-repetition fix.
+ *
+ * The return type is a NARROW record of only the penalty fields (not the whole
+ * ChatCompletionParams) so spreading it into the createChatCompletion literal
+ * does not widen the literal's `stream` property and trigger an overload error.
+ */
+type WllamaPenaltyParams = {
+  penalty_repeat?: number;
+  penalty_freq?: number;
+  penalty_present?: number;
+  penalty_last_n?: number;
+};
+function buildWllamaPenalties(options?: LLMGenerateOptions): WllamaPenaltyParams {
+  const rp = options?.repeatPenalty;
+  const fp = options?.frequencyPenalty;
+  const pp = options?.presencePenalty;
+  if (rp === undefined && fp === undefined && pp === undefined) {
+    return {};
+  }
+  return {
+    penalty_repeat: rp,
+    penalty_freq: fp,
+    penalty_present: pp,
+    penalty_last_n: -1,
+  };
+}
+
+/**
  * HEAD-probe a same-origin asset without downloading it, hardened against the
  * SPA-fallback false positive (Vite dev/preview serve index.html with HTTP 200
  * for any unmatched path). See `src/lib/models/probe.ts`.
@@ -285,6 +324,14 @@ export class WllamaService implements LLMService {
         max_tokens: options?.maxTokens,
         temp: options?.temperature,
         top_p: options?.topP,
+        // Issue #40 RC2: anti-repetition sampling params. wllama's chat path
+        // (createChatCompletion) accepts the SamplingParams names (penalty_*),
+        // NOT the OpenAI-style repeat_penalty/frequency_penalty — using the
+        // wrong names silently no-ops the fix. penalty_last_n: -1 = full-context
+        // lookback (small model, small context — no reason to window). Only set
+        // the lookback when at least one penalty is supplied, so callers that
+        // pass no penalties get unchanged default behavior.
+        ...buildWllamaPenalties(options),
       });
       for await (const chunk of stream) {
         const content = chunk.choices?.[0]?.delta?.content;
@@ -311,6 +358,8 @@ export class WllamaService implements LLMService {
         max_tokens: options?.maxTokens,
         temp: options?.temperature,
         top_p: options?.topP,
+        // Issue #40 RC2: see generate() above.
+        ...buildWllamaPenalties(options),
       });
       return response.choices?.[0]?.message?.content ?? '';
     } finally {

--- a/web_ui/src/lib/rag/rag-orchestrator.rewrite.test.ts
+++ b/web_ui/src/lib/rag/rag-orchestrator.rewrite.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Unit tests for the Issue #40 RC3 retrieval-query contextualization heuristic.
+ *
+ * `contextualizeRetrievalQuery` rewrites pronoun-heavy / short / continuation
+ * follow-ups into self-contained retrieval queries using conversation history.
+ * It is a pure, deterministic, exported function — tested in isolation here so
+ * every branch (anaphora, short-non-wh, continuation keywords, fallbacks,
+ * self-contained pass-through, empty history) is covered.
+ *
+ * The mocks below stub the orchestrator's transitive imports (vector-index →
+ * edgevec WASM, etc.) so importing the module does not require a build step —
+ * mirroring the setup in rag-orchestrator.test.ts. Only the pure exported
+ * function is exercised; no orchestrator instances are constructed here.
+ */
+
+import { describe, test, expect, vi } from 'vitest';
+
+// Stub transitive imports BEFORE importing the module under test. These match
+// the mocks in rag-orchestrator.test.ts; only the module boundaries matter
+// here, not their return values (no orchestrator is instantiated).
+vi.mock('../embeddings/embedding-service', () => ({ getEmbeddingService: vi.fn() }));
+vi.mock('../search/vector-index', () => ({ getVectorIndex: vi.fn() }));
+vi.mock('../search/keyword-index', () => ({ getKeywordIndex: vi.fn() }));
+vi.mock('../search/rrf-fusion', () => ({ rrfFuse: vi.fn() }));
+vi.mock('../search/reranker', () => ({ getRerankerService: vi.fn() }));
+vi.mock('../llm/llm-factory', () => ({ getLLMService: vi.fn() }));
+vi.mock('../../hooks/useServiceInitialization', () => ({
+  ensureEmbeddingServiceReady: vi.fn(),
+  ensureReadinessGateChecked: vi.fn(),
+}));
+
+import { contextualizeRetrievalQuery } from './rag-orchestrator';
+import type { RAGHistoryTurn } from './rag-orchestrator';
+
+const userTurn = (content: string): RAGHistoryTurn => ({ role: 'user', content });
+const assistantTurn = (content: string): RAGHistoryTurn => ({ role: 'assistant', content });
+
+describe('contextualizeRetrievalQuery (Issue #40 RC3)', () => {
+  test('rewrites a pronoun-heavy follow-up by prepending the most recent user turn', () => {
+    const history: RAGHistoryTurn[] = [
+      userTurn('How do I order medication in CDP?'),
+      assistantTurn('You cannot order medication without the Order Medications permission.'),
+    ];
+    const result = contextualizeRetrievalQuery('how do I fix it?', history);
+    // Prepends the prior user turn (topic carrier) and keeps the follow-up.
+    expect(result).toContain('medication');
+    expect(result).toContain('how do I fix it?');
+    expect(result.startsWith('How do I order medication in CDP?')).toBe(true);
+  });
+
+  test('rewrites a short non-wh follow-up', () => {
+    const history: RAGHistoryTurn[] = [
+      userTurn('Explain the storage architecture.'),
+      assistantTurn('It uses IndexedDB.'),
+    ];
+    // 2 words, doesn't start with a wh-word → follow-up.
+    const result = contextualizeRetrievalQuery('more detail', history);
+    expect(result).toContain('storage architecture');
+    expect(result).toContain('more detail');
+  });
+
+  test('rewrites a continuation-keyword follow-up (elaborate)', () => {
+    const history: RAGHistoryTurn[] = [
+      userTurn('What is the cosign workflow?'),
+      assistantTurn('A second user must approve orders above a threshold.'),
+    ];
+    const result = contextualizeRetrievalQuery('Can you elaborate further on that?', history);
+    expect(result).toContain('cosign workflow');
+    expect(result).toContain('elaborate');
+  });
+
+  test('returns the question unchanged when it is self-contained (no pronoun, starts with wh-word)', () => {
+    const history: RAGHistoryTurn[] = [userTurn('prior topic'), assistantTurn('prior answer')];
+    const result = contextualizeRetrievalQuery('What is machine learning?', history);
+    expect(result).toBe('What is machine learning?');
+  });
+
+  test('returns the question unchanged when history is empty (first-turn recall)', () => {
+    const result = contextualizeRetrievalQuery('how do I fix it?', []);
+    expect(result).toBe('how do I fix it?');
+  });
+
+  test('returns the question unchanged when it is empty', () => {
+    const history: RAGHistoryTurn[] = [userTurn('prior')];
+    const result = contextualizeRetrievalQuery('   ', history);
+    expect(result).toBe('   ');
+  });
+
+  test('falls back to the most recent assistant first-sentence when no user turn exists', () => {
+    // Degenerate history: only assistant turns (e.g. a system greeting).
+    const history: RAGHistoryTurn[] = [
+      assistantTurn('Welcome. You can ask me about medication ordering.'),
+    ];
+    const result = contextualizeRetrievalQuery('how do I fix it?', history);
+    // Prepends the assistant's first sentence (the only available context).
+    expect(result).toContain('Welcome');
+    expect(result).toContain('how do I fix it?');
+    // Should NOT include the second sentence.
+    expect(result).not.toContain('medication ordering');
+  });
+
+  test('pronoun in a self-contained-looking question still triggers rewrite (documented over-trigger)', () => {
+    // "What is this thing?" matches \bthis\b → treated as a follow-up. This is
+    // a documented, bounded over-trigger: prepended context rarely hurts
+    // retrieval, and the broader heuristic trades a little precision for recall
+    // on genuine follow-ups.
+    const history: RAGHistoryTurn[] = [userTurn('Tell me about the dashboard.')];
+    const result = contextualizeRetrievalQuery('What is this thing?', history);
+    expect(result).toContain('dashboard');
+    expect(result).toContain('What is this thing?');
+  });
+
+  test('does not rewrite when the only history turn is an empty assistant message', () => {
+    const history: RAGHistoryTurn[] = [assistantTurn('')];
+    const result = contextualizeRetrievalQuery('how do I fix it?', history);
+    // No substantive context to prepend → returns the raw question.
+    expect(result).toBe('how do I fix it?');
+  });
+
+  test('prepends the MOST RECENT user turn when multiple are present', () => {
+    const history: RAGHistoryTurn[] = [
+      userTurn('old topic one'),
+      assistantTurn('old answer one'),
+      userTurn('recent topic two'),
+      assistantTurn('recent answer two'),
+    ];
+    const result = contextualizeRetrievalQuery('elaborate', history);
+    expect(result.startsWith('recent topic two')).toBe(true);
+    expect(result).not.toContain('old topic one');
+  });
+
+  test('"vs" continuation keyword triggers rewrite when the question is NOT wh-led', () => {
+    const history: RAGHistoryTurn[] = [userTurn('Tell me about wllama.')];
+    const result = contextualizeRetrievalQuery('wllama vs webllm', history);
+    expect(result).toContain('wllama');
+  });
+
+  test('short question starting with a wh-word is NOT rewritten', () => {
+    const history: RAGHistoryTurn[] = [userTurn('prior')];
+    // 2 words, starts with "why" → not a follow-up despite being short.
+    const result = contextualizeRetrievalQuery('why though', history);
+    expect(result).toBe('why though');
+  });
+
+  test('a self-contained wh-led comparison question with "vs" is NOT rewritten (reviewer Q1 fix)', () => {
+    // "What is wllama vs webllm?" starts with a wh-word — even though it contains
+    // the continuation keyword "vs", it is self-contained and must pass through.
+    // Without this guard, after a prior medication question the rewrite would
+    // wrongly prepend the medication topic and degrade retrieval.
+    const history: RAGHistoryTurn[] = [
+      userTurn('How do I order medication in CDP?'),
+      assistantTurn('You need the Order Medications permission.'),
+    ];
+    const result = contextualizeRetrievalQuery('What is wllama vs webllm?', history);
+    expect(result).toBe('What is wllama vs webllm?');
+    expect(result).not.toContain('medication');
+  });
+
+  test('a self-contained wh-led comparison question with "compare" is NOT rewritten', () => {
+    const history: RAGHistoryTurn[] = [userTurn('prior topic')];
+    const result = contextualizeRetrievalQuery('How do these compare?', history);
+    // "How do these compare?" — "How" is wh-led, BUT "these" is anaphora, so
+    // pattern 1 (anaphora) DOES trigger. This documents that anaphora is the
+    // stronger signal and intentionally overrides the wh-led self-contained
+    // heuristic (a pronoun genuinely needs context).
+    expect(result).toContain('prior topic');
+  });
+});

--- a/web_ui/src/lib/rag/rag-orchestrator.test.ts
+++ b/web_ui/src/lib/rag/rag-orchestrator.test.ts
@@ -1488,4 +1488,280 @@ describe('RAGOrchestrator', () => {
       expect(imagePart!.data).toBe(imageData);
     });
   });
+
+  // ========================================================================
+  // Issue #40: conversation memory (RC1), repetition penalty (RC2), query
+  // rewriting (RC3). End-to-end tests at the orchestrator boundary.
+  // ========================================================================
+  describe('Issue #40: conversation memory, repetition penalty, query rewrite', () => {
+    test('RC1: history is threaded into the LLM message array between system and the current user turn', async () => {
+      const question = 'how do I fix it?';
+      const history = [
+        { role: 'user' as const, content: 'How do I order medication in CDP?' },
+        { role: 'assistant' as const, content: 'You cannot order medication without the Order Medications permission.' },
+      ];
+      const mockEmbedding = createMockEmbedding();
+      const chunks = createMockSearchResults(2, 1);
+      const fullAnswer = 'Grant the Order Medications permission.';
+
+      mockEmbeddingService.encodeWithMetadata.mockResolvedValue({
+        vector: mockEmbedding,
+        text: question,
+        dimensions: 384,
+      });
+      mockVectorIndex.search.mockResolvedValue(chunks);
+      mockKeywordIndex.search.mockReturnValue([]);
+      (rrfFuse as ReturnType<typeof vi.fn>).mockReturnValue(chunks);
+
+      let capturedMessages: LLMMessage[] | null = null;
+      mockWebLLMService.generateComplete = vi.fn().mockImplementation(async (messages: LLMMessage[]) => {
+        capturedMessages = messages;
+        return fullAnswer;
+      });
+
+      const orchestrator = new RAGOrchestrator();
+      for await (const _ev of orchestrator.query(question, {
+        history,
+        streamTokens: false,
+        rerank: false,
+      })) {
+        // consume
+      }
+
+      // The message array MUST be: [system, user(history), assistant(history), user(current turn)].
+      expect(capturedMessages).not.toBeNull();
+      expect(capturedMessages!.length).toBe(4);
+      expect(capturedMessages![0].role).toBe('system');
+      expect(capturedMessages![1].role).toBe('user');
+      expect(capturedMessages![1].content).toBe(history[0].content);
+      expect(capturedMessages![2].role).toBe('assistant');
+      expect(capturedMessages![2].content).toBe(history[1].content);
+      expect(capturedMessages![3].role).toBe('user');
+      // The current-turn user message still carries the question + context.
+      const lastUserContent = typeof capturedMessages![3].content === 'string'
+        ? capturedMessages![3].content
+        : '';
+      expect(lastUserContent).toContain(question);
+    });
+
+    test('RC1: without history the message array stays [system, user] (backward compatible)', async () => {
+      const question = 'What is machine learning?';
+      const mockEmbedding = createMockEmbedding();
+      const chunks = createMockSearchResults(2, 1);
+
+      mockEmbeddingService.encodeWithMetadata.mockResolvedValue({
+        vector: mockEmbedding,
+        text: question,
+        dimensions: 384,
+      });
+      mockVectorIndex.search.mockResolvedValue(chunks);
+      mockKeywordIndex.search.mockReturnValue([]);
+      (rrfFuse as ReturnType<typeof vi.fn>).mockReturnValue(chunks);
+
+      let capturedMessages: LLMMessage[] | null = null;
+      mockWebLLMService.generateComplete = vi.fn().mockImplementation(async (messages: LLMMessage[]) => {
+        capturedMessages = messages;
+        return 'answer';
+      });
+
+      const orchestrator = new RAGOrchestrator();
+      for await (const _ev of orchestrator.query(question, { streamTokens: false, rerank: false })) {
+        // consume
+      }
+
+      expect(capturedMessages!.length).toBe(2);
+      expect(capturedMessages![0].role).toBe('system');
+      expect(capturedMessages![1].role).toBe('user');
+    });
+
+    test('RC1 budget: history is charged to reservedTokens (fewer chunks fit when history is present)', async () => {
+      // Two large chunks that would both fit without history. With a long history
+      // consuming budget, the second chunk should be dropped to fit.
+      const question = 'follow up';
+      const longHistory = [
+        { role: 'user' as const, content: 'X'.repeat(20000) },
+        { role: 'assistant' as const, content: 'Y'.repeat(20000) },
+      ];
+      const mockEmbedding = createMockEmbedding();
+      const chunkA: SearchResult = { docId: 'a', chunkIndex: 0, score: 0.9, text: 'A'.repeat(5000) };
+      const chunkB: SearchResult = { docId: 'b', chunkIndex: 0, score: 0.8, text: 'B'.repeat(5000) };
+      const chunks = [chunkA, chunkB];
+
+      mockEmbeddingService.encodeWithMetadata.mockResolvedValue({
+        vector: mockEmbedding,
+        text: question,
+        dimensions: 384,
+      });
+      mockVectorIndex.search.mockResolvedValue(chunks);
+      mockKeywordIndex.search.mockReturnValue([]);
+      (rrfFuse as ReturnType<typeof vi.fn>).mockReturnValue(chunks);
+
+      mockWebLLMService.generateComplete = vi.fn().mockResolvedValue('answer');
+
+      const orchestrator = new RAGOrchestrator();
+      const events: any[] = [];
+      for await (const ev of orchestrator.query(question, {
+        history: longHistory,
+        streamTokens: false,
+        rerank: false,
+        maxTokens: 1024,
+      })) {
+        events.push(ev);
+      }
+
+      const complete = events.find((e) => e.type === 'complete');
+      // With ~40000 chars of history reserved, the context budget shrinks so at
+      // least one of the two 5000-char chunks is dropped (contextTrimmed >= 1).
+      // This proves the history term is in reservedTokens.
+      expect(complete.data.contextTrimmed).toBeGreaterThanOrEqual(1);
+    });
+
+    test('RC2: repeatPenalty/frequencyPenalty/presencePenalty are forwarded to the LLM service (NR1 critical fix)', async () => {
+      const question = 'anti repetition test';
+      const mockEmbedding = createMockEmbedding();
+      const chunks = createMockSearchResults(2, 1);
+
+      mockEmbeddingService.encodeWithMetadata.mockResolvedValue({
+        vector: mockEmbedding,
+        text: question,
+        dimensions: 384,
+      });
+      mockVectorIndex.search.mockResolvedValue(chunks);
+      mockKeywordIndex.search.mockReturnValue([]);
+      (rrfFuse as ReturnType<typeof vi.fn>).mockReturnValue(chunks);
+
+      let capturedOptions: any = null;
+      mockWebLLMService.generateComplete = vi.fn().mockImplementation(async (_messages: LLMMessage[], options?: any) => {
+        capturedOptions = options;
+        return 'answer';
+      });
+
+      const orchestrator = new RAGOrchestrator();
+      for await (const _ev of orchestrator.query(question, {
+        repeatPenalty: 1.1,
+        frequencyPenalty: 0.3,
+        presencePenalty: 0.0,
+        streamTokens: false,
+        rerank: false,
+      })) {
+        // consume
+      }
+
+      // This is the critical assertion: the penalty fields MUST cross the
+      // orchestrator→service boundary. Without the forward (the NR1 fix the
+      // critic caught), these would be absent and the test would fail.
+      expect(capturedOptions).not.toBeNull();
+      expect(capturedOptions.repeatPenalty).toBe(1.1);
+      expect(capturedOptions.frequencyPenalty).toBe(0.3);
+      expect(capturedOptions.presencePenalty).toBe(0.0);
+    });
+
+    test('RC2: streaming generate() also receives penalty options', async () => {
+      const question = 'anti repetition stream test';
+      const mockEmbedding = createMockEmbedding();
+      const chunks = createMockSearchResults(2, 1);
+
+      mockEmbeddingService.encodeWithMetadata.mockResolvedValue({
+        vector: mockEmbedding,
+        text: question,
+        dimensions: 384,
+      });
+      mockVectorIndex.search.mockResolvedValue(chunks);
+      mockKeywordIndex.search.mockReturnValue([]);
+      (rrfFuse as ReturnType<typeof vi.fn>).mockReturnValue(chunks);
+
+      let capturedOptions: any = null;
+      mockWebLLMService.generate = vi.fn().mockImplementation(async function* (_messages: LLMMessage[], options?: any) {
+        capturedOptions = options;
+        yield 'a';
+      });
+
+      const orchestrator = new RAGOrchestrator();
+      for await (const _ev of orchestrator.query(question, {
+        repeatPenalty: 1.1,
+        streamTokens: true,
+        rerank: false,
+      })) {
+        // consume
+      }
+
+      expect(capturedOptions.repeatPenalty).toBe(1.1);
+    });
+
+    test('RC3: a follow-up question is rewritten before embedding/keyword/rerank using history', async () => {
+      const question = 'how do I fix it?';
+      const history = [
+        { role: 'user' as const, content: 'How do I order medication in CDP?' },
+        { role: 'assistant' as const, content: 'You cannot order medication without the Order Medications permission.' },
+      ];
+      const mockEmbedding = createMockEmbedding();
+      const chunks = createMockSearchResults(2, 1);
+
+      mockEmbeddingService.encodeWithMetadata.mockResolvedValue({
+        vector: mockEmbedding,
+        text: question,
+        dimensions: 384,
+      });
+      mockVectorIndex.search.mockResolvedValue(chunks);
+      mockKeywordIndex.search.mockReturnValue([]);
+      (rrfFuse as ReturnType<typeof vi.fn>).mockReturnValue(chunks);
+
+      mockWebLLMService.generateComplete = vi.fn().mockResolvedValue('answer');
+
+      const orchestrator = new RAGOrchestrator();
+      for await (const _ev of orchestrator.query(question, {
+        history,
+        streamTokens: false,
+        rerank: false,
+      })) {
+        // consume
+      }
+
+      // The embedder receives BGE_QUERY_INSTRUCTION + the REWRITTEN query, which
+      // prepends the prior user turn (topical signal). The raw "how do I fix
+      // it?" would never contain "medication".
+      const embedCall = mockEmbeddingService.encodeWithMetadata.mock.calls[0];
+      expect(embedCall[0]).toContain('medication');
+      expect(embedCall[0]).toContain('how do I fix it?');
+
+      // The keyword index receives the rewritten query too.
+      const keywordCall = mockKeywordIndex.search.mock.calls[0];
+      expect(keywordCall[0]).toContain('medication');
+
+      // The `retrieving` event still surfaces the RAW question (UI fidelity).
+      // (Verified implicitly: not asserting the event here; the rewrite is an
+      // internal retrieval concern.)
+    });
+
+    test('RC3: a self-contained first-turn question is NOT rewritten (recall preserved)', async () => {
+      const question = 'What is machine learning?';
+      const mockEmbedding = createMockEmbedding();
+      const chunks = createMockSearchResults(2, 1);
+
+      mockEmbeddingService.encodeWithMetadata.mockResolvedValue({
+        vector: mockEmbedding,
+        text: question,
+        dimensions: 384,
+      });
+      mockVectorIndex.search.mockResolvedValue(chunks);
+      mockKeywordIndex.search.mockReturnValue([]);
+      (rrfFuse as ReturnType<typeof vi.fn>).mockReturnValue(chunks);
+
+      mockWebLLMService.generateComplete = vi.fn().mockResolvedValue('answer');
+
+      // No history → no rewrite possible even if the question looked like a
+      // follow-up. The embedder/keyword index see the raw question.
+      const orchestrator = new RAGOrchestrator();
+      for await (const _ev of orchestrator.query(question, {
+        streamTokens: false,
+        rerank: false,
+      })) {
+        // consume
+      }
+
+      const embedCall = mockEmbeddingService.encodeWithMetadata.mock.calls[0];
+      // The embedder input is BGE_QUERY_INSTRUCTION + the raw question (no prepend).
+      expect(embedCall[0]).toBe('Represent this sentence for searching relevant passages: ' + question);
+    });
+  });
 });

--- a/web_ui/src/lib/rag/rag-orchestrator.ts
+++ b/web_ui/src/lib/rag/rag-orchestrator.ts
@@ -39,6 +39,18 @@ export interface RAGImageInput {
   mimeType?: string;
 }
 
+/**
+ * Issue #40 RC1: one turn of prior conversation. `role` matches the LLM
+ * chat-template convention; `content` is the raw message text (history is
+ * text-only — multimodal history is out of scope; only the current turn carries
+ * images). Mirrors the {role, content} subset the server's `history` field
+ * accepts (api_server.py:187).
+ */
+export interface RAGHistoryTurn {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
 export interface RAGQueryOptions {
   /** Number of top results to retrieve from each index (default: 10) */
   topK?: number;
@@ -63,8 +75,19 @@ export interface RAGQueryOptions {
   temperature?: number;
   /** Nucleus sampling probability threshold */
   topP?: number;
+  /** Issue #40 RC2: anti-repetition sampling penalties (forwarded to the engine). */
+  repeatPenalty?: number;
+  frequencyPenalty?: number;
+  presencePenalty?: number;
   /** Images to include with the question (multimodal engines only). */
   images?: RAGImageInput[];
+  /**
+   * Issue #40 RC1: prior conversation turns threaded into the LLM prompt and
+   * used to contextualize the retrieval query (RC3). Caller caps at the last N
+   * turns; the orchestrator charges history to the token budget so it never
+   * starves context. Each turn is plain text.
+   */
+  history?: RAGHistoryTurn[];
   /** AbortSignal for cancelling the in-progress query */
   signal?: AbortSignal;
 }
@@ -105,9 +128,12 @@ export type RAGEvent =
 type RAGStage = 'embedding' | 'vector_search' | 'keyword_search' | 'rrf_fusion' | 'reranking' | 'context' | 'generation';
 
 /**
- * Default system prompt instructing the LLM to cite sources.
+ * Default system prompt. Issue #40 RC1/RC2: enriched beyond the bare citation
+ * instruction to (a) acknowledge the conversation history so the model treats
+ * follow-ups as continuing turns, and (b) reinforce anti-repetition. Kept short
+ * so it consumes minimal context budget.
  */
-const DEFAULT_SYSTEM_PROMPT = 'Answer the question based on the provided context. Cite sources using [1], [2] notation. If the context doesn\'t contain enough information, say so.';
+const DEFAULT_SYSTEM_PROMPT = 'You are a helpful assistant answering questions about uploaded documents. Use the provided context to answer, and cite sources using [1], [2] notation. The conversation history may provide context for follow-up questions. If the context doesn\'t contain enough information, say so. Do not repeat yourself.';
 
 /**
  * Retrieval query instruction. Issue #37 R9: the value is UNCHANGED from the
@@ -210,6 +236,15 @@ export class RAGOrchestrator {
     const maxTokens = options.maxTokens;
     const temperature = options.temperature;
     const topP = options.topP;
+    // Issue #40 RC2: anti-repetition sampling params. Forwarded to the engine at
+    // the generate() call below — without this forward, the penalty fields added
+    // to presets/LLMGenerateOptions die at the orchestrator→service boundary.
+    const repeatPenalty = options.repeatPenalty;
+    const frequencyPenalty = options.frequencyPenalty;
+    const presencePenalty = options.presencePenalty;
+    // Issue #40 RC1: prior conversation turns. Threaded into the LLM prompt
+    // (buildMessages) and used to contextualize the retrieval query (RC3).
+    const history = options.history ?? [];
     const signal = options.signal;
 
     // Ensure lazy services are initialized before the pipeline runs (FR-002)
@@ -240,6 +275,16 @@ export class RAGOrchestrator {
     // as a non-blocking "retrieval degraded" indicator in the UI (F4).
     let retrievalDegraded = false;
 
+    // Issue #40 RC3: rewrite a pronoun-heavy / short / continuation follow-up
+    // into a self-contained retrieval query using the conversation history.
+    // Deterministic heuristic (Option B per the issue) — microseconds, never
+    // fails, degrades to the raw question when no rewrite applies. Applied to
+    // the EMBEDDING, KEYWORD, and RERANKER inputs (all three consume this
+    // variable). The `retrieving` event still emits the raw `question` for UI
+    // fidelity — the rewrite is an internal retrieval concern, not something to
+    // surface to the user.
+    const retrievalQuery = contextualizeRetrievalQuery(question, history);
+
     // Stage 1: Embed the query
     yield { type: 'retrieving', data: { query: question } };
 
@@ -254,7 +299,7 @@ export class RAGOrchestrator {
     if (semanticAvailable) {
       try {
         const embeddingResult = await this.embeddingService.encodeWithMetadata(
-          QUERY_INSTRUCTION + question
+          QUERY_INSTRUCTION + retrievalQuery
         );
         queryEmbedding = embeddingResult.vector;
       } catch (err) {
@@ -300,7 +345,9 @@ export class RAGOrchestrator {
     let keywordResults: SearchResult[] = [];
     try {
       if (this.keywordIndex.isReady()) {
-        keywordResults = this.keywordIndex.search(question, { limit: fetchK });
+        // Issue #40 RC3: search on the contextualized query so pronoun-heavy
+        // follow-ups carry topical signal into FlexSearch.
+        keywordResults = this.keywordIndex.search(retrievalQuery, { limit: fetchK });
       } else {
         console.warn('[RAGOrchestrator] KeywordIndex not ready, skipping keyword search');
       }
@@ -366,7 +413,9 @@ export class RAGOrchestrator {
         if (this.rerankerService.isReady() && this.rerankerService.canRerank(fusedResults.length)) {
           yield { type: 'reranking', data: { count: fusedResults.length } };
 
-          const rerankedResults = await this.rerankerService.rerank(question, fusedResults, topK);
+          // Issue #40 RC3: rerank on the contextualized query so the
+          // cross-encoder scores against a self-contained question.
+          const rerankedResults = await this.rerankerService.rerank(retrievalQuery, fusedResults, topK);
 
           yield { type: 'reranked', data: { results: rerankedResults } };
           contextChunks = rerankedResults;
@@ -413,9 +462,16 @@ export class RAGOrchestrator {
     // many ranked chunks (highest first) as the remaining budget allows. Drop
     // whole chunks that overflow — never truncate mid-chunk. Applied BEFORE the
     // abstention check so that budget-induced emptiness also abstains.
+    //
+    // Issue #40 RC1: history is also in the prompt (threaded by buildMessages),
+    // so charge it to reservedTokens here. Without this term, history + context
+    // could silently overflow DEFAULT_N_CTX. The caller caps history length; the
+    // safety margin covers chat-template control tokens.
+    const historyText = history.map((t) => t.content).join('\n');
     const reservedTokens =
       estimateTokens(systemPrompt, CHARS_PER_TOKEN) +
       estimateTokens(question, CHARS_PER_TOKEN) +
+      estimateTokens(historyText, CHARS_PER_TOKEN) +
       (maxTokens ?? 512) +
       TOKEN_SAFETY_MARGIN;
     const contextBudgetChars = Math.max(0, (DEFAULT_N_CTX - reservedTokens) * CHARS_PER_TOKEN);
@@ -471,17 +527,24 @@ export class RAGOrchestrator {
 
     // Stage 6: Build context from chunks
     const contextText = this.buildContext(contextChunks);
-    const contextMessages = this.buildMessages(systemPrompt, question, contextText, options.images);
+    // Issue #40 RC1: thread history into the message array (between system and
+    // the current user turn) so the model has conversational continuity.
+    const contextMessages = this.buildMessages(systemPrompt, question, contextText, options.images, history);
 
     yield {
       type: 'generating',
       data: { contextLength: contextText.length, sourceCount: sources.length },
     };
 
-    // Stage 7 & 8: Generate answer with streaming
+    // Stage 7 & 8: Generate answer with streaming.
+    // Issue #40 RC2 (NR1 critical fix): forward repeatPenalty/frequencyPenalty/
+    // presencePenalty here — without this forward, the penalty fields added to
+    // presets/LLMGenerateOptions never cross the orchestrator→service boundary
+    // and the anti-repetition fix is a silent no-op.
+    const generateOptions = { maxTokens, temperature, topP, repeatPenalty, frequencyPenalty, presencePenalty, signal };
     try {
       if (streamTokens) {
-        for await (const token of this.llmService.generate(contextMessages, { maxTokens, temperature, topP, signal })) {
+        for await (const token of this.llmService.generate(contextMessages, generateOptions)) {
           if (signal?.aborted) {
             throw new DOMException('The operation was aborted.', 'AbortError');
           }
@@ -489,7 +552,7 @@ export class RAGOrchestrator {
           yield { type: 'token', data: token };
         }
       } else {
-        fullAnswer = await this.llmService.generateComplete(contextMessages, { maxTokens, temperature, topP, signal });
+        fullAnswer = await this.llmService.generateComplete(contextMessages, generateOptions);
         yield { type: 'token', data: fullAnswer };
       }
     } catch (err) {
@@ -559,12 +622,19 @@ export class RAGOrchestrator {
 
   /**
    * Build message array for LLM generation with system prompt and context.
+   *
+   * Issue #40 RC1: prior conversation turns are threaded between the system
+   * prompt and the current user turn, so the model has conversational continuity
+   * for follow-up questions. History is plain text (multimodal history is out of
+   * scope — only the current turn carries images) and is capped + budgeted by
+   * the caller. The chat-template sequence is: system, [...history], user.
    */
   private buildMessages(
     systemPrompt: string,
     question: string,
     context: string,
-    images?: RAGImageInput[]
+    images?: RAGImageInput[],
+    history?: RAGHistoryTurn[]
   ): LLMMessage[] {
     const userText = `Context:\n${context}\n\nQuestion: ${question}`;
 
@@ -578,10 +648,18 @@ export class RAGOrchestrator {
           ]
         : userText;
 
-    return [
+    const messages: LLMMessage[] = [
       { role: 'system', content: systemPrompt },
-      { role: 'user', content: userContent },
     ];
+    // Thread prior turns between system and the current turn. Each turn becomes
+    // a plain text message in the role it was spoken in.
+    if (history && history.length > 0) {
+      for (const turn of history) {
+        messages.push({ role: turn.role, content: turn.content });
+      }
+    }
+    messages.push({ role: 'user', content: userContent });
+    return messages;
   }
 
   /**
@@ -602,6 +680,97 @@ export class RAGOrchestrator {
  */
 function estimateTokens(text: string, charsPerToken: number): number {
   return Math.ceil((text?.length ?? 0) / charsPerToken);
+}
+
+/**
+ * Issue #40 RC3: rewrite a pronoun-heavy / short / continuation follow-up into a
+ * self-contained retrieval query using recent conversation history. Deterministic
+ * heuristic (Option B per the issue) — runs in microseconds, never fails, and
+ * degrades to the original question when no rewrite applies. Applied to the
+ * embedding, keyword, and reranker inputs so all three retrieval legs operate on
+ * a query with topical signal.
+ *
+ * Inspired by — but deliberately broader than — the server-side heuristic in
+ * rag_engine.py:420-455 (anaphora + short-non-wh + continuation keywords). The
+ * browser app is the primary surface and benefits from more aggressive
+ * follow-up detection; documented divergences:
+ *  - the anaphora set also covers they/them/their + "the second/first/last";
+ *  - when no prior USER turn exists it falls back to the last ASSISTANT answer's
+ *    first sentence (the server only ever uses last_user_msg).
+ * A self-contained question passes through unchanged (preserves first-turn
+ * recall — acceptance criterion). Exported for unit testing.
+ */
+const ANAPHORIC_RE =
+  /\b(it|this|that|these|those|they|them|their|the above|the previous|the (?:second|first|last))\b/i;
+const FOLLOWUP_WORDS = new Set([
+  'more', 'elaborate', 'detail', 'explain', 'expand', 'further',
+  'also', 'another', 'compare', 'difference', 'versus', 'vs',
+  'similar', 'unlike', 'deeper',
+]);
+const WH_WORDS = new Set(['what', 'who', 'when', 'where', 'which', 'how', 'why']);
+
+/**
+ * Does `question` look like a follow-up that lacks standalone topical signal?
+ * Three patterns (mirroring the server's detection, slightly broader):
+ *  1. anaphora / pronoun reference (it / this / that / they / ...);
+ *  2. very short (<=4 words) AND not starting with a wh-word;
+ *  3. continuation keywords (elaborate / more / compare / ...) — but ONLY when
+ *     the question does NOT start with a wh-word, so a self-contained comparison
+ *     question like "What is X vs Y?" passes through unchanged (a wh-word start
+ *     is a strong signal the question is already self-contained, even if it
+ *     contains a continuation keyword like "vs").
+ */
+function isFollowup(question: string): boolean {
+  const q = question.trim();
+  if (!q) return false;
+  const ql = q.toLowerCase();
+  const words = q.split(/\s+/).filter(Boolean);
+  const first = (ql.split(/\s+/)[0] ?? '').replace(/[^\w]/g, '');
+  const startsWithWh = WH_WORDS.has(first);
+  // Pattern 1: anaphora / pronoun reference.
+  if (ANAPHORIC_RE.test(ql)) return true;
+  // Pattern 2: very short non-wh question.
+  if (words.length <= 4 && !startsWithWh) return true;
+  // Pattern 3: continuation keywords — only when the question does not start
+  // with a wh-word (avoids rewriting self-contained "What is X vs Y?" queries).
+  if (
+    !startsWithWh &&
+    words.some((w) => FOLLOWUP_WORDS.has(w.toLowerCase().replace(/[^\w]/g, '')))
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Issue #40 RC3: produce the retrieval query. Returns the original question
+ * unchanged when it is already self-contained or when there is no history to
+ * contextualize with. Otherwise prepends the most recent substantive USER turn
+ * (preferred — it states the topic directly), falling back to the most recent
+ * ASSISTANT answer's first sentence.
+ */
+export function contextualizeRetrievalQuery(
+  question: string,
+  history: RAGHistoryTurn[]
+): string {
+  const q = question.trim();
+  if (!q || history.length === 0 || !isFollowup(q)) return question;
+  // Prefer the most recent substantive USER turn.
+  for (let i = history.length - 1; i >= 0; i--) {
+    const t = history[i];
+    if (t.role === 'user' && t.content.trim()) {
+      return `${t.content.trim()} ${question}`;
+    }
+  }
+  // Fall back to the most recent ASSISTANT answer's first sentence.
+  for (let i = history.length - 1; i >= 0; i--) {
+    const t = history[i];
+    if (t.role === 'assistant' && t.content.trim()) {
+      const firstSentence = t.content.trim().split(/[.!?\n]/)[0];
+      if (firstSentence.trim()) return `${firstSentence.trim()} ${question}`;
+    }
+  }
+  return question;
 }
 
 /**

--- a/web_ui/src/lib/rag/rag-presets.test.ts
+++ b/web_ui/src/lib/rag/rag-presets.test.ts
@@ -22,4 +22,22 @@ describe('rag-presets', () => {
   it('presetOptions returns the named preset', () => {
     expect(presetOptions('quality')).toEqual(RAG_PRESETS.quality);
   });
+
+  // Issue #40 RC2: every preset sets anti-repetition penalties + a sane topP.
+  it('all presets set repeatPenalty 1.1, topP 0.9, and zero freq/presence penalty', () => {
+    for (const preset of ['fast', 'balanced', 'quality'] as const) {
+      expect(RAG_PRESETS[preset].repeatPenalty).toBe(1.1);
+      expect(RAG_PRESETS[preset].topP).toBe(0.9);
+      expect(RAG_PRESETS[preset].frequencyPenalty).toBe(0.0);
+      expect(RAG_PRESETS[preset].presencePenalty).toBe(0.0);
+    }
+  });
+
+  it('presetOptions surfaces the penalty + topP fields (forwarded into RAGQueryOptions)', () => {
+    const opts = presetOptions('balanced');
+    expect(opts).toHaveProperty('repeatPenalty', 1.1);
+    expect(opts).toHaveProperty('topP', 0.9);
+    expect(opts).toHaveProperty('frequencyPenalty', 0.0);
+    expect(opts).toHaveProperty('presencePenalty', 0.0);
+  });
 });

--- a/web_ui/src/lib/rag/rag-presets.ts
+++ b/web_ui/src/lib/rag/rag-presets.ts
@@ -13,15 +13,18 @@ export type RAGPreset = 'fast' | 'balanced' | 'quality';
 export const DEFAULT_RAG_PRESET: RAGPreset = 'balanced';
 
 /** Retrieval/generation parameters per preset (merged into query options). */
-export const RAG_PRESETS: Record<RAGPreset, Pick<RAGQueryOptions, 'topK' | 'candidateMultiplier' | 'rerank' | 'maxTokens' | 'temperature'>> = {
+export const RAG_PRESETS: Record<
+  RAGPreset,
+  Pick<RAGQueryOptions, 'topK' | 'candidateMultiplier' | 'rerank' | 'maxTokens' | 'temperature' | 'topP' | 'repeatPenalty' | 'frequencyPenalty' | 'presencePenalty'>
+> = {
   // fast: no rerank → over-fetching wastes work. candidateMultiplier 1 keeps
   // both legs at topK.
-  fast: { topK: 5, candidateMultiplier: 1, rerank: false, maxTokens: 384, temperature: 0.3 },
+  fast: { topK: 5, candidateMultiplier: 1, rerank: false, maxTokens: 384, temperature: 0.3, topP: 0.9, repeatPenalty: 1.1, frequencyPenalty: 0.0, presencePenalty: 0.0 },
   // balanced: retrieve 3×topK per leg (30 candidates), rerank down to topK=10.
-  balanced: { topK: 10, candidateMultiplier: 3, rerank: true, maxTokens: 512, temperature: 0.3 },
+  balanced: { topK: 10, candidateMultiplier: 3, rerank: true, maxTokens: 512, temperature: 0.3, topP: 0.9, repeatPenalty: 1.1, frequencyPenalty: 0.0, presencePenalty: 0.0 },
   // quality: retrieve 4×topK per leg (64 candidates), rerank down to topK=16.
   // The reranker caps scoring at RERANK_INPUT_CAP=50 to bound per-query cost.
-  quality: { topK: 16, candidateMultiplier: 4, rerank: true, maxTokens: 1024, temperature: 0.2 },
+  quality: { topK: 16, candidateMultiplier: 4, rerank: true, maxTokens: 1024, temperature: 0.2, topP: 0.9, repeatPenalty: 1.1, frequencyPenalty: 0.0, presencePenalty: 0.0 },
 };
 
 /** Human-readable description for the settings UI. */
@@ -32,6 +35,8 @@ export const RAG_PRESET_LABELS: Record<RAGPreset, { label: string; description: 
 };
 
 /** Return the query-option overrides for a preset (defaults to balanced). */
-export function presetOptions(preset: RAGPreset | undefined): Pick<RAGQueryOptions, 'topK' | 'candidateMultiplier' | 'rerank' | 'maxTokens' | 'temperature'> {
+export function presetOptions(
+  preset: RAGPreset | undefined
+): Pick<RAGQueryOptions, 'topK' | 'candidateMultiplier' | 'rerank' | 'maxTokens' | 'temperature' | 'topP' | 'repeatPenalty' | 'frequencyPenalty' | 'presencePenalty'> {
   return RAG_PRESETS[preset ?? DEFAULT_RAG_PRESET];
 }

--- a/web_ui/src/pages/ChatPage.server-mode.test.tsx
+++ b/web_ui/src/pages/ChatPage.server-mode.test.tsx
@@ -163,7 +163,7 @@ describe('ChatPage API Mode (Task 8.4)', () => {
       // Verify the URL
       const [url, body, token] = mockStartSSEStream.mock.calls[0];
       expect(url).toBe('http://localhost:8000/ask/stream');
-      expect(body).toEqual({ question: 'What is AI?' });
+      expect(body).toEqual({ question: 'What is AI?', history: [] });
       expect(token).toBeUndefined();
     });
 
@@ -310,7 +310,7 @@ describe('ChatPage API Mode (Task 8.4)', () => {
       });
 
       const [, body] = mockStartSSEStream.mock.calls[0];
-      expect(body).toEqual({ question: 'What is machine learning?' });
+      expect(body).toEqual({ question: 'What is machine learning?', history: [] });
     });
 
     it('handles special characters in question text', async () => {
@@ -343,7 +343,7 @@ describe('ChatPage API Mode (Task 8.4)', () => {
       });
 
       const [, body] = mockStartSSEStream.mock.calls[0];
-      expect(body).toEqual({ question: 'What is "artificial intelligence"? & how does it work?' });
+      expect(body).toEqual({ question: 'What is "artificial intelligence"? & how does it work?', history: [] });
     });
   });
 
@@ -544,7 +544,7 @@ describe('ChatPage API Mode (Task 8.4)', () => {
       // Verify startSSEStream was called with correct parameters
       expect(mockStartSSEStream).toHaveBeenCalledWith(
         'http://localhost:8000/ask/stream',
-        { question: 'Test question' },
+        { question: 'Test question', history: [] },
         undefined
       );
 

--- a/web_ui/src/pages/ChatPage.tsx
+++ b/web_ui/src/pages/ChatPage.tsx
@@ -14,6 +14,7 @@ import { useInferenceMode } from '../lib/inference';
 import { InferenceModeToggle } from '../components/InferenceModeToggle';
 import { TokenStreamManager } from '../lib/streaming';
 import { RAGOrchestrator } from '../lib/rag/rag-orchestrator';
+import { buildHistorySnapshot } from '../lib/chat/history-snapshot';
 import { getLLMService } from '../lib/llm/llm-factory';
 import { ensureReadinessGateChecked, getReadinessResultSnapshot, resetReadinessCache } from '../lib/llm/readiness-gate';
 import { WEBLLM_DEFAULT_MODEL_ID } from '../lib/llm/web-llm-service';
@@ -441,7 +442,16 @@ function ChatPageInner({ messages: messagesProp, onMessagesChange, onSaveConvers
       // wedging the send pipeline permanently. (issue #21 F5, F9)
       const url = serverUrl ? `${serverUrl.replace(/\/$/, '')}/ask/stream` : '/ask/stream';
       try {
-        streamManager.startSSEStream(url, { question: text }, getToken() ?? undefined);
+        // Issue #40 RC1: thread conversation history into the server request so
+        // server mode benefits from multi-turn memory + retrieval rewriting too.
+        // The server (api_server.py) already accepts + validates `history`
+        // (<=20 turns, content truncated to 4000 chars) — Issue #37 R6 — so this
+        // is a pure client-side addition with ZERO Python changes.
+        streamManager.startSSEStream(
+          url,
+          { question: text, history: buildHistorySnapshot(owningMessages) },
+          getToken() ?? undefined
+        );
       } catch (err) {
         streamManager.error(err instanceof Error ? err.message : String(err));
       }
@@ -480,6 +490,9 @@ function ChatPageInner({ messages: messagesProp, onMessagesChange, onSaveConvers
             ...presetOptions(ragPreset),
             signal: abortController.signal,
             images: images?.map((img) => ({ data: img.data, mimeType: img.mimeType })),
+            // Issue #40 RC1: thread prior conversation turns for multi-turn
+            // memory + retrieval contextualization (RC3).
+            history: buildHistorySnapshot(owningMessages),
           })) {
             if (abortController.signal.aborted) return;
             if (tokenStreamManagerRef.current !== streamManager) return;

--- a/web_ui/src/types/llm.ts
+++ b/web_ui/src/types/llm.ts
@@ -40,6 +40,23 @@ export type LLMGenerateOptions = {
   temperature?: number;
   /** Nucleus sampling probability threshold. */
   topP?: number;
+  /**
+   * llama.cpp repeat penalty (>1.0 discourages repeating recent tokens).
+   * Issue #40 RC2: anti-repetition. wllama forwards this as `penalty_repeat`.
+   * WebLLM (MLC) has no equivalent — only frequencyPenalty/presencePenalty
+   * apply on that engine.
+   */
+  repeatPenalty?: number;
+  /**
+   * Penalty scaled by how often a token already appears in the output so far.
+   * Issue #40 RC2. wllama: `penalty_freq`; WebLLM: `frequency_penalty`.
+   */
+  frequencyPenalty?: number;
+  /**
+   * Penalty applied once per token already present anywhere in the output.
+   * Issue #40 RC2. wllama: `penalty_present`; WebLLM: `presence_penalty`.
+   */
+  presencePenalty?: number;
   /** Whether to stream tokens as they are generated. */
   stream?: boolean;
 };


### PR DESCRIPTION
Closes #40

## Summary

Resolve all three answer-quality root causes reported in issue #40 (web_ui: no conversation memory, degenerate repetition, irrelevant follow-up retrieval). All three are pre-existing design gaps, independent of the #37 retrieval-engine work.

**RC1 (CRITICAL — no conversation memory):** Thread prior conversation turns into the LLM. Added `RAGHistoryTurn` + `history` field to `RAGQueryOptions`; `buildMessages` now emits `[system, ...history, user]` (the multi-turn chat-template sequence), with history charged to `reservedTokens` so it can't overflow context. New `buildHistorySnapshot` helper drops the current turn + empty placeholder, skips error/abstain turns, enforces role alternation, caps at 6 turns. Threaded into BOTH the browser orchestrator call and the server `/ask/stream` POST body (the server already accepts `history` — Issue #37 R6 — so zero Python changes).

**RC2 (HIGH — degenerate repetition):** Add and forward anti-repetition sampling penalties. Added `repeatPenalty`/`frequencyPenalty`/`presencePenalty` to `LLMGenerateOptions`; presets set `repeatPenalty: 1.1` + `topP: 0.9` (was unset → wllama defaulted to 1.0 full nucleus, degeneration-prone). `WllamaService` forwards `penalty_repeat`/`penalty_freq`/`penalty_present`/`penalty_last_n: -1` (the `SamplingParams` names — NOT `repeat_penalty`, which would silently no-op). `WebLLMService` forwards `frequency_penalty`/`presence_penalty` (no `repeat_penalty` equivalent on MLC). **The orchestrator destructures and forwards the penalties at the generate() call** — without this forward the fix is a silent no-op (caught by an independent plan critic during Phase 5).

**RC3 (HIGH — irrelevant follow-up retrieval):** Deterministic query-rewrite heuristic. New `contextualizeRetrievalQuery` rewrites pronoun-heavy / short / continuation follow-ups into self-contained retrieval queries using conversation history, BEFORE embedding/keyword/rerank (a single `retrievalQuery` feeds all three). Self-contained first-turn questions pass through unchanged (recall preserved). Option B per the issue (microseconds, never fails); inspired by but deliberately broader than `rag_engine.py:420-455`.

## Invariant audit

- **Air-gap (F10):** PRESERVED. No engine-selection, network, or CDN changes. `getLLMService` still defaults to wllama offline-first; no new fetches.
- **Citation numbering (F7):** `buildContext` and `chunks` array unchanged; the `[1],[2]` invariant holds.
- **Budget (F11):** extended, not broken — `reservedTokens` gains a `historyText` term; the chunk-fitting loop is unchanged.
- **Abstention (F2) / degraded retrieval (F4):** unchanged; history threading + rewrite happen upstream of these.

## Test plan

Run from `web_ui/`:
- `npm run typecheck` → clean (exit 0)
- `npm run typecheck:all` → clean (exit 0)
- `npx vitest run` → **67 files, 1171 passed, 2 pre-existing skipped**
- `npm run build` → succeeds (exit 0; only pre-existing chunk-size warning)

New tests (+35): RC1 history threading + budget overflow; RC2 penalty forwarding through orchestrator + wllama (exact `penalty_*` names) + webllm (drops `repeat_penalty`); RC3 rewrite unit tests (anaphora, short-non-wh, continuation keywords, self-contained pass-through, assistant-fallback, wh-led comparison guard) + end-to-end retrieval-query assertion; `buildHistorySnapshot` unit tests; preset default assertions. Updated 4 `ChatPage.server-mode.test.tsx` assertions for the new `history` field (test is pre-existing excluded for unrelated reasons).

## Caveats (honestly acknowledged)

- **Criterion (b) "stress test":** satisfied at the penalty-forwarding mechanism level (the exact anti-repetition config the issue prescribed), not via a real-model loop test. A genuine model-driven stress test can't live in the unit suite (`@wllama/wllama` is mocked; takes minutes per query; non-deterministic). Real-model loop validation deferred to manual QA on target hardware.
- **`topP: 0.9`** narrows sampling globally (intentional; addresses RC2; the issue prescribed `top_p: 0.9`).
- **Heuristic over-trigger** on pronoun-bearing self-contained questions is documented, bounded, and tested.
- **Server-mode history** is wired (typecheck + static inspection) but not exercised by an executed test (the covering test is pre-existing excluded).

## Review trail
- Phase 5 plan critic (GLM-5.2): NEEDS_REVISION → all 3 items fixed (NR1 critical orchestrator-forward, NR2 test regression, NR3 false claim).
- Phase 8b implementation reviewer (Kimi K2.7): APPROVE; Q1/N1/N2 addressed.
- Phase 9 final critic (GLM-5.2): APPROVE (independently re-ran all gates).
