### PR TITLE
fix(web_ui): override Gemma 4 chat template at wllama load time

### DIFF
--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -183,6 +183,20 @@ Validate on target hardware before packaging. ~2.3B effective parameters (~5.1B
 total with Per-Layer Embeddings), 128K context window (capped at 8192 by default
 for RAM headroom on 8 GB target boxes).
 
+**Chat-template override (important):** The `gemma-4-e2b-it` GGUF embeds an
+~18 KB Jinja chat template that uses macros (`format_parameters`,
+`format_argument`, etc.) wllama 3.5.1's Jinja subset cannot evaluate — the
+macros render to empty strings, producing a blank prompt and **empty assistant
+responses** (model emits `<eos>` immediately). The app works around this by
+injecting a macro-free Gemma 4 template override at load time via
+`LoadModelParams.chat_template` + `jinja: true` (see
+`web_ui/src/lib/llm/wllama-service.ts` → `GEMMA4_CHAT_TEMPLATE`). This makes
+the app robust to any Gemma 4 GGUF regardless of its embedded template, so
+operators staging a different quant (e.g. Q5_K_M, Q8_0) from
+`unsloth/gemma-4-E2B-it-GGUF` do not need to verify the template field
+themselves. The override can be removed once wllama ships a Jinja runtime
+with macro support.
+
 The user picks the engine in Settings (**wllama** default, or **WebLLM** when
 WebGPU is usable); the choice persists and the RAG pipeline routes accordingly.
 

--- a/web_ui/src/lib/chat/history-snapshot.test.ts
+++ b/web_ui/src/lib/chat/history-snapshot.test.ts
@@ -83,6 +83,34 @@ describe('buildHistorySnapshot (Issue #40 RC1)', () => {
     expect(snap[snap.length - 1].content).toBe('a7');
   });
 
+  test('PRR-001: re-anchors an assistant-first window to user-first', () => {
+    // When the MAX_HISTORY_TURNS cap splits mid-conversation on an odd-length
+    // alternating history, slice(-N) lands on an assistant-first window
+    // (e.g. [u,a,u,a,u,a,u].slice(-6) = [a,u,a,u,a,u]). A leading assistant
+    // turn is orphaned context (no preceding user turn in the window) and,
+    // under the Gemma 4 chat-template override, mis-targets loop.first so a
+    // system_prefix kwarg would be silently dropped. The fix drops the
+    // leading assistant turn so the window always opens user-first.
+    //
+    // 7 prior alternating turns (odd length) + current user + placeholder:
+    //   [u0, a0, u1, a1, u2, a2, u3] + [current, placeholder]
+    // After dropping current + placeholder: [u0,a0,u1,a1,u2,a2,u3] (length 7)
+    // slice(-6) = [a0,u1,a1,u2,a2,u3] → ASSISTANT-FIRST (bug)
+    // After re-anchor: [u1,a1,u2,a2,u3] (length 5, user-first)
+    const msgs: ChatMessage[] = [
+      user('u0'), assistant('a0'),
+      user('u1'), assistant('a1'),
+      user('u2'), assistant('a2'),
+      user('u3'),
+      user('current'), emptyAssistant(),
+    ];
+    const snap = buildHistorySnapshot(msgs);
+    // The leading a0 must be dropped; window starts at u1.
+    expect(snap[0]).toEqual({ role: 'user', content: 'u1' });
+    expect(snap[0].role).toBe('user'); // always user-first
+    expect(snap.map((t) => t.content)).toEqual(['u1', 'a1', 'u2', 'a2', 'u3']);
+  });
+
   test('skips error assistant turns', () => {
     const msgs = [user('q1'), errorAssistant(), user('q2'), emptyAssistant()];
     const snap = buildHistorySnapshot(msgs);

--- a/web_ui/src/lib/chat/history-snapshot.ts
+++ b/web_ui/src/lib/chat/history-snapshot.ts
@@ -68,7 +68,18 @@ export function buildHistorySnapshot(owningMessages: ChatMessage[]): RAGHistoryT
     }
   }
   // 5. Cap at the last MAX_HISTORY_TURNS (oldest truncated first).
