### PR TITLE
fix(web_ui): Gemma 4 QAT swap + canonical chat template + answer quality overhaul

### DIFF
--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -167,34 +167,45 @@ running **Google Gemma 4 E2B-it GGUF + mmproj**. Two pieces are packaged:
    browser generation, server mode is unaffected):
 
 ```bash
-# (a) obtain Gemma 4 E2B-it GGUF + mmproj from unsloth/gemma-4-E2B-it-GGUF on HuggingFace:
-#       gemma-4-E2B-it-Q4_K_M.gguf  (~2.9 GB) → rename to model.gguf
-#       mmproj-F16.gguf              (~940 MB) → rename to mmproj.gguf
+# (a) obtain Gemma 4 E2B-it QAT weights + mmproj from unsloth/gemma-4-E2B-it-qat-GGUF on HuggingFace:
+#       gemma-4-E2B-it-qat-UD-Q4_K_XL.gguf  (~2.44 GB) → rename to model.gguf
+#       mmproj-F16.gguf                       (~940 MB) → rename to mmproj.gguf
 #     then place them at the repo root as:
 #       models/gemma-4-e2b-it/model.gguf
 #       models/gemma-4-e2b-it/mmproj.gguf
 # (b) npm run prepare-models   # copies them to public/models/llm/gemma-4-e2b-it/
 ```
 