-  return alternating.slice(-MAX_HISTORY_TURNS).map((m) => ({
+  let windowed = alternating.slice(-MAX_HISTORY_TURNS);
+  // PRR-001: when the cap splits mid-conversation, slice(-N) can land on an
+  // assistant-first window (e.g. [u,a,u,a,u,a,u].slice(-6) = [a,u,a,u,a,u]).
+  // A leading assistant turn is orphaned context — it has no preceding user
+  // turn in the window — and, under the Gemma 4 chat-template override, it
+  // also mis-targets `loop.first` so a `system_prefix` kwarg would be silently
+  // dropped (the assistant branch has no prefix handling). Drop a leading
+  // assistant turn so the window always opens user-first.
+  while (windowed.length > 1 && windowed[0].role === 'assistant') {
+    windowed = windowed.slice(1);
+  }
+  return windowed.map((m) => ({
     role: m.role === 'assistant' ? 'assistant' : 'user',
     content: m.content ?? '',
   }));

--- a/web_ui/src/lib/llm/wllama-service.test.ts
+++ b/web_ui/src/lib/llm/wllama-service.test.ts
@@ -379,4 +379,61 @@ describe('WllamaService', () => {
     };
     expect(lastCall.chat_template_kwargs).toBeUndefined();
   });
+
+  it('PRR-008: streaming generate() also threads system message via chat_template_kwargs.system_prefix', async () => {
+    // The streaming path (generate) is the default UI chat path
+    // (streamTokens ?? true in rag-orchestrator.ts). The shared buildChatArgs
+    // helper is tested via generateComplete above, but generate() has its OWN
+    // chat_template_kwargs spread at the call site (mirrored line). This test
+    // pins that the streaming spread is present, mirroring the Issue #40 RC2
+    // penalty-streaming test pattern. If the streaming-path spread were
+    // dropped, the system prompt would be stripped (by buildChatArgs) but
+    // never threaded → silently lost in the default UI path.
+    const svc = WllamaService.getInstance();
+    await svc.initialize();
+
+    const tokens: string[] = [];
+    for await (const t of svc.generate([
+      { role: 'system', content: 'You are a helpful assistant.' },
+      { role: 'user', content: 'hi' },
+    ])) {
+      tokens.push(t);
+    }
+    expect(tokens).toEqual(['Hello', ', ', 'world']);
+    expect(createChatCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stream: true,
+        chat_template_kwargs: { system_prefix: 'You are a helpful assistant.' },
+        // The system message must be STRIPPED from the messages array so the
+        // override template (which has no system branch) never sees it.
+        messages: [{ role: 'user', content: 'hi' }],
+      })
+    );
+  });
+
+  it('PRR-007: non-Gemma model id does NOT get the chat-template override', async () => {
+    // isGemma4Model gates the override on modelId.startsWith('gemma-4'). The
+    // negative branch (override NOT applied) is currently unreachable in
+    // production (LLM_MODEL_DIR is gemma-4-e2b-it and WebLLM uses a separate
+    // service), but a non-Gemma model id must NOT receive chat_template/jinja
+    // keys — those would force a Gemma-specific template onto a different
+    // architecture. This test is cheap insurance for the next model swap.
+    const svc = WllamaService.getInstance();
+    await svc.initialize('lfm2.5-vl-450m');
+
+    expect(loadModelFromUrl).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.not.objectContaining({ chat_template: expect.anything() })
+    );
+    expect(loadModelFromUrl).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.not.objectContaining({ jinja: true })
+    );
+    // The default sampling/context params are still present (the override
+    // absence is a pure removal of chat_template/jinja, not a different load).
+    expect(loadModelFromUrl).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ useCache: true })
+    );
+  });
 });

--- a/web_ui/src/lib/llm/wllama-service.test.ts
+++ b/web_ui/src/lib/llm/wllama-service.test.ts
@@ -286,4 +286,97 @@ describe('WllamaService', () => {
     expect(await backend.read('test-key')).toBeNull();
     expect(await backend.getSize('test-key')).toBe(-1);
   });
+
+  // --- Gemma 4 chat-template override regression tests ----------------------
+  //
+  // Regression: the gemma-4-e2b-it GGUF embeds an 18 KB Jinja chat template
+  // that uses macros (format_parameters, format_argument, etc.) wllama 3.5.1's
+  // Jinja subset cannot evaluate. The macros render to empty strings, producing
+  // a BLANK prompt — the model emits <eos> immediately, createChatCompletion's
+  // stream yields zero content chunks, and the assistant bubble stays empty
+  // despite retrieval + citations working. The fix injects a macro-free
+  // override template via LoadModelParams.chat_template + jinja: true. These
+  // tests pin the override so the empty-output regression cannot recur.
+
+  it('Gemma 4 chat-template override: injects chat_template + jinja at load time', async () => {
+    // The default model id is gemma-4-e2b-it (LLM_MODEL_DIR), so the override
+    // must be applied on the default initialize() path.
+    const svc = WllamaService.getInstance();
+    await svc.initialize();
+
+    expect(loadModelFromUrl).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        chat_template: expect.stringContaining('<|turn>') as string,
+        jinja: true,
+      })
+    );
+    // The override template uses the Gemma 4 turn markers verbatim and folds
+    // the system role into the first user turn via the system_prefix kwarg.
+    // Assert each marker via withCalledWith so we don't index into the mock's
+    // calls tuple (the mock fn is typed as () => undefined, so calls[n][1] is
+    // not statically known to exist).
+    expect(loadModelFromUrl).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ chat_template: expect.stringContaining('<|turn>user') })
+    );
+    expect(loadModelFromUrl).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ chat_template: expect.stringContaining('<|turn>model') })
+    );
+    expect(loadModelFromUrl).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ chat_template: expect.stringContaining('<turn|>') })
+    );
+    expect(loadModelFromUrl).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ chat_template: expect.stringContaining('system_prefix') })
+    );
+  });
+
+  it('Gemma 4 chat-template override: threads system message via chat_template_kwargs.system_prefix', async () => {
+    // When the override is active, the system message is extracted from the
+    // messages array and threaded via chat_template_kwargs.system_prefix (the
+    // override template folds it into the first user turn). Without this, the
+    // override template has no system role handling and the system prompt
+    // would be silently dropped.
+    const svc = WllamaService.getInstance();
+    await svc.initialize();
+
+    await svc.generateComplete([
+      { role: 'system', content: 'You are a helpful assistant.' },
+      { role: 'user', content: 'hi' },
+    ]);
+
+    expect(createChatCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chat_template_kwargs: { system_prefix: 'You are a helpful assistant.' },
+        // The system message must be STRIPPED from the messages array so the
+        // override template (which has no system branch) never sees it.
+        messages: [{ role: 'user', content: 'hi' }],
+      })
+    );
+  });
+
+  it('Gemma 4 chat-template override: streaming still yields tokens end-to-end', async () => {
+    // The override must not break the streaming protocol. The model generates
+    // (GPU active) but tokens never reached the UI in the bug — this test
+    // pins the full generate() → createChatCompletion → yield path.
+    const svc = WllamaService.getInstance();
+    await svc.initialize();
+
+    const tokens: string[] = [];
+    for await (const t of svc.generate([{ role: 'user', content: 'hi' }])) {
+      tokens.push(t);
+    }
+    expect(tokens).toEqual(['Hello', ', ', 'world']);
+    // No system message → no chat_template_kwargs should be threaded.
+    expect(createChatCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({ stream: true })
+    );
+    const lastCall = createChatCompletion.mock.calls.at(-1)?.[0] as {
+      chat_template_kwargs?: unknown;
+    };
+    expect(lastCall.chat_template_kwargs).toBeUndefined();
+  });
 });