-Gemma 4 E2B-it Q4_K_M is ~2.9 GB. This exceeds the historical ~2 GB/file WASM
-`ArrayBuffer` ceiling, but wllama v3+ streams via HTTP range requests (not a
-single ArrayBuffer), so the practical limit is browser RAM, not the 2 GB ceiling.
-Validate on target hardware before packaging. ~2.3B effective parameters (~5.1B
-total with Per-Layer Embeddings), 128K context window (capped at 8192 by default
-for RAM headroom on 8 GB target boxes).
+Gemma 4 E2B-it QAT UD-Q4_K_XL is ~2.44 GB (down from ~2.9 GB for the prior
+post-training Q4_K_M — quantization-aware training preserves more accuracy per
+bit, so the smaller file is the recommended baseline). This exceeds the
+historical ~2 GB/file WASM `ArrayBuffer` ceiling, but wllama v3+ streams via
+HTTP range requests (not a single ArrayBuffer), so the practical limit is
+browser RAM, not the 2 GB ceiling. Validate on target hardware before packaging.
+~2.3B effective parameters (~5.1B total with Per-Layer Embeddings), 128K context
+window (capped at 8192 by default for RAM headroom on 8 GB target boxes).
+
+The QAT repo also ships an `mtp-gemma-4-E2B-it.gguf` Multi-Token Prediction
+drafter (~56 MB). **Do not stage it** — wllama 3.5.1 does not expose the
+`--spec-type draft-mtp` path (only the classic `--model-draft` path, which
+fails on Gemma 4 E2B/E4B per llama.cpp#22337). MTP is server-mode-only until
+wllama adds the API surface. See the QAT investigation notes in the PR that
+introduced this swap.
 
 **Chat-template override (important):** The `gemma-4-e2b-it` GGUF embeds an
 ~18 KB Jinja chat template that uses macros (`format_parameters`,
 `format_argument`, etc.) wllama 3.5.1's Jinja subset cannot evaluate — the
 macros render to empty strings, producing a blank prompt and **empty assistant
-responses** (model emits `<eos>` immediately). The app works around this by
-injecting a macro-free Gemma 4 template override at load time via
-`LoadModelParams.chat_template` + `jinja: true` (see
+responses** (model emits `<eos>` immediately). The embedded template is
+byte-identical between the QAT and post-training repos (MD5
+`d451e60cbddd44f7a929b8eee8b209c6`), so the override applies to both. The app
+works around this by injecting a macro-free Gemma 4 template override at load
+time via `LoadModelParams.chat_template` + `jinja: true` (see
 `web_ui/src/lib/llm/wllama-service.ts` → `GEMMA4_CHAT_TEMPLATE`). This makes
 the app robust to any Gemma 4 GGUF regardless of its embedded template, so
-operators staging a different quant (e.g. Q5_K_M, Q8_0) from
-`unsloth/gemma-4-E2B-it-GGUF` do not need to verify the template field
-themselves. The override can be removed once wllama ships a Jinja runtime
+operators staging a different quant (e.g. UD-Q2_K_XL, or a non-QAT Q5_K_M /
+Q8_0 from `unsloth/gemma-4-E2B-it-GGUF`) do not need to verify the template
+field themselves. The override can be removed once wllama ships a Jinja runtime
 with macro support.
 
 The user picks the engine in Settings (**wllama** default, or **WebLLM** when

--- a/web_ui/src/components/ChatMessageBubble.tsx
+++ b/web_ui/src/components/ChatMessageBubble.tsx
@@ -194,7 +194,7 @@ export const ChatMessageBubble: React.FC<ChatMessageBubbleProps> = React.memo(({
       <div
         style={{
           width: '100%',
-          padding: 'var(--spacing-md)',
+          padding: 'var(--spacing-md) var(--spacing-lg)',
           backgroundColor: 'var(--color-surface-elevated)',
           border: '1px solid var(--color-bubble-system)',
           borderRadius: 'var(--radius-md)',

--- a/web_ui/src/components/MarkdownRenderer.test.tsx
+++ b/web_ui/src/components/MarkdownRenderer.test.tsx
@@ -181,6 +181,9 @@ describe('MarkdownRenderer', () => {
 
       const bold = screen.getByText('bold');
       expect(bold.tagName).toBe('STRONG');
+      // PRR48-018: pin the fontWeight override so a regression to default
+      // weight (400) or a removed override would fail this test.
+      expect((bold as HTMLElement).style.fontWeight).toBe('600');
     });
 
     it('renders bold text with __', () => {
@@ -202,6 +205,8 @@ describe('MarkdownRenderer', () => {
 
       const italic = screen.getByText('italic');
       expect(italic.tagName).toBe('EM');
+      // PRR48-018: pin the fontStyle override.
+      expect((italic as HTMLElement).style.fontStyle).toBe('italic');
     });
 
     it('renders italic text with _ (issue #36)', () => {

--- a/web_ui/src/components/MarkdownRenderer.tsx
+++ b/web_ui/src/components/MarkdownRenderer.tsx
@@ -316,30 +316,44 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = React.memo(({ c
           },
           ul({ children, ...rest }) {
             return (
-              <ul style={{ margin: 'var(--spacing-sm) 0', paddingLeft: 'var(--spacing-xl)' }} {...rest}>
+              <ul style={{ margin: 'var(--spacing-md) 0', paddingLeft: 'var(--spacing-lg)' }} {...rest}>
                 {children}
               </ul>
             );
           },
           ol({ children, ...rest }) {
             return (
-              <ol style={{ margin: 'var(--spacing-sm) 0', paddingLeft: 'var(--spacing-xl)' }} {...rest}>
+              <ol style={{ margin: 'var(--spacing-md) 0', paddingLeft: 'var(--spacing-lg)' }} {...rest}>
                 {children}
               </ol>
             );
           },
           li({ children, ...rest }) {
             return (
-              <li style={{ marginBottom: 'var(--spacing-xs)' }} {...rest}>
+              <li style={{ marginBottom: 'var(--spacing-sm)', lineHeight: 'var(--line-height-body)' }} {...rest}>
                 {children}
               </li>
             );
           },
           p({ children, ...rest }) {
             return (
-              <p style={{ margin: 'var(--spacing-sm) 0' }} {...rest}>
+              <p style={{ margin: 'var(--spacing-sm) 0', lineHeight: 'var(--line-height-body)' }} {...rest}>
                 {children}
               </p>
+            );
+          },
+          strong({ children, ...rest }) {
+            return (
+              <strong style={{ fontWeight: 600 }} {...rest}>
+                {children}
+              </strong>
+            );
+          },
+          em({ children, ...rest }) {
+            return (
+              <em style={{ fontStyle: 'italic' }} {...rest}>
+                {children}
+              </em>
             );
           },
           h1: (props) => <Heading level={1} {...props} />,

--- a/web_ui/src/lib/chat/history-snapshot.ts
+++ b/web_ui/src/lib/chat/history-snapshot.ts
@@ -72,10 +72,9 @@ export function buildHistorySnapshot(owningMessages: ChatMessage[]): RAGHistoryT
   // PRR-001: when the cap splits mid-conversation, slice(-N) can land on an
   // assistant-first window (e.g. [u,a,u,a,u,a,u].slice(-6) = [a,u,a,u,a,u]).
   // A leading assistant turn is orphaned context — it has no preceding user
-  // turn in the window — and, under the Gemma 4 chat-template override, it
-  // also mis-targets `loop.first` so a `system_prefix` kwarg would be silently
-  // dropped (the assistant branch has no prefix handling). Drop a leading
-  // assistant turn so the window always opens user-first.
+  // turn in the window, which violates the user/assistant alternation the
+  // chat template expects. Drop a leading assistant turn so the window always
+  // opens user-first.
   while (windowed.length > 1 && windowed[0].role === 'assistant') {
     windowed = windowed.slice(1);
   }

--- a/web_ui/src/lib/llm/model-readiness.test.ts
+++ b/web_ui/src/lib/llm/model-readiness.test.ts
@@ -210,17 +210,18 @@ describe('ModelReadinessGate', () => {
     });
 
     test('uses modelId to determine required bytes (gemma-4-e2b-it)', () => {
-      // Gemma 4 E2B-it Q4_K_M (wllama): ~2.9 GB GGUF + ~940 MB mmproj + KV cache.
-      // MODEL_REQUIRED_BYTES budgets conservatively at 4 GB.
+      // Gemma 4 E2B-it QAT UD-Q4_K_XL (wllama): ~2.44 GB GGUF + ~940 MB mmproj
+      // + KV cache. MODEL_REQUIRED_BYTES budgets at 5 GB (above the ~4.3-4.7 GB
+      // peak so the gate is genuinely conservative — PRR48-013).
       mockGetMemoryBudget.mockReturnValue({
         totalMB: 8192,
-        availableMB: 5_000_000_000 / (1024 * 1024), // ~4768MB
+        availableMB: 6_000_000_000 / (1024 * 1024), // ~5722MB — comfortably above 5 GB
         browserOverheadMB: 1024,
       });
 
       const result = gate.checkMemory('gemma-4-e2b-it');
 
-      expect(result.requiredBytes).toBe(4_000_000_000);
+      expect(result.requiredBytes).toBe(5_000_000_000);
     });
 
     test('uses default 2GB for unknown modelId', () => {

--- a/web_ui/src/lib/llm/model-readiness.ts
+++ b/web_ui/src/lib/llm/model-readiness.ts
@@ -74,10 +74,10 @@ const MODEL_REQUIRED_BYTES: Record<string, number> = {
   // working memory. ~2.3B effective params (~5.1B total w/ PLE), 128K context.
   // QAT (quantization-aware training) replaces the prior post-training Q4_K_M
   // (~2.9 GB) — ~450 MB smaller with comparable-or-better quality. Peak
-  // (without download-blob retention) ~4.3-4.7 GB; budgeted at 4 GB
-  // conservatively (the gate is moot on the 8 GB target box but should not
-  // false-pass on low-RAM boxes).
-  'gemma-4-e2b-it': 4_000_000_000,
+  // (without download-blob retention) ~4.3-4.7 GB; budgeted at 5 GB so the
+  // gate is genuinely conservative (above peak) and rejects low-RAM boxes
+  // that would OOM during generation. The 8 GB target box passes comfortably.
+  'gemma-4-e2b-it': 5_000_000_000,
 };
 
 /**

--- a/web_ui/src/lib/llm/model-readiness.ts
+++ b/web_ui/src/lib/llm/model-readiness.ts
@@ -69,11 +69,14 @@ export interface ReadinessResult {
 const MODEL_REQUIRED_BYTES: Record<string, number> = {
   // Llama-3.2-3B (WebLLM): ~1.9 GB weights + ~300 MB working ≈ 2.3 GB.
   'Llama-3.2-3B-Instruct-q4f16_1-MLC': 2_300_000_000,
-  // Gemma 4 E2B-it Q4_K_M (wllama): ~2.9 GB GGUF + ~940 MB mmproj (F16) +
-  // KV cache (~0.8-1.2 GB at 8192 ctx f16) + WASM working memory. ~2.3B
-  // effective params (~5.1B total w/ PLE), 128K context. Peak (without download-
-  // blob retention) ~4.7-5.1 GB; budgeted at 4 GB conservatively (the gate is
-  // moot on the 8 GB target box but should not false-pass on low-RAM boxes).
+  // Gemma 4 E2B-it QAT UD-Q4_K_XL (wllama): ~2.44 GB GGUF +
+  // ~940 MB mmproj (F16) + KV cache (~0.8-1.2 GB at 8192 ctx f16) + WASM
+  // working memory. ~2.3B effective params (~5.1B total w/ PLE), 128K context.
+  // QAT (quantization-aware training) replaces the prior post-training Q4_K_M
+  // (~2.9 GB) — ~450 MB smaller with comparable-or-better quality. Peak
+  // (without download-blob retention) ~4.3-4.7 GB; budgeted at 4 GB
+  // conservatively (the gate is moot on the 8 GB target box but should not
+  // false-pass on low-RAM boxes).
   'gemma-4-e2b-it': 4_000_000_000,
 };
 

--- a/web_ui/src/lib/llm/wllama-service.test.ts
+++ b/web_ui/src/lib/llm/wllama-service.test.ts
@@ -298,7 +298,7 @@ describe('WllamaService', () => {
   // override template via LoadModelParams.chat_template + jinja: true. These
   // tests pin the override so the empty-output regression cannot recur.
 
-  it('Gemma 4 chat-template override: injects chat_template + jinja at load time', async () => {
+  it('Gemma 4 chat-template override: injects canonical chat_template + jinja at load time', async () => {
     // The default model id is gemma-4-e2b-it (LLM_MODEL_DIR), so the override
     // must be applied on the default initialize() path.
     const svc = WllamaService.getInstance();
@@ -311,11 +311,19 @@ describe('WllamaService', () => {
         jinja: true,
       })
     );
-    // The override template uses the Gemma 4 turn markers verbatim and folds
-    // the system role into the first user turn via the system_prefix kwarg.
-    // Assert each marker via withCalledWith so we don't index into the mock's
-    // calls tuple (the mock fn is typed as () => undefined, so calls[n][1] is
-    // not statically known to exist).
+    // The override template uses the canonical Gemma 4 prompt structure:
+    // bos_token, dedicated <|turn>system turn, <|turn>user/model turns,
+    // <turn|> turn close with trailing newline, and <|turn>model generation
+    // prompt. Assert each marker via toHaveBeenCalledWith so we don't index
+    // into the mock's calls tuple.
+    expect(loadModelFromUrl).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ chat_template: expect.stringContaining('bos_token') })
+    );
+    expect(loadModelFromUrl).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ chat_template: expect.stringContaining('<|turn>system') })
+    );
     expect(loadModelFromUrl).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ chat_template: expect.stringContaining('<|turn>user') })
@@ -330,7 +338,16 @@ describe('WllamaService', () => {
     );
     expect(loadModelFromUrl).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ chat_template: expect.stringContaining('system_prefix') })
+      expect.objectContaining({ chat_template: expect.stringContaining('add_generation_prompt') })
+    );
+    // PRR48-001 regression guard: the template must NOT reference system_prefix
+    // (the old folding-via-kwarg approach). The canonical template emits a
+    // proper <|turn>system turn instead. Verified via toHaveBeenCalledWith
+    // (the mock fn is typed as () => undefined, so calls[n][1] is not
+    // statically known to exist — toHaveBeenCalledWith matches any call).
+    expect(loadModelFromUrl).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.not.objectContaining({ chat_template: expect.stringContaining('system_prefix') })
     );
   });
 

--- a/web_ui/src/lib/llm/wllama-service.test.ts
+++ b/web_ui/src/lib/llm/wllama-service.test.ts
@@ -334,12 +334,14 @@ describe('WllamaService', () => {
     );
   });
 
-  it('Gemma 4 chat-template override: threads system message via chat_template_kwargs.system_prefix', async () => {
-    // When the override is active, the system message is extracted from the
-    // messages array and threaded via chat_template_kwargs.system_prefix (the
-    // override template folds it into the first user turn). Without this, the
-    // override template has no system role handling and the system prompt
-    // would be silently dropped.
+  it('Gemma 4 chat-template override: system message passes through unchanged (native system turn)', async () => {
+    // The override template emits a proper <|turn>system turn, so the system
+    // message is NOT extracted or threaded via kwargs — it passes through
+    // buildChatArgs unchanged to createChatCompletion, where wllama's Jinja
+    // renders it into the canonical Gemma 4 system turn. This is the key
+    // correctness invariant: if a future change re-introduced system
+    // extraction, the system prompt would be lost (the override template no
+    // longer has a system_prefix kwarg path).
     const svc = WllamaService.getInstance();
     await svc.initialize();
 
@@ -350,12 +352,19 @@ describe('WllamaService', () => {
 
     expect(createChatCompletion).toHaveBeenCalledWith(
       expect.objectContaining({
-        chat_template_kwargs: { system_prefix: 'You are a helpful assistant.' },
-        // The system message must be STRIPPED from the messages array so the
-        // override template (which has no system branch) never sees it.
-        messages: [{ role: 'user', content: 'hi' }],
+        // Both messages pass through unchanged — no extraction, no kwargs.
+        messages: [
+          { role: 'system', content: 'You are a helpful assistant.' },
+          { role: 'user', content: 'hi' },
+        ],
       })
     );
+    // No chat_template_kwargs should be threaded (the template handles system
+    // natively; kwargs are not used).
+    const lastCall = createChatCompletion.mock.calls.at(-1)?.[0] as {
+      chat_template_kwargs?: unknown;
+    };
+    expect(lastCall.chat_template_kwargs).toBeUndefined();
   });
 
   it('Gemma 4 chat-template override: streaming still yields tokens end-to-end', async () => {
@@ -370,25 +379,20 @@ describe('WllamaService', () => {
       tokens.push(t);
     }
     expect(tokens).toEqual(['Hello', ', ', 'world']);
-    // No system message → no chat_template_kwargs should be threaded.
     expect(createChatCompletion).toHaveBeenCalledWith(
       expect.objectContaining({ stream: true })
     );
-    const lastCall = createChatCompletion.mock.calls.at(-1)?.[0] as {
-      chat_template_kwargs?: unknown;
-    };
-    expect(lastCall.chat_template_kwargs).toBeUndefined();
   });
 
-  it('PRR-008: streaming generate() also threads system message via chat_template_kwargs.system_prefix', async () => {
+  it('PRR-008: streaming generate() preserves system message in the messages array', async () => {
     // The streaming path (generate) is the default UI chat path
     // (streamTokens ?? true in rag-orchestrator.ts). The shared buildChatArgs
     // helper is tested via generateComplete above, but generate() has its OWN
-    // chat_template_kwargs spread at the call site (mirrored line). This test
-    // pins that the streaming spread is present, mirroring the Issue #40 RC2
-    // penalty-streaming test pattern. If the streaming-path spread were
-    // dropped, the system prompt would be stripped (by buildChatArgs) but
-    // never threaded → silently lost in the default UI path.
+    // call site. This test pins that the streaming path also passes the
+    // system message through unchanged (mirroring the Issue #40 RC2
+    // penalty-streaming test pattern). If the streaming path were ever
+    // diverged to drop/extract system, the system prompt would be silently
+    // lost in the default UI path.
     const svc = WllamaService.getInstance();
     await svc.initialize();
 
@@ -403,10 +407,11 @@ describe('WllamaService', () => {
     expect(createChatCompletion).toHaveBeenCalledWith(
       expect.objectContaining({
         stream: true,
-        chat_template_kwargs: { system_prefix: 'You are a helpful assistant.' },
-        // The system message must be STRIPPED from the messages array so the
-        // override template (which has no system branch) never sees it.
-        messages: [{ role: 'user', content: 'hi' }],
+        // System message passes through unchanged on the streaming path too.
+        messages: [
+          { role: 'system', content: 'You are a helpful assistant.' },
+          { role: 'user', content: 'hi' },
+        ],
       })
     );
   });

--- a/web_ui/src/lib/llm/wllama-service.ts
+++ b/web_ui/src/lib/llm/wllama-service.ts
@@ -116,22 +116,6 @@ function toWllamaMessages(
 }
 
 /**
- * Extract the text of a system message (flattening content parts to text) if
- * one is present at the head of the messages array. Returns null when there
- * is no system message.
- */
-function extractSystemText(messages: LLMMessage[]): string | null {
-  if (messages.length === 0 || messages[0].role !== 'system') return null;
-  const content = messages[0].content;
-  if (typeof content === 'string') return content;
-  // Flatten content parts to text, dropping image parts (system prompts are
-  // text-only by construction in the orchestrator's buildMessages).
-  return content
-    .map((part) => (part.type === 'text' ? part.text : ''))
-    .join('');
-}
-
-/**
  * Issue #40 RC2: translate our camelCase LLMGenerateOptions penalty fields into
  * wllama's SamplingParams names (penalty_*). Returns an empty object when no
  * penalty is set, so callers that pass no penalties get unchanged default
@@ -249,13 +233,6 @@ export class WllamaService implements LLMService {
   private initPromise: Promise<void> | null = null;
   private disposed = false;
   private modelInfo: LLMModelInfo | null = null;
-  /**
-   * True when the loaded model's chat template was overridden at load time
-   * (currently: Gemma 4 variants whose embedded macro template wllama can't
-   * render). When true, system messages must be threaded via
-   * chat_template_kwargs.system_prefix instead of as a separate message.
-   */
-  private chatTemplateOverridden = false;
   /** Tracks the in-flight generation so interrupt() can cancel it. */
   private activeAbort: AbortController | null = null;
 
@@ -325,11 +302,11 @@ export class WllamaService implements LLMService {
       // Gemma 4 chat-template override: the GGUF's embedded template uses Jinja
       // macros wllama can't evaluate, which silently produces an empty prompt
       // (see GEMMA4_CHAT_TEMPLATE doc comment). When the staged model is a
-      // Gemma 4 variant, inject a macro-free override + enable the Jinja
-      // interpreter so wllama renders messages correctly. Track the override
-      // so the generation path knows to thread system messages via kwargs.
+      // Gemma 4 variant, inject the macro-free override above + enable the
+      // Jinja interpreter so wllama renders messages correctly. The override
+      // template handles the system role natively, so no per-call system
+      // extraction is needed.
       const needsTemplateOverride = isGemma4Model(modelId);
-      this.chatTemplateOverridden = needsTemplateOverride;
 
       await this.wllama.loadModelFromUrl(
         // mmprojUrl loads the vision projector so the model can accept images.
@@ -407,31 +384,16 @@ export class WllamaService implements LLMService {
   }
 
   /**
-   * Build the `messages` + optional `chat_template_kwargs` for a
-   * createChatCompletion call. When the chat-template override is active
-   * (Gemma 4), the system message is extracted from the messages array and
-   * threaded via `chat_template_kwargs.system_prefix` (the override template
-   * folds it into the first user turn). Without the override, messages pass
-   * through unchanged so non-Gemma models keep their native system handling.
+   * Build the messages payload for a createChatCompletion call. The override
+   * template (GEMMA4_CHAT_TEMPLATE) now handles the system role natively
+   * (emitting a proper `<|turn>system` turn), so no system-message extraction
+   * or chat_template_kwargs threading is needed — messages pass through
+   * unchanged. Kept as a helper to centralize the wllama-message cast.
    */
   private buildChatArgs(messages: LLMMessage[]): {
     messages: Parameters<Wllama['createChatCompletion']>[0]['messages'];
-    chatTemplateKwargs?: Record<string, unknown>;
   } {
-    if (!this.chatTemplateOverridden) {
-      return { messages: toWllamaMessages(messages) };
-    }
-    const systemText = extractSystemText(messages);
-    if (systemText === null) {
-      // No system message to fold — pass messages through unchanged.
-      return { messages: toWllamaMessages(messages) };
-    }
-    // Strip the leading system message; thread its text as the kwarg the
-    // override template prepends to the first user turn.
-    return {
-      messages: toWllamaMessages(messages.slice(1)),
-      chatTemplateKwargs: { system_prefix: systemText },
-    };
+    return { messages: toWllamaMessages(messages) };
   }
 
   async *generate(
@@ -443,7 +405,7 @@ export class WllamaService implements LLMService {
     }
     const { signal, cleanup } = this.beginGeneration(options?.signal);
     try {
-      const { messages: wllamaMessages, chatTemplateKwargs } = this.buildChatArgs(messages);
+      const { messages: wllamaMessages } = this.buildChatArgs(messages);
       const stream = await this.wllama.createChatCompletion({
         messages: wllamaMessages,
         stream: true,
@@ -451,7 +413,6 @@ export class WllamaService implements LLMService {
         max_tokens: options?.maxTokens,
         temp: options?.temperature,
         top_p: options?.topP,
-        ...(chatTemplateKwargs ? { chat_template_kwargs: chatTemplateKwargs } : {}),
         // Issue #40 RC2: anti-repetition sampling params. wllama's chat path
         // (createChatCompletion) accepts the SamplingParams names (penalty_*),
         // NOT the OpenAI-style repeat_penalty/frequency_penalty — using the
@@ -479,7 +440,7 @@ export class WllamaService implements LLMService {
     }
     const { signal, cleanup } = this.beginGeneration(options?.signal);
     try {
-      const { messages: wllamaMessages, chatTemplateKwargs } = this.buildChatArgs(messages);
+      const { messages: wllamaMessages } = this.buildChatArgs(messages);
       const response = await this.wllama.createChatCompletion({
         messages: wllamaMessages,
         stream: false,
@@ -487,7 +448,6 @@ export class WllamaService implements LLMService {
         max_tokens: options?.maxTokens,
         temp: options?.temperature,
         top_p: options?.topP,
-        ...(chatTemplateKwargs ? { chat_template_kwargs: chatTemplateKwargs } : {}),
         // Issue #40 RC2: see generate() above.
         ...buildWllamaPenalties(options),
       });
@@ -544,7 +504,6 @@ export class WllamaService implements LLMService {
     this.ready = false;
     this.initPromise = null;
     this.modelInfo = null;
-    this.chatTemplateOverridden = false;
     WllamaService.instance = null;
   }
 }

--- a/web_ui/src/lib/llm/wllama-service.ts
+++ b/web_ui/src/lib/llm/wllama-service.ts
@@ -357,7 +357,12 @@ export class WllamaService implements LLMService {
         throw new Error('WllamaService was disposed during initialization');
       }
 
-      this.modelInfo = { modelId, quantization: 'Q4_K_M', sizeBytes: 0, cached: true };
+      // Quantization label reflects the staged GGUF. The Gemma 4 E2B-it weights
+      // are staged as Unsloth's QAT UD-Q4_K_XL (quantization-aware trained,
+      // file_type=Q4_0 with dynamic tensor-precision bumps); see PACKAGING.md.
+      // sizeBytes stays 0 here — actual size is computed by the model-download
+      // layer from the staged file, not hardcoded.
+      this.modelInfo = { modelId, quantization: 'UD-Q4_K_XL (QAT)', sizeBytes: 0, cached: true };
       this.ready = true;
     } catch (error) {
       await this.safeExit();

--- a/web_ui/src/lib/llm/wllama-service.ts
+++ b/web_ui/src/lib/llm/wllama-service.ts
@@ -53,16 +53,33 @@ export const DEFAULT_N_CTX = 8192;
  * llama.cpp#22786 all describe Gemma 4 "loads but produces nothing").
  *
  * This override is the macro-free equivalent of the embedded template's actual
- * message-rendering loop (extracted byte-for-byte from tokenizer.chat_template
- * in the GGUF). It uses the SAME turn markers the model was trained on —
- * `<|turn>{role}\n` to open a turn and `<turn|>` to close it (the closing
- * marker has no trailing newline; the next line's `{%-` strip handles
- * whitespace separation, and `<turn|>` tokenizes as a single special token
- * that absorbs surrounding whitespace). System messages are folded into the
- * first user turn via the `system_prefix` kwarg — Gemma 4 has no standalone
- * system role, matching Google's documented prompt structure
- * (https://ai.google.dev/gemma/docs/core/prompt-structure) and the embedded
- * template's own behavior.
+ * message-rendering logic (extracted byte-for-byte from tokenizer.chat_template
+ * in the GGUF at offsets 8185-11200). It produces the EXACT canonical Gemma 4
+ * prompt structure the model was trained on:
+ *
+ *   <bos><|turn>system\n{system content}<turn|>\n
+ *   <|turn>user\n{user content}<turn|>\n
+ *   <|turn>model\n{assistant content}<turn|>\n
+ *   <|turn>model\n   (generation prompt)
+ *
+ * Key structural elements (all verified against the embedded template):
+ *   - `{{- bos_token -}}` at the very start (the embedded template emits this
+ *     unconditionally at offset 8207; wllama substitutes the real BOS token).
+ *   - A dedicated `<|turn>system` turn for the system message (Gemma 4 DOES
+ *     have a system role — confirmed at offset 8255: `{{- '<|turn>system\n' -}}`
+ *     when `messages[0]['role'] in ['system', 'developer']`).
+ *   - Turn markers + newlines emitted via `{{ '<|turn>...\n' }}` string
+ *     literals (the `\n` survives Jinja's whitespace stripping because it is
+ *     inside a string, not template whitespace).
+ *   - `<turn|>\n` closes each turn WITH a trailing newline (offset 11188).
+ *   - `<|turn>model\n` as the generation prompt (offset end).
+ *   - Role mapping: assistant → model (offset 10100); system/user pass through.
+ *
+ * NOTE: PR #48 review (swarm-pr-review run-48 PRR48-001/002) caught that an
+ * earlier commit (ccc97be) claimed to rewrite this template but the edit was
+ * lost — the committed code kept the old system-folding template while
+ * removing the `system_prefix` kwarg threading it relied on, silently dropping
+ * the system prompt. This is the actual canonical rewrite.
  *
  * Multimodal note: image content parts flow through createChatCompletion
  * unchanged; wllama inserts `<|image|>` tokens at the projector boundary.
@@ -70,20 +87,29 @@ export const DEFAULT_N_CTX = 8192;
  * TODO: remove this override once wllama ships a Jinja runtime that supports
  * the macros Gemma 4's embedded template requires.
  */
-const GEMMA4_CHAT_TEMPLATE = `{%- for message in messages -%}
-{%- if message.role == "system" -%}
-{# Gemma 4 has no standalone system turn; fold into first user turn via system_prefix kwarg #}
-{%- elif message.role == "user" -%}
-<|turn>user
-{{ system_prefix if system_prefix and loop.first else "" }}{{ message.content }}<turn|>
-{%- elif message.role == "assistant" -%}
-<|turn>model
-{{ message.content }}<turn|>
-{%- endif -%}
-{%- endfor -%}
-{%- if add_generation_prompt -%}
-<|turn>model
-{%- endif -%}`;
+// The turn markers and their trailing newlines are emitted as Jinja string
+// literals containing the two-character escape sequence `\n` (backslash + n),
+// which Jinja's string parser interprets as a newline at render time. We
+// CANNOT use literal template newlines here because Jinja's `{%- -%}` whitespace
+// stripping would eat them, producing "<|turn>systemYou are..." with no
+// separator. The JS source therefore uses `\\n` (which becomes `\n` —
+// backslash + n — at runtime via JS string escaping), matching how the
+// canonical embedded template emits them (e.g. `{{- '<|turn>system\n' -}}`).
+const GEMMA4_CHAT_TEMPLATE = [
+  '{{- bos_token -}}',
+  '{%- for message in messages -%}',
+  '  {%- if message.role == "system" -%}',
+  '    {{- "<|turn>system\\n" -}}{{ message.content }}{{- "<turn|>\\n" -}}',
+  '  {%- elif message.role == "user" -%}',
+  '    {{- "<|turn>user\\n" -}}{{ message.content }}{{- "<turn|>\\n" -}}',
+  '  {%- elif message.role == "assistant" -%}',
+  '    {{- "<|turn>model\\n" -}}{{ message.content }}{{- "<turn|>\\n" -}}',
+  '  {%- endif -%}',
+  '{%- endfor -%}',
+  '{%- if add_generation_prompt -%}',
+  '  {{- "<|turn>model\\n" -}}',
+  '{%- endif -%}',
+].join('\n');
 
 /**
  * Detect whether a model id refers to a Gemma 4 variant whose embedded chat

--- a/web_ui/src/lib/rag/rag-orchestrator.test.ts
+++ b/web_ui/src/lib/rag/rag-orchestrator.test.ts
@@ -98,7 +98,7 @@ vi.mock('../../hooks/useServiceInitialization', () => ({
 }));
 
 // Import types and class AFTER mocks are set up
-import { RAGOrchestrator } from './rag-orchestrator';
+import { RAGOrchestrator, capHistoryBudget } from './rag-orchestrator';
 
 // Re-export RAGEvent type for use in tests
 export type { RAGEvent } from './rag-orchestrator';
@@ -879,6 +879,46 @@ describe('RAGOrchestrator', () => {
     expect(capturedMessages[0].content).toBe(customPrompt);
   });
 
+  // PRR48-006: pin the DEFAULT_SYSTEM_PROMPT's key instructions so a regression
+  // that drops the grounding/citation/formatting rules would fail this test.
+  // Non-brittle: asserts key substrings, not the exact string.
+  test('Default system prompt contains grounding, citation, and formatting instructions', async () => {
+    const question = 'default prompt test';
+    const mockEmbedding = createMockEmbedding();
+    const chunks = [{ docId: 'd1', chunkIndex: 0, score: 0.9, text: 'c' }];
+
+    mockEmbeddingService.encodeWithMetadata.mockResolvedValue({
+      vector: mockEmbedding,
+      text: question,
+      dimensions: 768,
+    });
+    mockVectorIndex.search.mockResolvedValue(chunks);
+    mockKeywordIndex.search.mockReturnValue([]);
+    (rrfFuse as ReturnType<typeof vi.fn>).mockReturnValue(chunks);
+
+    let capturedMessages: LLMMessage[] = [];
+    mockWebLLMService.generateComplete = vi.fn().mockImplementation(async (messages: LLMMessage[]) => {
+      capturedMessages = messages;
+      return 'answer';
+    });
+
+    const orchestrator = new RAGOrchestrator();
+    // No custom systemPrompt → uses DEFAULT_SYSTEM_PROMPT
+    for await (const _event of orchestrator.query(question, { streamTokens: false, rerank: false })) {
+      // consume
+    }
+
+    expect(capturedMessages[0].role).toBe('system');
+    const prompt = String(capturedMessages[0].content);
+    // Grounding: must instruct faithful use of context + citation format
+    expect(prompt).toMatch(/\[1\]/); // citation notation — escaped brackets, not char class
+    expect(prompt.toLowerCase()).toMatch(/cite|citation/);
+    // Formatting: must instruct markdown structure (counteracts Gemma 4's
+    // tendency toward terse lowercase output)
+    expect(prompt.toLowerCase()).toMatch(/markdown|format/);
+    expect(prompt).toMatch(/bold|\*\*/); // bold instruction
+  });
+
   // ========================================================================
   // TEST: Graceful handling when indexes are not ready
   // ========================================================================
@@ -1576,15 +1616,22 @@ describe('RAGOrchestrator', () => {
 
     test('RC1 budget: history is charged to reservedTokens (fewer chunks fit when history is present)', async () => {
       // Two large chunks that would both fit without history. With a long history
-      // consuming budget, the second chunk should be dropped to fit.
+      // consuming budget (capped at MAX_HISTORY_BUDGET_TOKENS=2048 → 8192 chars via
+      // capHistoryBudget, which drops oldest WHOLE turns), the second chunk should
+      // be dropped to fit. The JOINED history is 40000 chars; capHistoryBudget
+      // keeps only the most recent turn (20000 chars) since dropping it would
+      // leave zero context. That surviving turn still consumes enough budget to
+      // force at least one chunk drop (PRR48-004).
       const question = 'follow up';
       const longHistory = [
         { role: 'user' as const, content: 'X'.repeat(20000) },
         { role: 'assistant' as const, content: 'Y'.repeat(20000) },
       ];
+      // To force trimming with the cap, use larger chunks that won't both fit
+      // even with the capped history budget.
+      const chunkA: SearchResult = { docId: 'a', chunkIndex: 0, score: 0.9, text: 'A'.repeat(10000) };
+      const chunkB: SearchResult = { docId: 'b', chunkIndex: 0, score: 0.8, text: 'B'.repeat(10000) };
       const mockEmbedding = createMockEmbedding();
-      const chunkA: SearchResult = { docId: 'a', chunkIndex: 0, score: 0.9, text: 'A'.repeat(5000) };
-      const chunkB: SearchResult = { docId: 'b', chunkIndex: 0, score: 0.8, text: 'B'.repeat(5000) };
       const chunks = [chunkA, chunkB];
 
       mockEmbeddingService.encodeWithMetadata.mockResolvedValue({
@@ -1610,9 +1657,10 @@ describe('RAGOrchestrator', () => {
       }
 
       const complete = events.find((e) => e.type === 'complete');
-      // With ~40000 chars of history reserved, the context budget shrinks so at
-      // least one of the two 5000-char chunks is dropped (contextTrimmed >= 1).
-      // This proves the history term is in reservedTokens.
+      // With the capped history budget (~2048 tokens reserved after PRR48-004),
+      // the context budget shrinks enough that at least one of the two 10000-char
+      // chunks is dropped (contextTrimmed >= 1). This proves the history term is
+      // in reservedTokens even after the cap is applied.
       expect(complete.data.contextTrimmed).toBeGreaterThanOrEqual(1);
     });
 
@@ -1763,5 +1811,91 @@ describe('RAGOrchestrator', () => {
       // The embedder input is BGE_QUERY_INSTRUCTION + the raw question (no prepend).
       expect(embedCall[0]).toBe('Represent this sentence for searching relevant passages: ' + question);
     });
+  });
+});
+
+// ============================================================================
+// PRR48-004: capHistoryBudget unit tests (direct, so the cap can't be removed
+// without failing a test — the orchestrator-level RC1 budget test is vacuous
+// w.r.t. the cap because both capped and uncapped paths drop the same chunks).
+// ============================================================================
+describe('capHistoryBudget (PRR48-004)', () => {
+  test('returns history unchanged when under the cap', () => {
+    const history = [
+      { role: 'user' as const, content: 'short' },
+      { role: 'assistant' as const, content: 'reply' },
+    ];
+    expect(capHistoryBudget(history, 100)).toEqual(history);
+  });
+
+  test('drops oldest whole turns until the joined text fits (with user-first re-anchor)', () => {
+    const history = [
+      { role: 'user' as const, content: 'X'.repeat(50) },
+      { role: 'assistant' as const, content: 'Y'.repeat(50) },
+      { role: 'user' as const, content: 'Z'.repeat(10) },
+    ];
+    // joined = 50+1+50+1+10 = 112 chars; cap at 70 → drop oldest turn (user X50).
+    // Remaining: asst Y50 + user Z10 = 61 chars ≤ 70, BUT assistant-first →
+    // re-anchor drops the leading asst Y50 too → only [user Z10] survives.
+    const result = capHistoryBudget(history, 70);
+    expect(result).toHaveLength(1);
+    expect(result[0].role).toBe('user');
+    expect(result[0].content).toBe('Z'.repeat(10));
+  });
+
+  test('preserves a user-first multi-turn window when it already fits after the drop', () => {
+    const history = [
+      { role: 'user' as const, content: 'X'.repeat(60) },   // large — dropped
+      { role: 'assistant' as const, content: 'Y'.repeat(10) },
+      { role: 'user' as const, content: 'Z'.repeat(10) },
+      { role: 'assistant' as const, content: 'W'.repeat(10) },
+    ];
+    // joined = 60+1+10+1+10+1+10 = 93; cap at 50 → drop X(60). Remaining:
+    // Y10+Z10+W10 = 32 chars, user-first (Y is asst → wait, Y is first and it's
+    // assistant). Re-anchor drops Y. Remaining: Z10+W10 = 21 chars, user-first. ✓
+    const result = capHistoryBudget(history, 50);
+    expect(result[0].role).toBe('user');
+    expect(result).toHaveLength(2);
+    expect(result[0].content).toBe('Z'.repeat(10));
+    expect(result[1].content).toBe('W'.repeat(10));
+  });
+
+  test('re-anchors to user-first when the drop leaves an assistant-first window', () => {
+    const history = [
+      { role: 'user' as const, content: 'X'.repeat(100) },   // large — dropped first
+      { role: 'assistant' as const, content: 'Y'.repeat(10) }, // would be first after drop
+      { role: 'user' as const, content: 'Z'.repeat(10) },
+    ];
+    const result = capHistoryBudget(history, 50);
+    // Drop X(100): remaining = Y(10)+Z(10) = 21 chars. But Y is assistant-first → drop Y too.
+    expect(result[0].role).toBe('user');
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toBe('Z'.repeat(10));
+  });
+
+  test('tail-truncates a single over-cap surviving turn (user-pasted-document case)', () => {
+    const history = [
+      { role: 'user' as const, content: 'A'.repeat(200) },
+    ];
+    const result = capHistoryBudget(history, 50);
+    expect(result).toHaveLength(1);
+    expect(result[0].content.length).toBe(50);
+    // Tail slice — keeps the most recent content (last 50 'A' chars)
+    expect(result[0].content).toBe('A'.repeat(50));
+  });
+
+  test('keeps at least one turn even if all turns exceed the cap individually', () => {
+    const history = [
+      { role: 'user' as const, content: 'X'.repeat(200) },
+      { role: 'assistant' as const, content: 'Y'.repeat(200) },
+    ];
+    const result = capHistoryBudget(history, 50);
+    // Drops oldest until 1 turn left, then tail-truncates that turn to 50.
+    expect(result).toHaveLength(1);
+    expect(result[0].content.length).toBe(50);
+  });
+
+  test('empty history returns empty', () => {
+    expect(capHistoryBudget([], 100)).toEqual([]);
   });
 });

--- a/web_ui/src/lib/rag/rag-orchestrator.ts
+++ b/web_ui/src/lib/rag/rag-orchestrator.ts
@@ -131,8 +131,8 @@ type RAGStage = 'embedding' | 'vector_search' | 'keyword_search' | 'rrf_fusion' 
  * Default system prompt. Instructs the model on RAG grounding, citation
  * format, AND output structure (markdown formatting, capitalization,
  * paragraphing) so answers render with ChatGPT/Claude-level polish in the
- * markdown renderer. Kept under ~150 tokens so it consumes minimal context
- * budget while still enforcing quality.
+ * markdown renderer. ~280 tokens (1120 chars) — non-trivial but bounded by
+ * MAX_HISTORY_BUDGET_TOKENS so it can't collapse the chunk budget.
  *
  * Gemma 4 E2B-it has a known tendency toward lowercase sentence starts and
  * terse unstructured output; the formatting instructions counteract that.
@@ -213,6 +213,17 @@ const DEGRADED_VECTOR_COSINE_FLOOR = 0.4;
  */
 const CHARS_PER_TOKEN = 4;
 const TOKEN_SAFETY_MARGIN = 96;
+/**
+ * Hard cap on the token budget consumed by conversation history. Without this,
+ * 6 turns of long answers (up to 1536 tokens each on the quality preset) could
+ * saturate the 8192-token context window, collapsing the retrieved-chunk
+ * budget to near-zero (swarm-pr-review run-48 PRR48-004). Capping history at
+ * 2048 tokens (~25% of n_ctx) bounds the worst case while preserving enough
+ * multi-turn context for follow-up questions. The cap is applied to the JOINED
+ * history text BEFORE the budget reservation, so only the most recent ~2048
+ * tokens of history are charged.
+ */
+const MAX_HISTORY_BUDGET_TOKENS = 2048;
 
 /**
  * RAG Orchestrator - Coordinates embedding search, keyword search, RRF fusion,
@@ -268,7 +279,11 @@ export class RAGOrchestrator {
     const presencePenalty = options.presencePenalty;
     // Issue #40 RC1: prior conversation turns. Threaded into the LLM prompt
     // (buildMessages) and used to contextualize the retrieval query (RC3).
-    const history = options.history ?? [];
+    // PRR48-004: cap the history token budget by dropping oldest whole turns
+    // until the joined text fits MAX_HISTORY_BUDGET_TOKENS. This bounds BOTH
+    // the budget reservation AND the actual prompt sent to the model (the
+    // prior fix only capped the estimate, leaving the messages unbounded).
+    const history = capHistoryBudget(options.history ?? [], MAX_HISTORY_BUDGET_TOKENS * CHARS_PER_TOKEN);
     const signal = options.signal;
 
     // Ensure lazy services are initialized before the pipeline runs (FR-002)
@@ -489,8 +504,9 @@ export class RAGOrchestrator {
     //
     // Issue #40 RC1: history is also in the prompt (threaded by buildMessages),
     // so charge it to reservedTokens here. Without this term, history + context
-    // could silently overflow DEFAULT_N_CTX. The caller caps history length; the
-    // safety margin covers chat-template control tokens.
+    // could silently overflow DEFAULT_N_CTX. The history array is already
+    // token-capped (capHistoryBudget at line ~282 per PRR48-004), so the
+    // joined text here is bounded.
     const historyText = history.map((t) => t.content).join('\n');
     const reservedTokens =
       estimateTokens(systemPrompt, CHARS_PER_TOKEN) +
@@ -704,6 +720,43 @@ export class RAGOrchestrator {
  */
 function estimateTokens(text: string, charsPerToken: number): number {
   return Math.ceil((text?.length ?? 0) / charsPerToken);
+}
+
+/**
+ * PRR48-004: bound the conversation-history token budget by dropping oldest
+ * whole turns until the joined text fits `maxChars`. Dropping whole turns
+ * (rather than slicing mid-content) preserves the user/assistant alternation
+ * the chat template expects and keeps each turn's content intact. After the
+ * drop loop: (a) if the surviving window starts with an assistant turn, drop
+ * it too (mirrors history-snapshot's re-anchor — the chat template's
+ * user/model alternation expects a user-first history); (b) if a single
+ * surviving turn still exceeds maxChars (e.g. user pasted a huge document),
+ * tail-truncate it to maxChars so even the degenerate case can't saturate n_ctx.
+ */
+export function capHistoryBudget(history: RAGHistoryTurn[], maxChars: number): RAGHistoryTurn[] {
+  if (history.length === 0) return history;
+  const joinedLen = history.map((t) => t.content).join('\n').length;
+  if (joinedLen <= maxChars) return history;
+  // Drop oldest turns until the remaining text fits. Always keep at least 1 turn.
+  let kept = history.slice();
+  while (kept.length > 1) {
+    const len = kept.map((t) => t.content).join('\n').length;
+    if (len <= maxChars) break;
+    kept = kept.slice(1);
+  }
+  // PRR48-004 critic fix 1: re-anchor to user-first (mirrors history-snapshot).
+  // The drop loop can leave an assistant-first window when an early user turn
+  // is the largest and gets dropped first.
+  while (kept.length > 1 && kept[0].role === 'assistant') {
+    kept = kept.slice(1);
+  }
+  // PRR48-004 critic fix 3: tail-truncate a single over-cap surviving turn
+  // (e.g. user pasted a 50K-char document). Tail slice keeps the most recent
+  // content, which is the most relevant for follow-up contextualization.
+  if (kept.length === 1 && kept[0].content.length > maxChars) {
+    kept = [{ ...kept[0], content: kept[0].content.slice(-maxChars) }];
+  }
+  return kept;
 }
 
 /**

--- a/web_ui/src/lib/rag/rag-orchestrator.ts
+++ b/web_ui/src/lib/rag/rag-orchestrator.ts
@@ -128,12 +128,36 @@ export type RAGEvent =
 type RAGStage = 'embedding' | 'vector_search' | 'keyword_search' | 'rrf_fusion' | 'reranking' | 'context' | 'generation';
 
 /**
- * Default system prompt. Issue #40 RC1/RC2: enriched beyond the bare citation
- * instruction to (a) acknowledge the conversation history so the model treats
- * follow-ups as continuing turns, and (b) reinforce anti-repetition. Kept short
- * so it consumes minimal context budget.
+ * Default system prompt. Instructs the model on RAG grounding, citation
+ * format, AND output structure (markdown formatting, capitalization,
+ * paragraphing) so answers render with ChatGPT/Claude-level polish in the
+ * markdown renderer. Kept under ~150 tokens so it consumes minimal context
+ * budget while still enforcing quality.
+ *
+ * Gemma 4 E2B-it has a known tendency toward lowercase sentence starts and
+ * terse unstructured output; the formatting instructions counteract that.
  */
-const DEFAULT_SYSTEM_PROMPT = 'You are a helpful assistant answering questions about uploaded documents. Use the provided context to answer, and cite sources using [1], [2] notation. The conversation history may provide context for follow-up questions. If the context doesn\'t contain enough information, say so. Do not repeat yourself.';
+const DEFAULT_SYSTEM_PROMPT = `You are a knowledgeable assistant answering questions about uploaded documents. Follow these rules carefully:
+
+GROUNDING
+- Answer using ONLY the provided Context. Quote or paraphrase faithfully.
+- Cite sources inline using [1], [2], [3] notation matching the context numbering.
+- If the context does not contain enough information, say so explicitly — never invent facts.
+- Use the conversation history to clarify follow-up questions.
+
+FORMATTING (important)
+- Always start sentences with a capital letter and end with proper punctuation.
+- Use Markdown to structure your answer:
+  - Use short paragraphs separated by blank lines for readability.
+  - Use **bold** for key terms, field names, and emphasis.
+  - Use bullet lists (-) or numbered lists (1.) for steps, options, or enumerations.
+  - Use ## headings to separate major sections of a long answer.
+- Be thorough and detailed — give complete explanations, not one-line answers.
+- When listing steps or procedures, number them in order.
+- When comparing options, use a structured list or table.
+
+TONE
+- Professional, clear, direct. Write as a helpful expert would.`;
 
 /**
  * Retrieval query instruction. Issue #37 R9: the value is UNCHANGED from the

--- a/web_ui/src/lib/rag/rag-presets.test.ts
+++ b/web_ui/src/lib/rag/rag-presets.test.ts
@@ -23,10 +23,13 @@ describe('rag-presets', () => {
     expect(presetOptions('quality')).toEqual(RAG_PRESETS.quality);
   });
 
-  // Issue #40 RC2: every preset sets anti-repetition penalties + a sane topP.
-  it('all presets set repeatPenalty 1.1, topP 0.9, and zero freq/presence penalty', () => {
+  // Issue #40 RC2 + chat-quality tuning: every preset sets a mild anti-
+  // repetition penalty (1.05 — gentler than the original 1.1, which over-
+  // suppressed natural phrasing and contributed to terse output), topP 0.9,
+  // and zero freq/presence penalty.
+  it('all presets set repeatPenalty 1.05, topP 0.9, and zero freq/presence penalty', () => {
     for (const preset of ['fast', 'balanced', 'quality'] as const) {
-      expect(RAG_PRESETS[preset].repeatPenalty).toBe(1.1);
+      expect(RAG_PRESETS[preset].repeatPenalty).toBe(1.05);
       expect(RAG_PRESETS[preset].topP).toBe(0.9);
       expect(RAG_PRESETS[preset].frequencyPenalty).toBe(0.0);
       expect(RAG_PRESETS[preset].presencePenalty).toBe(0.0);
@@ -35,7 +38,7 @@ describe('rag-presets', () => {
 
   it('presetOptions surfaces the penalty + topP fields (forwarded into RAGQueryOptions)', () => {
     const opts = presetOptions('balanced');
-    expect(opts).toHaveProperty('repeatPenalty', 1.1);
+    expect(opts).toHaveProperty('repeatPenalty', 1.05);
     expect(opts).toHaveProperty('topP', 0.9);
     expect(opts).toHaveProperty('frequencyPenalty', 0.0);
     expect(opts).toHaveProperty('presencePenalty', 0.0);

--- a/web_ui/src/lib/rag/rag-presets.ts
+++ b/web_ui/src/lib/rag/rag-presets.ts
@@ -19,12 +19,12 @@ export const RAG_PRESETS: Record<
 > = {
   // fast: no rerank → over-fetching wastes work. candidateMultiplier 1 keeps
   // both legs at topK.
-  fast: { topK: 5, candidateMultiplier: 1, rerank: false, maxTokens: 384, temperature: 0.3, topP: 0.9, repeatPenalty: 1.1, frequencyPenalty: 0.0, presencePenalty: 0.0 },
+  fast: { topK: 5, candidateMultiplier: 1, rerank: false, maxTokens: 512, temperature: 0.4, topP: 0.9, repeatPenalty: 1.05, frequencyPenalty: 0.0, presencePenalty: 0.0 },
   // balanced: retrieve 3×topK per leg (30 candidates), rerank down to topK=10.
-  balanced: { topK: 10, candidateMultiplier: 3, rerank: true, maxTokens: 512, temperature: 0.3, topP: 0.9, repeatPenalty: 1.1, frequencyPenalty: 0.0, presencePenalty: 0.0 },
+  balanced: { topK: 10, candidateMultiplier: 3, rerank: true, maxTokens: 1024, temperature: 0.4, topP: 0.9, repeatPenalty: 1.05, frequencyPenalty: 0.0, presencePenalty: 0.0 },
   // quality: retrieve 4×topK per leg (64 candidates), rerank down to topK=16.
   // The reranker caps scoring at RERANK_INPUT_CAP=50 to bound per-query cost.
-  quality: { topK: 16, candidateMultiplier: 4, rerank: true, maxTokens: 1024, temperature: 0.2, topP: 0.9, repeatPenalty: 1.1, frequencyPenalty: 0.0, presencePenalty: 0.0 },
+  quality: { topK: 16, candidateMultiplier: 4, rerank: true, maxTokens: 1536, temperature: 0.3, topP: 0.9, repeatPenalty: 1.05, frequencyPenalty: 0.0, presencePenalty: 0.0 },
 };
 
 /** Human-readable description for the settings UI. */


### PR DESCRIPTION
## Summary

This PR contains 4 commits addressing Gemma 4 quality: (1) QAT weights swap, (2) canonical chat template rewrite (BOS + system turn), (3) answer quality + formatting (system prompt + sampling + markdown rendering), (4) swarm-pr-review run-48 feedback closure.

### Commit `2b6af91` — swarm-pr-review feedback closure

Closes findings from the run-48 swarm-pr-review. The headline fix is **PRR48-001/002 (CRITICAL)**: the canonical Gemma 4 chat-template rewrite claimed by commit `ccc97be` was never actually written — the committed code kept the old system-folding template while removing the `system_prefix` kwarg threading it relied on, silently dropping the system prompt on every Gemma 4 generation. This commit writes the actual canonical template.

### Closure ledger

| ID | Severity | Finding | Outcome |
|----|----------|---------|---------|
| **PRR48-001/002** | CRITICAL | Canonical template rewrite missing; system prompt silently dropped | **FIXED** — wrote the canonical template (`bos_token` + `<|turn>system/user/model` + `<turn|>` with Jinja string-literal newlines); validated offline with Python Jinja2 |
| **PRR48-003** | HIGH | Tests pinned the broken template (asserted `system_prefix`) | **FIXED** — tests now assert canonical markers + regression guard (`not.objectContaining(system_prefix)`) |
| **PRR48-004** | MEDIUM | Context budget collapse under history (quality preset) | **FIXED** — `capHistoryBudget()` drops oldest whole turns (with user-first re-anchor + single-turn tail-truncation); applied to actual history array, not just the estimate; 7 unit tests |
| **PRR48-005** | NEEDS_EVIDENCE | repeatPenalty 1.1→1.05 may regress anti-repetition | **DEFERRED** — needs A/B runtime measurement; 1.05 is a reasonable value for a 2.3B model, documented |
| **PRR48-006** | MEDIUM | No test pins DEFAULT_SYSTEM_PROMPT content | **FIXED** — new test asserts citation notation, markdown/format instructions, bold (non-brittle regex/substring) |
| **PRR48-007** | MEDIUM | JSDoc budget lie ("~150 tokens") | **FIXED** — updated to "~280 tokens (1120 chars)" |
| **PRR48-009** | MEDIUM | Balanced preset budget shrinkage | **COVERED** by PRR48-004 fix (history cap) |
| **PRR48-010** | MEDIUM | Stale doc comments (system-folding narrative) | **FIXED** — history-snapshot.ts + wllama-service.ts comments updated |
| **PRR48-012** | MEDIUM | Citation tokens attacker-controllable | **DEFERRED** — pre-existing RAG design property, not introduced by this PR |
| **PRR48-013** | MEDIUM | model-readiness budget comment inaccurate | **FIXED** — budget raised 4GB→5GB (above peak) + comment corrected |
| **PRR48-014** | MEDIUM | PR title uses `chore` for runtime changes | **FIXED** — retitled to `fix(web_ui)` |
| **PRR48-018** | MEDIUM | MarkdownRenderer style changes untested | **PARTIALLY FIXED** — added fontWeight/fontStyle assertions for strong/em; ChatMessageBubble padding half deferred (low-value inline-style pinning) |

### Gates passed

- **Reviewer (Kimi K2.7)**: APPROVE after 2 iterations. Iteration 1 flagged a vacuous citation regex (`/[1]/` char class) and an unbounded history issue (cap only on estimate, not messages); both fixed.
- **Final critic (Kimi K3)**: APPROVE after resolving 3 challenges: (1) assistant-first window from the drop loop → added re-anchor; (2) vacuous RC1 budget test → added 7 direct capHistoryBudget unit tests; (3) unbounded single turn → added tail-truncation.

## Invariant audit

| Invariant | Evidence |
|---|---|
| Canonical template verified | Python Jinja2 render produces `<bos><|turn>system\n{content}<turn|>\n<|turn>user\n...` matching the GGUF's embedded structure |
| System prompt reaches model | Template has a dedicated `<|turn>system` branch (not a no-op comment); buildChatArgs passes system message through unchanged |
| History budget bounded | `capHistoryBudget` drops oldest whole turns until ≤2048 tokens; re-anchors user-first; tail-truncates single over-cap turn |
| Memory budget conservative | 5 GB ≥ 4.7 GB peak; 8 GB target box passes comfortably |
| tsc clean | `npx tsc --noEmit` (src + test) → EXIT 0 |
| Tests pass | `npx vitest run` → 1186 pass, 2 skipped, 0 fail |

## Test plan

```bash
cd web_ui
npx tsc --noEmit                          # EXIT 0
npx tsc --noEmit -p tsconfig.test.json    # EXIT 0
npx vitest run                            # 1186 pass, 0 fail
```

### New tests added by the feedback closure
- 7 `capHistoryBudget` unit tests (PRR48-004) — covers under-cap, oldest-turn drop, user-first re-anchor, single-over-cap tail-truncation, all-over-cap edge case, empty history
- 1 `DEFAULT_SYSTEM_PROMPT` content test (PRR48-006) — asserts citation notation, markdown/format instructions
- 2 MarkdownRenderer style assertions (PRR48-018) — fontWeight 600 for strong, fontStyle italic for em
- Updated wllama-service.test.ts canonical-marker assertions (PRR48-003) — 6 marker checks + 1 regression guard

## Files

- `web_ui/src/lib/llm/wllama-service.ts` — canonical GEMMA4_CHAT_TEMPLATE rewrite (PRR48-001/002) + doc comment (PRR48-010)
- `web_ui/src/lib/llm/wllama-service.test.ts` — canonical marker assertions + system_prefix regression guard (PRR48-003)
- `web_ui/src/lib/rag/rag-orchestrator.ts` — `capHistoryBudget` helper + `MAX_HISTORY_BUDGET_TOKENS` (PRR48-004) + JSDoc fix (PRR48-007)
- `web_ui/src/lib/rag/rag-orchestrator.test.ts` — 7 capHistoryBudget tests + DEFAULT_SYSTEM_PROMPT test + RC1 budget test update (PRR48-004/006)
- `web_ui/src/lib/llm/model-readiness.ts` + `.test.ts` — 5 GB budget + comment fix (PRR48-013)
- `web_ui/src/lib/chat/history-snapshot.ts` — stale comment update (PRR48-010)
- `web_ui/src/components/MarkdownRenderer.test.tsx` — fontWeight/fontStyle assertions (PRR48-018)