--- a/web_ui/src/lib/llm/wllama-service.ts
+++ b/web_ui/src/lib/llm/wllama-service.ts
@@ -54,10 +54,13 @@ export const DEFAULT_N_CTX = 8192;
  *
  * This override is the macro-free equivalent of the embedded template's actual
  * message-rendering loop (extracted byte-for-byte from tokenizer.chat_template
- * in the GGUF). It uses the SAME turn markers (`<|turn>{role}\n` … `<turn|>\n`)
- * the model was trained on, so tokenization matches training. System messages
- * are folded into the first user turn via the `system_prefix` kwarg — Gemma 4
- * has no standalone system role, matching Google's documented prompt structure
+ * in the GGUF). It uses the SAME turn markers the model was trained on —
+ * `<|turn>{role}\n` to open a turn and `<turn|>` to close it (the closing
+ * marker has no trailing newline; the next line's `{%-` strip handles
+ * whitespace separation, and `<turn|>` tokenizes as a single special token
+ * that absorbs surrounding whitespace). System messages are folded into the
+ * first user turn via the `system_prefix` kwarg — Gemma 4 has no standalone
+ * system role, matching Google's documented prompt structure
  * (https://ai.google.dev/gemma/docs/core/prompt-structure) and the embedded
  * template's own behavior.
  *

--- a/web_ui/src/lib/llm/wllama-service.ts
+++ b/web_ui/src/lib/llm/wllama-service.ts
@@ -38,6 +38,61 @@ import { probeAsset } from '../models/probe';
  *  that leaves ample RAM for weights + KV cache on 8 GB target boxes. */
 export const DEFAULT_N_CTX = 8192;
 
+/**
+ * Macro-free Gemma 4 chat template, injected as `LoadModelParams.chat_template`
+ * with `jinja: true` to override the broken template embedded in the GGUF.
+ *
+ * Why this is required: the `gemma-4-e2b-it` GGUF ships an 18 KB Jinja chat
+ * template that uses 5 macros (format_parameters, format_function_declaration,
+ * format_argument, strip_thinking, format_tool_response_block) plus custom
+ * `<|"|>` escape tokens. wllama 3.5.1's Jinja subset cannot evaluate those
+ * macros — they render to empty strings, producing a BLANK prompt, so the
+ * model emits <eos> immediately and the assistant bubble stays empty despite
+ * retrieval + citations working. This is a known class of bug across the
+ * llama.cpp ecosystem (goose#9110, LLamaSharp#1375, lmstudio#2012, and
+ * llama.cpp#22786 all describe Gemma 4 "loads but produces nothing").
+ *
+ * This override is the macro-free equivalent of the embedded template's actual
+ * message-rendering loop (extracted byte-for-byte from tokenizer.chat_template
+ * in the GGUF). It uses the SAME turn markers (`<|turn>{role}\n` … `<turn|>\n`)
+ * the model was trained on, so tokenization matches training. System messages
+ * are folded into the first user turn via the `system_prefix` kwarg — Gemma 4
+ * has no standalone system role, matching Google's documented prompt structure
+ * (https://ai.google.dev/gemma/docs/core/prompt-structure) and the embedded
+ * template's own behavior.
+ *
+ * Multimodal note: image content parts flow through createChatCompletion
+ * unchanged; wllama inserts `<|image|>` tokens at the projector boundary.
+ *
+ * TODO: remove this override once wllama ships a Jinja runtime that supports
+ * the macros Gemma 4's embedded template requires.
+ */
+const GEMMA4_CHAT_TEMPLATE = `{%- for message in messages -%}
+{%- if message.role == "system" -%}
+{# Gemma 4 has no standalone system turn; fold into first user turn via system_prefix kwarg #}
+{%- elif message.role == "user" -%}
+<|turn>user
+{{ system_prefix if system_prefix and loop.first else "" }}{{ message.content }}<turn|>
+{%- elif message.role == "assistant" -%}
+<|turn>model
+{{ message.content }}<turn|>
+{%- endif -%}
+{%- endfor -%}
+{%- if add_generation_prompt -%}
+<|turn>model
+{%- endif -%}`;
+
+/**
+ * Detect whether a model id refers to a Gemma 4 variant whose embedded chat
+ * template requires the macro-free override above. Keyed off the model id
+ * (the directory name under /models/llm/) rather than runtime architecture
+ * introspection, because the override must be injected at LOAD time before
+ * the model metadata is available.
+ */
+function isGemma4Model(modelId: string | undefined): boolean {
+  return !!modelId && modelId.startsWith('gemma-4');
+}
+
 function threadCount(): number {
   return navigator.hardwareConcurrency ? Math.min(navigator.hardwareConcurrency, 4) : 2;
 }
@@ -55,6 +110,22 @@ function toWllamaMessages(
   messages: LLMMessage[]
 ): Parameters<Wllama['createChatCompletion']>[0]['messages'] {
   return messages as unknown as Parameters<Wllama['createChatCompletion']>[0]['messages'];
+}
+
+/**
+ * Extract the text of a system message (flattening content parts to text) if
+ * one is present at the head of the messages array. Returns null when there
+ * is no system message.
+ */
+function extractSystemText(messages: LLMMessage[]): string | null {
+  if (messages.length === 0 || messages[0].role !== 'system') return null;
+  const content = messages[0].content;
+  if (typeof content === 'string') return content;
+  // Flatten content parts to text, dropping image parts (system prompts are
+  // text-only by construction in the orchestrator's buildMessages).
+  return content
+    .map((part) => (part.type === 'text' ? part.text : ''))
+    .join('');
 }
 
 /**
@@ -175,6 +246,13 @@ export class WllamaService implements LLMService {
   private initPromise: Promise<void> | null = null;
   private disposed = false;
   private modelInfo: LLMModelInfo | null = null;
+  /**
+   * True when the loaded model's chat template was overridden at load time
+   * (currently: Gemma 4 variants whose embedded macro template wllama can't
+   * render). When true, system messages must be threaded via
+   * chat_template_kwargs.system_prefix instead of as a separate message.
+   */
+  private chatTemplateOverridden = false;
   /** Tracks the in-flight generation so interrupt() can cancel it. */
   private activeAbort: AbortController | null = null;
 
@@ -241,6 +319,15 @@ export class WllamaService implements LLMService {
       // them from jsdelivr and breaks the offline guarantee.
       this.wllama.setCompat({ worker: WLLAMA_COMPAT_WORKER_URL, wasm: WLLAMA_COMPAT_WASM_URL });
 
+      // Gemma 4 chat-template override: the GGUF's embedded template uses Jinja
+      // macros wllama can't evaluate, which silently produces an empty prompt
+      // (see GEMMA4_CHAT_TEMPLATE doc comment). When the staged model is a
+      // Gemma 4 variant, inject a macro-free override + enable the Jinja
+      // interpreter so wllama renders messages correctly. Track the override
+      // so the generation path knows to thread system messages via kwargs.
+      const needsTemplateOverride = isGemma4Model(modelId);
+      this.chatTemplateOverridden = needsTemplateOverride;
+
       await this.wllama.loadModelFromUrl(
         // mmprojUrl loads the vision projector so the model can accept images.
         { url: LLM_GGUF_URL, mmprojUrl: LLM_MMPROJ_URL },
@@ -248,6 +335,9 @@ export class WllamaService implements LLMService {
           n_ctx: DEFAULT_N_CTX,
           n_threads: threadCount(),
           useCache: true,
+          ...(needsTemplateOverride
+            ? { chat_template: GEMMA4_CHAT_TEMPLATE, jinja: true }
+            : {}),
           progressCallback: ({ loaded, total }) => {
             if (onProgress && total > 0) {
               onProgress({
@@ -308,6 +398,34 @@ export class WllamaService implements LLMService {
     };
   }
 
+  /**
+   * Build the `messages` + optional `chat_template_kwargs` for a
+   * createChatCompletion call. When the chat-template override is active
+   * (Gemma 4), the system message is extracted from the messages array and
+   * threaded via `chat_template_kwargs.system_prefix` (the override template
+   * folds it into the first user turn). Without the override, messages pass
+   * through unchanged so non-Gemma models keep their native system handling.
+   */
+  private buildChatArgs(messages: LLMMessage[]): {
+    messages: Parameters<Wllama['createChatCompletion']>[0]['messages'];
+    chatTemplateKwargs?: Record<string, unknown>;
+  } {
+    if (!this.chatTemplateOverridden) {
+      return { messages: toWllamaMessages(messages) };
+    }
+    const systemText = extractSystemText(messages);
+    if (systemText === null) {
+      // No system message to fold — pass messages through unchanged.
+      return { messages: toWllamaMessages(messages) };
+    }
+    // Strip the leading system message; thread its text as the kwarg the
+    // override template prepends to the first user turn.
+    return {
+      messages: toWllamaMessages(messages.slice(1)),
+      chatTemplateKwargs: { system_prefix: systemText },
+    };
+  }
+
   async *generate(
     messages: LLMMessage[],
     options?: LLMGenerateOptions & { signal?: AbortSignal }
@@ -317,13 +435,15 @@ export class WllamaService implements LLMService {
     }
     const { signal, cleanup } = this.beginGeneration(options?.signal);
     try {
+      const { messages: wllamaMessages, chatTemplateKwargs } = this.buildChatArgs(messages);
       const stream = await this.wllama.createChatCompletion({
-        messages: toWllamaMessages(messages),
+        messages: wllamaMessages,
         stream: true,
         abortSignal: signal,
         max_tokens: options?.maxTokens,
         temp: options?.temperature,
         top_p: options?.topP,
+        ...(chatTemplateKwargs ? { chat_template_kwargs: chatTemplateKwargs } : {}),
         // Issue #40 RC2: anti-repetition sampling params. wllama's chat path
         // (createChatCompletion) accepts the SamplingParams names (penalty_*),
         // NOT the OpenAI-style repeat_penalty/frequency_penalty — using the
@@ -351,13 +471,15 @@ export class WllamaService implements LLMService {
     }
     const { signal, cleanup } = this.beginGeneration(options?.signal);
     try {
+      const { messages: wllamaMessages, chatTemplateKwargs } = this.buildChatArgs(messages);
       const response = await this.wllama.createChatCompletion({
-        messages: toWllamaMessages(messages),
+        messages: wllamaMessages,
         stream: false,
         abortSignal: signal,
         max_tokens: options?.maxTokens,
         temp: options?.temperature,
         top_p: options?.topP,
+        ...(chatTemplateKwargs ? { chat_template_kwargs: chatTemplateKwargs } : {}),
         // Issue #40 RC2: see generate() above.
         ...buildWllamaPenalties(options),
       });
@@ -414,6 +536,7 @@ export class WllamaService implements LLMService {
     this.ready = false;
     this.initPromise = null;
     this.modelInfo = null;
+    this.chatTemplateOverridden = false;
     WllamaService.instance = null;
   }
 }


### PR DESCRIPTION
## Summary

The browser LLM (Gemma 4 E2B-it via wllama) generated responses but **tokens never appeared in the chat UI** — the assistant bubble stayed empty while citation pills rendered correctly (retrieval worked, generation appeared to run). This was discovered during local air-gapped testing after the Gemma 4 swap (commit `8c01d02`).

### Root cause

The `gemma-4-e2b-it/model.gguf` embeds an **18,808-byte Jinja chat template** that uses 5 macros (`format_parameters`, `format_function_declaration`, `format_argument`, `strip_thinking`, `format_tool_response_block`) plus custom `<|"|>` escape tokens (22×). **wllama 3.5.1's Jinja subset cannot evaluate these macros** — they silently render to empty strings, producing a blank prompt. The model receives nothing, emits `<eos>` immediately, `createChatCompletion`'s stream yields zero content chunks, `fullAnswer` stays `''`, and the `complete` event fires with citations but no text — exactly the observed symptom.

This is a known class of bug across the Gemma 4 + llama.cpp ecosystem:
- [goose#9110](https://github.com/aaif-goose/goose/issues/9110) — "null result from llama cpp"
- [LLamaSharp#1375](https://github.com/SciSharp/LLamaSharp/issues/1375) — llama.cpp bypasses the generic template path for Gemma 4
- [lmstudio#2012](https://github.com/lmstudio-ai/lmstudio-bug-tracker/issues/2012) — missing `format_type_argument` macro
- [llama.cpp#22786](https://github.com/ggml-org/llama.cpp/issues/22786) — Gemma 4 tool-call format mishandled

Evidence gathered: byte-level extraction of the GGUF's `tokenizer.chat_template` field (confirmed 5 macros, 22× `<|"|>` markers), `general.architecture = 'gemma4'`, and verification that wllama 3.5.1's `LoadModelParams` exposes `chat_template?: string` + `jinja?: boolean` for override.

### Fix

Inject a **macro-free Gemma 4 template override** via `LoadModelParams.chat_template` + `jinja: true` at load time. The override:
- Uses the SAME turn markers (`<|turn>{role}\n` … `<turn|>\n`) extracted verbatim from the model's own embedded template — so tokenization matches training distribution
- Folds the system message into the first user turn via a `system_prefix` kwarg (Gemma convention — no standalone system role, per [Google's prompt docs](https://ai.google.dev/gemma/docs/core/prompt-structure))
- Preserves streaming (still `createChatCompletion`)
- Preserves multimodal images (image content parts flow through unchanged; wllama inserts `<|image|>` at the projector boundary)
- Leaves non-Gemma models untouched (gated on `modelId.startsWith('gemma-4')`)

The override template was validated offline with Python Jinja2 — it parses and renders correctly for conversations with/without system messages.

### Files

- `web_ui/src/lib/llm/wllama-service.ts` — `GEMMA4_CHAT_TEMPLATE` constant, `isGemma4Model()` guard, `chatTemplateOverridden` field, load-time override injection in `loadModelFromUrl`, `buildChatArgs()` helper + `extractSystemText()` for system-prefix threading in `generate()`/`generateComplete()`
- `web_ui/src/lib/llm/wllama-service.test.ts` — 3 regression tests
- `PACKAGING.md` — operator note on the override

## Invariant audit

| Invariant | Evidence |
|---|---|
| `LLMService` interface unchanged | `src/types/llm.ts:109-136` — no signature changes; `generate`/`generateComplete` still accept `LLMMessage[]` + return same types |
| Orchestrator untouched | `rag-orchestrator.ts` — engine-agnostic; no edits |
| Non-Gemma paths unchanged | Override gated on `modelId.startsWith('gemma-4')`; conditional spread means non-matching models get `{}` (no-op) |
| Token markers match training | Extracted from the GGUF's own `tokenizer.chat_template` (offsets 10100–11200) — `<|turn>`, `<turn|>`, `<|turn>model` generation prompt |
| Jinja renders correctly | Validated offline: parses + renders with/without system message |
| tsc clean | `npx tsc --noEmit` (src) and `npx tsc --noEmit -p tsconfig.test.json` (test) → EXIT 0 |
| Build succeeds | `npm run build` → EXIT 0, all chunks emitted |
| No secrets/local files staged | Pre-push scan: no `sk_live_|ghp_|xox|AKIA|eyJ|AIza` patterns; no `.local/.vscode/.env` files |

## Test plan

```bash
cd web_ui
npx tsc --noEmit                          # EXIT 0
npx tsc --noEmit -p tsconfig.test.json    # EXIT 0
npx vitest run src/lib/llm/wllama-service.test.ts   # 20/20 pass (17 existing + 3 new)
npx vitest run                            # 1175 pass, 2 skipped (pre-existing), 0 fail
npm run build                             # EXIT 0
```

### New regression tests (the tests that would have caught the bug)

1. **`Gemma 4 chat-template override: injects chat_template + jinja at load time`** — asserts `loadModelFromUrl` is called with `chat_template` (containing `<|turn>user`, `<|turn>model`, `<turn|>`, `system_prefix`) + `jinja: true` when the default model id (`gemma-4-e2b-it`) is loaded.
2. **`Gemma 4 chat-template override: threads system message via chat_template_kwargs.system_prefix`** — asserts the system message is extracted and threaded as `system_prefix`, and stripped from the messages array so the override template (which has no system branch) never sees it.
3. **`Gemma 4 chat-template override: streaming still yields tokens end-to-end`** — asserts the full `generate()` → `createChatCompletion` → yield path still produces `['Hello', ', ', 'world']`, and that no `chat_template_kwargs` is threaded when there's no system message.

### Manual smoke test (the validation the original swap commit never ran)

Fresh page load at `http://localhost:5173/`, model loaded with the override (verified the served module contains `GEMMA4_CHAT_TEMPLATE` + `jinja: true`), sent the query `What is CDP?`:

- ✅ Model loaded (loading overlay progressed to 100%, no errors)
- ✅ Tokens streamed into the assistant bubble: *"CDP is a powerful and intuitive tool designed to provide multiple paths for documenting a patient's care. It is built to be robust, user-friendly, and to seamlessly integrate into workflows [2]."* (799 chars total)
- ✅ 10 citation pills rendered with correct source documents
- ✅ Inline `[2]` citation marker emitted by the model
- ✅ Regenerate button present (onDone fired correctly)
- ✅ 0 console errors throughout the entire load + generate cycle

The empty-output bug is resolved.

## Notes

- This PR does NOT revert the Gemma 4 swap — the model is correct, only the template wiring was broken.
- The override is gated on `modelId.startsWith('gemma-4')` rather than runtime architecture introspection because the override must be injected at LOAD time before model metadata is available.
- The override can be removed once wllama ships a Jinja runtime with macro support (noted in a TODO comment).
- edgevec 0.6→0.9 + FlatIndex remains deferred (separate future PR).

## Swarm-pr-review feedback closure (commit `96df2f2`)

A `swarm-pr-review` (run-47) and follow-on `swarm-pr-feedback` pass closed 4 validated findings. No CRITICAL/HIGH findings survived the critic gate. Closure ledger:

| ID | Severity | Finding | Outcome |
|----|----------|---------|---------|
| PRR-008 | MEDIUM | Streaming `generate()` + system_prefix path untested | FIXED — added streaming test mirroring the Issue #40 RC2 penalty-streaming pattern |
| PRR-007 | LOW | Non-Gemma model path untested | FIXED — added `initialize('lfm2.5-vl-450m')` test asserting no `chat_template`/`jinja` |
| PRR-013 | LOW | Doc comment claimed `<turn|>\n`, template emits `<turn|>` | FIXED — doc now matches the template |
| PRR-001 | LOW | `buildHistorySnapshot` slice could land assistant-first | FIXED — re-anchor loop in `history-snapshot.ts` + regression test |
| PRR-014 | INFO | `dispose()` reset is dead code | ACCEPT-AS-IS — `instance=null` forces fresh construction; reset is harmless redundancy |

Gates: reviewer (Kimi K2.7) APPROVE 95-98%; final critic (Kimi K3) APPROVE — all 6 investigation threads resolved clean. Notable: server mode uses the same `buildHistorySnapshot` but flattens history into text (no template interaction), so no unwired path.

Updated test counts: 1178 pass (was 1175), 3 new tests, 0 regressions. Full validation (tsc + vitest + build) green.
