### PR TITLE
fix(ws-a): realistic RAM gate, fast-profile fallback, real load diagnostics, raised thread defaults (issue #53)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,4 +25,4 @@ repos:
     hooks:
       - id: flake8
         args: ['--max-line-length=100', '--extend-ignore=E203,W503',
-               '--per-file-ignores=tests/test_low_end_hardware.py:F401,F811,F841,E501,F541 tests/test_rag_pipeline_edge_cases.py:F401,F811,F841 tests/test_vector_store.py:F401,F841,E501 tests/test_rag_performance.py:F401,F841']
+               '--per-file-ignores=tests/test_low_end_hardware.py:F401,F811,F841,E501,F541 tests/test_rag_pipeline_edge_cases.py:F401,F811,F841 tests/test_vector_store.py:F401,F841,E501 tests/test_rag_performance.py:F401,F841 tests/test_full_council_adversarial.py:F401,F841,E501,E302,E712']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,4 +25,4 @@ repos:
     hooks:
       - id: flake8
         args: ['--max-line-length=100', '--extend-ignore=E203,W503',
-               '--per-file-ignores=tests/test_low_end_hardware.py:F401,F811,F841,E501,F541 tests/test_rag_pipeline_edge_cases.py:F401,F811,F841 tests/test_vector_store.py:F401,F841,E501 tests/test_rag_performance.py:F401,F841 tests/test_full_council_adversarial.py:F401,F841,E501,E302,E712']
+               '--per-file-ignores=tests/test_low_end_hardware.py:F401,F811,F841,E501,F541 tests/test_rag_pipeline_edge_cases.py:F401,F811,F841 tests/test_vector_store.py:F401,F841,E501 tests/test_rag_performance.py:F401,F841 tests/test_full_council_adversarial.py:F401,F841,E501,E302,E712 tests/test_app_gui_message_queue_validation.py:F401 tests/test_app_gui_streaming_callback.py:E501 tests/test_app_gui_streaming_logging_fix.py:E402,F541,E501 tests/test_keyboard_shortcuts_styling.py:F401']

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -47,6 +47,7 @@ Set environment variables before running the application or in your system's env
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
 | `RAG_GGUF_PATH` | Path to GGUF model file | Bundled Gemma 4 E2B | No |
+| `RAG_FAST_PROFILE_PATH` | Optional smaller fallback GGUF loaded when the primary model fails the RAM gate | None (fallback disabled) | No |
 
 ### Performance Variables
 
@@ -269,9 +270,18 @@ Only GGUF models are supported through the GUI Settings dialog. The application 
 
 **Parameters**:
 ```
-n_ctx=8192        # Context window size
-n_threads=4       # CPU threads
+n_ctx=4096                       # Context window size
+n_threads=min(os.cpu_count(), 8) # CPU threads (default: all CPUs, capped at 8)
 ```
+
+**Model Load RAM Gate**:
+Before loading a GGUF model the app estimates the free RAM requirement as
+`model file size + ~1 GB KV cache + ~1 GB runtime overhead` (about 5-6 GB for
+the bundled ~3.1 GB Gemma 4 E2B model). If the estimate exceeds available
+RAM the load is refused with a diagnostic naming the model, the required and
+available memory. When `RAG_FAST_PROFILE_PATH` points to a smaller GGUF, that
+fast-profile model is loaded instead; without it the diagnostic is surfaced
+through the GUI error message and the API 503 `detail`.
 
 **Model Selection**:
 - Gemma 4 2B (2GB, recommended - bundled)

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -270,8 +270,8 @@ Only GGUF models are supported through the GUI Settings dialog. The application 
 
 **Parameters**:
 ```
-n_ctx=4096                       # Context window size
-n_threads=min(os.cpu_count(), 8) # CPU threads (default: all CPUs, capped at 8)
+n_ctx=4096                            # Context window size
+n_threads=min(os.cpu_count() or 4, 8) # CPU threads (all CPUs up to 8; 4 if cpu_count unavailable)
 ```
 
 **Model Load RAM Gate**:
@@ -279,9 +279,12 @@ Before loading a GGUF model the app estimates the free RAM requirement as
 `model file size + ~1 GB KV cache + ~1 GB runtime overhead` (about 5-6 GB for
 the bundled ~3.1 GB Gemma 4 E2B model). If the estimate exceeds available
 RAM the load is refused with a diagnostic naming the model, the required and
-available memory. When `RAG_FAST_PROFILE_PATH` points to a smaller GGUF, that
-fast-profile model is loaded instead; without it the diagnostic is surfaced
-through the GUI error message and the API 503 `detail`.
+available memory. The `RAG_FAST_PROFILE_PATH` fallback fires only when the
+primary model is refused by this RAM gate AND the fast-profile file exists
+on disk — not for corrupt files, a missing `llama-cpp` install, a missing
+primary path, or a fast profile that itself fails to load (those surface the
+diagnostic directly) — through the GUI error message and the API 503
+`detail`.
 
 **Model Selection**:
 - Gemma 4 2B (2GB, recommended - bundled)

--- a/api_server.py
+++ b/api_server.py
@@ -390,6 +390,7 @@ async def lifespan(app: FastAPI):
             context_truncation=settings.rag_context_truncation,
             gguf_n_ctx=settings.rag_gguf_n_ctx,
             gguf_n_threads=settings.rag_gguf_n_threads,
+            fast_profile_path=settings.rag_fast_profile_path,
         )
 
         engine = RAGEngine(
@@ -546,7 +547,13 @@ async def ask_question(request: QuestionRequest, auth: dict = Security(require_a
         raise HTTPException(status_code=503, detail="Engine not initialized")
 
     if not engine.llm:
-        raise HTTPException(status_code=503, detail="No LLM backend available")
+        # Surface the recorded load diagnostic (RAM numbers, model name) so
+        # clients see WHY no LLM is available instead of a bare generic string.
+        raise HTTPException(
+            status_code=503,
+            detail=getattr(engine, "llm_init_error", None)
+            or "No LLM backend available",
+        )
 
     try:
         # Issue #37 R6: thread conversation_history through to the engine.
@@ -719,7 +726,11 @@ if HAS_SSE:
             raise HTTPException(status_code=503, detail="Engine not initialized")
 
         if not engine.llm:
-            raise HTTPException(status_code=503, detail="No LLM backend available")
+            raise HTTPException(
+                status_code=503,
+                detail=getattr(engine, "llm_init_error", None)
+                or "No LLM backend available",
+            )
 
         async def event_generator():
             queue: asyncio.Queue = asyncio.Queue()

--- a/app_gui.py
+++ b/app_gui.py
@@ -847,6 +847,12 @@ class DocumentQAApp(CTk):
             "min_similarity": 0.3,
             "context_truncation": 20000,
         }
+        # Issue #53: honor RAG_FAST_PROFILE_PATH on the desktop entry point so
+        # the fast-profile fallback advised in load errors is actionable here
+        # too (engine_factory.create_engine_from_settings reads this key).
+        env_fast_profile = os.environ.get("RAG_FAST_PROFILE_PATH")
+        if env_fast_profile:
+            default_settings["fast_profile_path"] = env_fast_profile
 
         try:
             if os.path.exists(settings_path):
@@ -3020,12 +3026,17 @@ class DocumentQAApp(CTk):
                 # Initialize LLM in background thread to avoid freezing GUI
                 self.engine._ensure_llm()
                 if not self.engine.llm:
-                    # Queue error to run on main thread
+                    # Surface the real load diagnostic through the classifier
+                    # instead of a hardcoded "Check Settings" misdirection.
+                    err = RuntimeError(
+                        getattr(self.engine, "llm_init_error", None)
+                        or "LLM not initialized."
+                    )
                     self.message_queue.put(
                         (
                             "message",
                             "system",
-                            "No LLM backend available. Check Settings.",
+                            _classify_error(err, "query"),
                             None,
                             datetime.now().strftime("%H:%M"),
                         )

--- a/app_gui.py
+++ b/app_gui.py
@@ -3,27 +3,31 @@ Document Q&A Assistant - GUI Application
 A user-friendly interface for the RAG-based document question answering system.
 """
 
-import os
-import sys
 import json
 import logging
-import threading
+import os
 import queue
+import sys
+import threading
+from datetime import datetime
 from pathlib import Path
 from typing import Optional
-from datetime import datetime
 
 from engine_factory import create_engine_from_settings
 
 try:
     import customtkinter as ctk
-    from customtkinter import CTk, CTkFrame, CTkLabel, CTkButton, CTkEntry, CTkTextbox
     from customtkinter import (
+        CTk,
+        CTkButton,
+        CTkEntry,
+        CTkFrame,
+        CTkLabel,
         CTkProgressBar,
-        CTkOptionMenu,
         CTkScrollableFrame,
-        CTkToplevel,
         CTkSwitch,
+        CTkTextbox,
+        CTkToplevel,
     )
 
     GUI_AVAILABLE = True
@@ -32,42 +36,78 @@ except ImportError:
     print("customtkinter not installed. Run: pip install customtkinter")
 
 try:
-    from tkinter import filedialog, messagebox
     import tkinter as tk
+    from tkinter import filedialog, messagebox
 except ImportError:
     pass
 
 import app_paths
-from config import MIN_CHUNK_SIZE, MAX_CHUNK_SIZE, DEFAULT_CHUNK_SIZE, MIN_MAX_TOKENS, MAX_MAX_TOKENS, DEFAULT_MAX_TOKENS
-from theme import ColorTokens, TypeScale, FONT_FAMILY, Spacing
+from config import (
+    DEFAULT_CHUNK_SIZE,
+    DEFAULT_MAX_TOKENS,
+    MAX_CHUNK_SIZE,
+    MAX_MAX_TOKENS,
+    MIN_CHUNK_SIZE,
+    MIN_MAX_TOKENS,
+    default_gguf_threads,
+)
+from theme import FONT_FAMILY, ColorTokens, Spacing, TypeScale
+
+# Dynamic default (all CPUs up to 8), evaluated at import so the presets below
+# always match the config default on the machine running the app.
+_DEFAULT_GGUF_THREADS = default_gguf_threads()
 
 # Canonical default values for UI presets (minimum-hardware safe)
 _PRESET_FAST = {
-    "chunk_size": 512, "chunk_overlap": 50, "n_results": 3,
+    "chunk_size": 512,
+    "chunk_overlap": 50,
+    "n_results": 3,
     "min_similarity": 0.35,
-    "max_tokens": 256, "temperature": 0.2, "hybrid_search": False,
-    "reranking_enabled": False, "retrieval_window": 1,
-    "initial_retrieval_top_k": 6, "rerank_top_k": 3,
-    "context_truncation": 10000, "query_transformation_enabled": False,
-    "gguf_n_ctx": 2048, "gguf_n_threads": 4,
+    "max_tokens": 256,
+    "temperature": 0.2,
+    "hybrid_search": False,
+    "reranking_enabled": False,
+    "retrieval_window": 1,
+    "initial_retrieval_top_k": 6,
+    "rerank_top_k": 3,
+    "context_truncation": 10000,
+    "query_transformation_enabled": False,
+    "gguf_n_ctx": 2048,
+    "gguf_n_threads": _DEFAULT_GGUF_THREADS,
 }
 _PRESET_BALANCED = {
-    "chunk_size": 512, "chunk_overlap": 100, "n_results": 4,
+    "chunk_size": 512,
+    "chunk_overlap": 100,
+    "n_results": 4,
     "min_similarity": 0.3,
-    "max_tokens": 512, "temperature": 0.3, "hybrid_search": True,
-    "reranking_enabled": False, "retrieval_window": 1,
-    "initial_retrieval_top_k": 12, "rerank_top_k": 4,
-    "context_truncation": 20000, "query_transformation_enabled": False,
-    "gguf_n_ctx": 4096, "gguf_n_threads": 4,
+    "max_tokens": 512,
+    "temperature": 0.3,
+    "hybrid_search": True,
+    "reranking_enabled": False,
+    "retrieval_window": 1,
+    "initial_retrieval_top_k": 12,
+    "rerank_top_k": 4,
+    "context_truncation": 20000,
+    "query_transformation_enabled": False,
+    "gguf_n_ctx": 4096,
+    "gguf_n_threads": _DEFAULT_GGUF_THREADS,
 }
 _PRESET_QUALITY = {
-    "chunk_size": 512, "chunk_overlap": 100, "n_results": 6,
+    "chunk_size": 512,
+    "chunk_overlap": 100,
+    "n_results": 6,
     "min_similarity": 0.25,
-    "max_tokens": 1024, "temperature": 0.3, "hybrid_search": True,
-    "reranking_enabled": True, "retrieval_window": 2,
-    "initial_retrieval_top_k": 20, "rerank_top_k": 6,
-    "context_truncation": 30000, "query_transformation_enabled": True,
-    "gguf_n_ctx": 4096, "gguf_n_threads": 8,
+    "max_tokens": 1024,
+    "temperature": 0.3,
+    "hybrid_search": True,
+    "reranking_enabled": True,
+    "retrieval_window": 2,
+    "initial_retrieval_top_k": 20,
+    "rerank_top_k": 6,
+    "context_truncation": 30000,
+    "query_transformation_enabled": True,
+    "gguf_n_ctx": 4096,
+    "gguf_n_threads": 8,
 }
 
 logger = logging.getLogger(__name__)
@@ -83,6 +123,7 @@ _LEGACY_KEY_MAP = {
     "model_path": "gguf_path",  # already handled, but include for completeness
 }
 
+
 def normalize_settings(settings: dict) -> dict:
     """Migrate legacy rag_*-prefixed keys to canonical equivalents.
 
@@ -97,8 +138,11 @@ def normalize_settings(settings: dict) -> dict:
                 del result[legacy]  # canonical present, drop legacy
     return result
 
+
 # FR-708: Minimum button height for WCAG 2.5.5 compliance
-DEFAULT_BUTTON_HEIGHT = 36  # 36px visual height meets 44px touch target with default CTkButton padding
+DEFAULT_BUTTON_HEIGHT = (
+    36  # 36px visual height meets 44px touch target with default CTkButton padding
+)
 
 # === CTkTooltip CLASS (add before SettingsDialog class) ===
 
@@ -239,6 +283,7 @@ def attach_field_tooltip(
         return None
     return CTkTooltip(parent=parent, widget=widget, text=hint)
 
+
 # === SOURCE PILL CONSTANTS ===
 _SOURCE_PILL_MAX_CHARS = 30
 _SOURCE_PILL_CORNER_RADIUS = 12
@@ -261,20 +306,32 @@ def _classify_error(err: Exception, operation: str) -> str:
     msg = str(err)
     if operation == "ingest":
         if isinstance(err, (ConnectionError, OSError)) and "connect" in msg.lower():
-            return "Could not load the model. Make sure the GGUF model path in Settings is correct and the file exists."
+            return "Could not load the model. Make sure the GGUF model path in Settings is correct and the file exists."  # noqa: E501
         if isinstance(err, FileNotFoundError):
             return f"File not found: {err}. Check the GGUF model path in Settings."
-        if "token" in msg.lower() and ("limit" in msg.lower() or "exceed" in msg.lower()):
-            return "Token limit exceeded. Try reducing Chunk Size or Results to Retrieve in Settings."
+        if "token" in msg.lower() and (
+            "limit" in msg.lower() or "exceed" in msg.lower()
+        ):
+            return "Token limit exceeded. Try reducing Chunk Size or Results to Retrieve in Settings."  # noqa: E501
         return f"Ingestion failed. Check the document directory and try again.\n\nError: {err}"
     else:  # query
         if isinstance(err, (ConnectionError, TimeoutError)):
-            return "Could not load the LLM. Make sure the GGUF model file exists and the path in Settings is correct."
+            return "Could not load the LLM. Make sure the GGUF model file exists and the path in Settings is correct."  # noqa: E501
+        if "Insufficient RAM" in msg:
+            # A backend IS configured; the machine refused the load. Relay the
+            # real numbers instead of the misdirecting "configure a backend".
+            return (
+                "Not enough free memory to load the model. "
+                + msg
+                + " Close other applications, or set RAG_FAST_PROFILE_PATH to a smaller model."
+            )
         if "timeout" in msg.lower():
             return "Request timed out. Try reducing Max Tokens in Settings."
-        if "token" in msg.lower() and ("limit" in msg.lower() or "exceed" in msg.lower()):
+        if "token" in msg.lower() and (
+            "limit" in msg.lower() or "exceed" in msg.lower()
+        ):
             return "Token limit exceeded. Try reducing Max Tokens in Settings."
-        return f"Query failed. Make sure at least one LLM backend is configured in Settings.\n\nError: {err}"
+        return f"Query failed. Make sure at least one LLM backend is configured in Settings.\n\nError: {err}"  # noqa: E501
 
 
 def get_resource_path(relative_path: str) -> str:
@@ -317,7 +374,9 @@ class SettingsDialog(CTkToplevel):
         CTkLabel(main_frame, text="GGUF Model Path:").pack(anchor="w")
         model_frame = CTkFrame(main_frame)
         model_frame.pack(fill="x", pady=(0, Spacing.LG))
-        self.model_path_entry = CTkEntry(model_frame, width=350, placeholder_text="./model.gguf")
+        self.model_path_entry = CTkEntry(
+            model_frame, width=350, placeholder_text="./model.gguf"
+        )
         self.model_path_entry.pack(side="left", padx=(0, Spacing.SM))
         _make_button(
             model_frame, text="Browse", command=self._browse_model, width=70
@@ -326,14 +385,20 @@ class SettingsDialog(CTkToplevel):
         # Embedding Model (read-only)
         CTkLabel(main_frame, text="Embedding Model:").pack(anchor="w")
         self.embedding_model_label = CTkLabel(
-            main_frame, text="", font=TypeScale.body(), text_color=ColorTokens.text_muted()
+            main_frame,
+            text="",
+            font=TypeScale.body(),
+            text_color=ColorTokens.text_muted(),
         )
         self.embedding_model_label.pack(anchor="w", pady=(0, Spacing.LG))
 
         # Reranker Model (read-only)
         CTkLabel(main_frame, text="Reranker Model:").pack(anchor="w")
         self.reranker_model_label = CTkLabel(
-            main_frame, text="", font=TypeScale.body(), text_color=ColorTokens.text_muted()
+            main_frame,
+            text="",
+            font=TypeScale.body(),
+            text_color=ColorTokens.text_muted(),
         )
         self.reranker_model_label.pack(anchor="w", pady=(0, Spacing.LG))
 
@@ -348,7 +413,9 @@ class SettingsDialog(CTkToplevel):
         CTkLabel(settings_frame, text="Chunk Size:").grid(
             row=0, column=0, sticky="w", pady=Spacing.SM
         )
-        self.chunk_size_entry = CTkEntry(settings_frame, width=100, placeholder_text="512")
+        self.chunk_size_entry = CTkEntry(
+            settings_frame, width=100, placeholder_text="512"
+        )
         self.chunk_size_entry.grid(row=0, column=1, padx=Spacing.LG, pady=Spacing.SM)
         attach_field_tooltip(settings_frame, self.chunk_size_entry, "chunk_size")
 
@@ -362,14 +429,18 @@ class SettingsDialog(CTkToplevel):
         CTkLabel(settings_frame, text="Max Tokens:").grid(
             row=2, column=0, sticky="w", pady=Spacing.SM
         )
-        self.max_tokens_entry = CTkEntry(settings_frame, width=100, placeholder_text=str(DEFAULT_MAX_TOKENS))
+        self.max_tokens_entry = CTkEntry(
+            settings_frame, width=100, placeholder_text=str(DEFAULT_MAX_TOKENS)
+        )
         self.max_tokens_entry.grid(row=2, column=1, padx=Spacing.LG, pady=Spacing.SM)
         attach_field_tooltip(settings_frame, self.max_tokens_entry, "max_tokens")
 
         CTkLabel(settings_frame, text="Temperature:").grid(
             row=3, column=0, sticky="w", pady=Spacing.SM
         )
-        self.temperature_entry = CTkEntry(settings_frame, width=100, placeholder_text="0.3")
+        self.temperature_entry = CTkEntry(
+            settings_frame, width=100, placeholder_text="0.3"
+        )
         self.temperature_entry.grid(row=3, column=1, padx=Spacing.LG, pady=Spacing.SM)
         attach_field_tooltip(settings_frame, self.temperature_entry, "temperature")
 
@@ -377,7 +448,9 @@ class SettingsDialog(CTkToplevel):
         CTkLabel(settings_frame, text="Chunk Overlap:").grid(
             row=4, column=0, sticky="w", pady=Spacing.SM
         )
-        self.chunk_overlap_entry = CTkEntry(settings_frame, width=100, placeholder_text="0")
+        self.chunk_overlap_entry = CTkEntry(
+            settings_frame, width=100, placeholder_text="0"
+        )
         self.chunk_overlap_entry.grid(row=4, column=1, padx=Spacing.LG, pady=Spacing.SM)
         attach_field_tooltip(settings_frame, self.chunk_overlap_entry, "chunk_overlap")
 
@@ -385,9 +458,15 @@ class SettingsDialog(CTkToplevel):
         CTkLabel(settings_frame, text="Min Similarity:").grid(
             row=5, column=0, sticky="w", pady=Spacing.SM
         )
-        self.min_similarity_entry = CTkEntry(settings_frame, width=100, placeholder_text="0.5")
-        self.min_similarity_entry.grid(row=5, column=1, padx=Spacing.LG, pady=Spacing.SM)
-        attach_field_tooltip(settings_frame, self.min_similarity_entry, "min_similarity")
+        self.min_similarity_entry = CTkEntry(
+            settings_frame, width=100, placeholder_text="0.5"
+        )
+        self.min_similarity_entry.grid(
+            row=5, column=1, padx=Spacing.LG, pady=Spacing.SM
+        )
+        attach_field_tooltip(
+            settings_frame, self.min_similarity_entry, "min_similarity"
+        )
 
         # Advanced RAG Settings
         CTkLabel(main_frame, text="Advanced RAG Settings", font=TypeScale.h2()).pack(
@@ -408,16 +487,24 @@ class SettingsDialog(CTkToplevel):
             onvalue="on",
             offvalue="off",
         )
-        self.hybrid_switch.grid(row=0, column=0, columnspan=2, sticky="w", pady=Spacing.SM)
+        self.hybrid_switch.grid(
+            row=0, column=0, columnspan=2, sticky="w", pady=Spacing.SM
+        )
         attach_field_tooltip(advanced_frame, self.hybrid_switch, "hybrid_search")
 
         # Window Expansion
         CTkLabel(advanced_frame, text="Window Expansion (chunks):").grid(
             row=1, column=0, sticky="w", pady=Spacing.SM
         )
-        self.retrieval_window_entry = CTkEntry(advanced_frame, width=100, placeholder_text="2")
-        self.retrieval_window_entry.grid(row=1, column=1, padx=Spacing.LG, pady=Spacing.SM)
-        attach_field_tooltip(advanced_frame, self.retrieval_window_entry, "retrieval_window")
+        self.retrieval_window_entry = CTkEntry(
+            advanced_frame, width=100, placeholder_text="2"
+        )
+        self.retrieval_window_entry.grid(
+            row=1, column=1, padx=Spacing.LG, pady=Spacing.SM
+        )
+        attach_field_tooltip(
+            advanced_frame, self.retrieval_window_entry, "retrieval_window"
+        )
 
         # Reranking toggle
         self.reranking_var = tk.StringVar(
@@ -430,22 +517,32 @@ class SettingsDialog(CTkToplevel):
             onvalue="on",
             offvalue="off",
         )
-        self.reranking_switch.grid(row=2, column=0, columnspan=2, sticky="w", pady=Spacing.SM)
+        self.reranking_switch.grid(
+            row=2, column=0, columnspan=2, sticky="w", pady=Spacing.SM
+        )
         attach_field_tooltip(advanced_frame, self.reranking_switch, "reranking")
 
         # Initial Retrieval Top-K
         CTkLabel(advanced_frame, text="Initial Retrieval Top-K:").grid(
             row=3, column=0, sticky="w", pady=Spacing.SM
         )
-        self.initial_retrieval_top_k_entry = CTkEntry(advanced_frame, width=100, placeholder_text="30")
-        self.initial_retrieval_top_k_entry.grid(row=3, column=1, padx=Spacing.LG, pady=Spacing.SM)
-        attach_field_tooltip(advanced_frame, self.initial_retrieval_top_k_entry, "initial_top_k")
+        self.initial_retrieval_top_k_entry = CTkEntry(
+            advanced_frame, width=100, placeholder_text="30"
+        )
+        self.initial_retrieval_top_k_entry.grid(
+            row=3, column=1, padx=Spacing.LG, pady=Spacing.SM
+        )
+        attach_field_tooltip(
+            advanced_frame, self.initial_retrieval_top_k_entry, "initial_top_k"
+        )
 
         # Rerank Top-K
         CTkLabel(advanced_frame, text="Rerank Top-K:").grid(
             row=4, column=0, sticky="w", pady=Spacing.SM
         )
-        self.rerank_top_k_entry = CTkEntry(advanced_frame, width=100, placeholder_text="6")
+        self.rerank_top_k_entry = CTkEntry(
+            advanced_frame, width=100, placeholder_text="6"
+        )
         self.rerank_top_k_entry.grid(row=4, column=1, padx=Spacing.LG, pady=Spacing.SM)
         attach_field_tooltip(advanced_frame, self.rerank_top_k_entry, "rerank_top_k")
 
@@ -453,9 +550,15 @@ class SettingsDialog(CTkToplevel):
         CTkLabel(advanced_frame, text="Context Truncation:").grid(
             row=5, column=0, sticky="w", pady=Spacing.SM
         )
-        self.context_truncation_entry = CTkEntry(advanced_frame, width=100, placeholder_text="20000")
-        self.context_truncation_entry.grid(row=5, column=1, padx=Spacing.LG, pady=Spacing.SM)
-        attach_field_tooltip(advanced_frame, self.context_truncation_entry, "context_truncation")
+        self.context_truncation_entry = CTkEntry(
+            advanced_frame, width=100, placeholder_text="20000"
+        )
+        self.context_truncation_entry.grid(
+            row=5, column=1, padx=Spacing.LG, pady=Spacing.SM
+        )
+        attach_field_tooltip(
+            advanced_frame, self.context_truncation_entry, "context_truncation"
+        )
 
         # Database Settings
         CTkLabel(main_frame, text="Database", font=TypeScale.h2()).pack(
@@ -465,8 +568,12 @@ class SettingsDialog(CTkToplevel):
         db_frame = CTkFrame(main_frame)
         db_frame.pack(fill="x")
 
-        CTkLabel(db_frame, text="Database Path:").grid(row=0, column=0, sticky="w", pady=Spacing.SM)
-        self.db_path_entry = CTkEntry(db_frame, width=350, placeholder_text="./doc_qa_db")
+        CTkLabel(db_frame, text="Database Path:").grid(
+            row=0, column=0, sticky="w", pady=Spacing.SM
+        )
+        self.db_path_entry = CTkEntry(
+            db_frame, width=350, placeholder_text="./doc_qa_db"
+        )
         self.db_path_entry.grid(row=0, column=1, padx=Spacing.LG, pady=Spacing.SM)
         attach_field_tooltip(main_frame, self.db_path_entry, "db_path")
         _make_button(
@@ -477,14 +584,23 @@ class SettingsDialog(CTkToplevel):
         button_frame = CTkFrame(main_frame)
         button_frame.pack(fill="x", pady=(Spacing.XXL, 0))
 
-        _make_button(button_frame, "Cancel", self.destroy,
-                    fg_color=ColorTokens.secondary(), hover_color=ColorTokens.secondary_hover(), text_color=ColorTokens.text_on_secondary()).pack(
-            side="right", padx=Spacing.SM
-        )
-        _make_button(button_frame, "Save", self._save,
-                    fg_color=ColorTokens.primary(), hover_color=ColorTokens.primary_hover(), text_color=ColorTokens.text_on_primary(), border_width=1).pack(
-            side="right", padx=Spacing.SM
-        )
+        _make_button(
+            button_frame,
+            "Cancel",
+            self.destroy,
+            fg_color=ColorTokens.secondary(),
+            hover_color=ColorTokens.secondary_hover(),
+            text_color=ColorTokens.text_on_secondary(),
+        ).pack(side="right", padx=Spacing.SM)
+        _make_button(
+            button_frame,
+            "Save",
+            self._save,
+            fg_color=ColorTokens.primary(),
+            hover_color=ColorTokens.primary_hover(),
+            text_color=ColorTokens.text_on_primary(),
+            border_width=1,
+        ).pack(side="right", padx=Spacing.SM)
 
     def _browse_model(self):
         path = filedialog.askopenfilename(
@@ -503,7 +619,9 @@ class SettingsDialog(CTkToplevel):
     def _populate_fields(self):
         gguf = self.settings.get("gguf_path") or self.settings.get("model_path", "")
         self.model_path_entry.insert(0, gguf)
-        self.chunk_size_entry.insert(0, str(self.settings.get("chunk_size", DEFAULT_CHUNK_SIZE)))
+        self.chunk_size_entry.insert(
+            0, str(self.settings.get("chunk_size", DEFAULT_CHUNK_SIZE))
+        )
         self.n_results_entry.insert(0, str(self.settings.get("n_results", 4)))
         self.max_tokens_entry.insert(0, str(self.settings.get("max_tokens", 512)))
         self.temperature_entry.insert(0, str(self.settings.get("temperature", 0.3)))
@@ -516,7 +634,9 @@ class SettingsDialog(CTkToplevel):
         self.reranking_var.set(
             "on" if self.settings.get("reranking_enabled", False) else "off"
         )
-        self.initial_retrieval_top_k_entry.insert(0, str(self.settings.get("initial_retrieval_top_k", 12)))
+        self.initial_retrieval_top_k_entry.insert(
+            0, str(self.settings.get("initial_retrieval_top_k", 12))
+        )
         self.rerank_top_k_entry.insert(0, str(self.settings.get("rerank_top_k", 4)))
 
         # Read-only model info
@@ -527,8 +647,12 @@ class SettingsDialog(CTkToplevel):
 
         # New fields
         self.chunk_overlap_entry.insert(0, str(self.settings.get("chunk_overlap", 100)))
-        self.min_similarity_entry.insert(0, str(self.settings.get("min_similarity", 0.3)))
-        self.context_truncation_entry.insert(0, str(self.settings.get("context_truncation", 20000)))
+        self.min_similarity_entry.insert(
+            0, str(self.settings.get("min_similarity", 0.3))
+        )
+        self.context_truncation_entry.insert(
+            0, str(self.settings.get("context_truncation", 20000))
+        )
         self.db_path_entry.insert(0, str(self.settings.get("db_path", "./doc_qa_db")))
 
     def _save(self):
@@ -538,40 +662,46 @@ class SettingsDialog(CTkToplevel):
         try:
             chunk_size = int(self.chunk_size_entry.get() or DEFAULT_CHUNK_SIZE)
             if not (MIN_CHUNK_SIZE <= chunk_size <= MAX_CHUNK_SIZE):
-                errors.append(f"Chunk Size must be between {MIN_CHUNK_SIZE} and {MAX_CHUNK_SIZE}")
+                errors.append(
+                    f"Chunk Size must be between {MIN_CHUNK_SIZE} and {MAX_CHUNK_SIZE}"
+                )
         except ValueError:
             errors.append("Chunk Size must be a valid integer")
 
         try:
             n_results = int(self.n_results_entry.get() or 4)
             if not (1 <= n_results <= 20):
-                errors.append(f"Results to Retrieve must be between 1 and 20")
+                errors.append("Results to Retrieve must be between 1 and 20")
         except ValueError:
             errors.append("Results to Retrieve must be a valid integer")
 
         try:
             max_tokens = int(self.max_tokens_entry.get() or 512)
             if not (MIN_MAX_TOKENS <= max_tokens <= MAX_MAX_TOKENS):
-                errors.append(f"Max Tokens must be between {MIN_MAX_TOKENS} and {MAX_MAX_TOKENS}")
+                errors.append(
+                    f"Max Tokens must be between {MIN_MAX_TOKENS} and {MAX_MAX_TOKENS}"
+                )
         except ValueError:
             errors.append("Max Tokens must be a valid integer")
 
         try:
             temperature = float(self.temperature_entry.get() or 0.3)
             if not (0.0 <= temperature <= 2.0):
-                errors.append(f"Temperature must be between 0.0 and 2.0")
+                errors.append("Temperature must be between 0.0 and 2.0")
         except ValueError:
             errors.append("Temperature must be a valid number")
 
         try:
             retrieval_window = int(self.retrieval_window_entry.get() or 1)
             if not (0 <= retrieval_window <= 5):
-                errors.append(f"Window Expansion must be between 0 and 5")
+                errors.append("Window Expansion must be between 0 and 5")
         except ValueError:
             errors.append("Window Expansion must be a valid integer")
 
         try:
-            initial_retrieval_top_k = int(self.initial_retrieval_top_k_entry.get() or 12)
+            initial_retrieval_top_k = int(
+                self.initial_retrieval_top_k_entry.get() or 12
+            )
             if not (1 <= initial_retrieval_top_k <= 100):
                 errors.append("Initial Retrieval Top-K must be between 1 and 100")
         except ValueError:
@@ -600,7 +730,7 @@ class SettingsDialog(CTkToplevel):
             messagebox.showerror(
                 "Invalid Settings",
                 f"Chunk overlap ({chunk_overlap}) must be less than chunk size ({chunk_size}).",
-                parent=self
+                parent=self,
             )
             return
 
@@ -698,7 +828,7 @@ class DocumentQAApp(CTk):
         bundled_model = ""
         if not os.path.exists(settings_path):
             bundled_models = [
-                Path("models") / "gemma-4-E2B-it-Q5_K-M.gguf",
+                Path("models") / "gemma-4-E2B-it-Q5_K_M.gguf",
             ]
             for model_file in bundled_models:
                 if model_file.is_file():
@@ -758,40 +888,58 @@ class DocumentQAApp(CTk):
         nav_btn_hover = ColorTokens.secondary_hover()
 
         self.nav_chat_btn = _make_button(
-            nav_rail, "💬\nChat", lambda: self._switch_page("chat"),
-            width=nav_width, height=nav_width,
-            fg_color=ColorTokens.primary(), hover_color=ColorTokens.primary_hover(),
+            nav_rail,
+            "💬\nChat",
+            lambda: self._switch_page("chat"),
+            width=nav_width,
+            height=nav_width,
+            fg_color=ColorTokens.primary(),
+            hover_color=ColorTokens.primary_hover(),
             text_color=ColorTokens.text_on_primary(),
         )
         self.nav_chat_btn.pack(pady=Spacing.SM, padx=Spacing.SM)
 
         self.nav_docs_btn = _make_button(
-            nav_rail, "📄\nDocuments", lambda: self._switch_page("documents"),
-            width=nav_width, height=nav_width,
-            fg_color=nav_btn_color, hover_color=nav_btn_hover,
+            nav_rail,
+            "📄\nDocuments",
+            lambda: self._switch_page("documents"),
+            width=nav_width,
+            height=nav_width,
+            fg_color=nav_btn_color,
+            hover_color=nav_btn_hover,
             text_color=ColorTokens.text_on_secondary(),
         )
         self.nav_docs_btn.pack(pady=Spacing.SM, padx=Spacing.SM)
 
         self.nav_settings_btn = _make_button(
-            nav_rail, "⚙\nSettings", lambda: self._switch_page("settings"),
-            width=nav_width, height=nav_width,
-            fg_color=nav_btn_color, hover_color=nav_btn_hover,
+            nav_rail,
+            "⚙\nSettings",
+            lambda: self._switch_page("settings"),
+            width=nav_width,
+            height=nav_width,
+            fg_color=nav_btn_color,
+            hover_color=nav_btn_hover,
             text_color=ColorTokens.text_on_secondary(),
         )
         self.nav_settings_btn.pack(pady=Spacing.SM, padx=Spacing.SM)
 
         self.nav_help_btn = _make_button(
-            nav_rail, "?\nHelp", lambda: self._switch_page("help"),
-            width=nav_width, height=nav_width,
-            fg_color=nav_btn_color, hover_color=nav_btn_hover,
+            nav_rail,
+            "?\nHelp",
+            lambda: self._switch_page("help"),
+            width=nav_width,
+            height=nav_width,
+            fg_color=nav_btn_color,
+            hover_color=nav_btn_hover,
             text_color=ColorTokens.text_on_secondary(),
         )
         self.nav_help_btn.pack(pady=Spacing.SM, padx=Spacing.SM)
 
         # Content area
         self.content_frame = CTkFrame(main_container)
-        self.content_frame.pack(side="right", fill="both", expand=True, padx=Spacing.LG, pady=Spacing.LG)
+        self.content_frame.pack(
+            side="right", fill="both", expand=True, padx=Spacing.LG, pady=Spacing.LG
+        )
 
         # Initialize cancellation event before page creation (pages may reference it)
         self._operation_cancelled = threading.Event()
@@ -824,7 +972,9 @@ class DocumentQAApp(CTk):
         middle_frame = CTkFrame(top_bar)
         middle_frame.pack(side="left", expand=True, fill="x")
 
-        self.model_label = CTkLabel(middle_frame, text="Model: None", font=TypeScale.small())
+        self.model_label = CTkLabel(
+            middle_frame, text="Model: None", font=TypeScale.small()
+        )
         self.model_label.pack(side="left", padx=Spacing.XXL)
 
         self.doc_count_label = CTkLabel(
@@ -841,14 +991,20 @@ class DocumentQAApp(CTk):
 
         # Progress label — also hidden when idle
         self.progress_label = CTkLabel(
-            self.chat_page, text="", font=TypeScale.caption(), text_color=ColorTokens.text_muted()
+            self.chat_page,
+            text="",
+            font=TypeScale.caption(),
+            text_color=ColorTokens.text_muted(),
         )
         # progress_label NOT packed at startup
 
         # Cancel button
         self.cancel_button = _make_button(
-            self.chat_page, "Cancel", command=self._cancel_operation,
-            width=60, height=24,
+            self.chat_page,
+            "Cancel",
+            command=self._cancel_operation,
+            width=60,
+            height=24,
             font=TypeScale.small(),
             fg_color=ColorTokens.danger(),
             hover_color=ColorTokens.danger_hover(),
@@ -864,9 +1020,13 @@ class DocumentQAApp(CTk):
         self._clear_confirm_pending = False
         self._empty_state_visible = False
         self._empty_state_frame = None
-        self._streaming_message_ref: Optional[CTkLabel] = None  # Reference to streaming message content label
-        self._streaming_message_frame: Optional[CTkFrame] = None  # Reference to streaming message frame
-        self._streaming_finalized: bool = False  # Guard: prevents tokens arriving after finalization from being processed
+        self._streaming_message_ref: Optional[
+            CTkLabel
+        ] = None  # Reference to streaming message content label
+        self._streaming_message_frame: Optional[
+            CTkFrame
+        ] = None  # Reference to streaming message frame
+        self._streaming_finalized: bool = False  # Guard: prevents tokens arriving after finalization from being processed  # noqa: E501
 
         # Start surface (shown when no messages; sibling of chat_frame, NOT inside it)
         self._chat_area_frame = CTkFrame(self.chat_page, fg_color="transparent")
@@ -886,33 +1046,49 @@ class DocumentQAApp(CTk):
         input_frame.pack(fill="x", pady=(0, 0))
 
         # Multiline textbox for question input
-        self.question_entry = CTkTextbox(
-            input_frame, height=80, wrap="word"
+        self.question_entry = CTkTextbox(input_frame, height=80, wrap="word")
+        self.question_entry.pack(
+            side="left",
+            fill="both",
+            expand=True,
+            padx=(0, Spacing.LG),
+            pady=(Spacing.LG, 0),
         )
-        self.question_entry.pack(side="left", fill="both", expand=True, padx=(0, Spacing.LG), pady=(Spacing.LG, 0))
 
         # Keyboard bindings for multiline textbox
-        self.question_entry.bind("<Control-Return>", lambda e: self._ask_question() or "break")
+        self.question_entry.bind(
+            "<Control-Return>", lambda e: self._ask_question() or "break"
+        )
         self.question_entry.bind("<Escape>", lambda e: self._handle_escape_key())
-        self.question_entry.bind("<Return>", lambda e: None)  # Allow normal Enter for newline
+        self.question_entry.bind(
+            "<Return>", lambda e: None
+        )  # Allow normal Enter for newline
 
         # Button frame
         button_frame = CTkFrame(input_frame, fg_color="transparent")
         button_frame.pack(side="left", fill="y", padx=(0, 0), pady=(Spacing.LG, 0))
 
         self.ask_button = _make_button(
-            button_frame, text="Ask", command=self._ask_question,
-            width=70, height=40, fg_color=ColorTokens.primary(),
+            button_frame,
+            text="Ask",
+            command=self._ask_question,
+            width=70,
+            height=40,
+            fg_color=ColorTokens.primary(),
             hover_color=ColorTokens.primary_hover(),
-            text_color=ColorTokens.text_on_primary()
+            text_color=ColorTokens.text_on_primary(),
         )
         self.ask_button.pack(pady=(0, Spacing.SM))
 
         self.clear_button = _make_button(
-            button_frame, text="Clear", command=self._confirm_clear_chat,
-            width=70, height=40, fg_color=ColorTokens.secondary(),
+            button_frame,
+            text="Clear",
+            command=self._confirm_clear_chat,
+            width=70,
+            height=40,
+            fg_color=ColorTokens.secondary(),
             hover_color=ColorTokens.secondary_hover(),
-            text_color=ColorTokens.text_on_secondary()
+            text_color=ColorTokens.text_on_secondary(),
         )
         self.clear_button.pack(pady=(0, 0))
 
@@ -935,15 +1111,30 @@ class DocumentQAApp(CTk):
         # Command row
         cmd_row = CTkFrame(self.documents_page, fg_color="transparent")
         cmd_row.pack(fill="x", pady=(0, Spacing.LG))
-        _make_button(cmd_row, text="Add Folder", command=self._add_folder,
-                     fg_color=ColorTokens.primary(), hover_color=ColorTokens.primary_hover(),
-                     text_color=ColorTokens.text_on_primary()).pack(side="left", padx=(0, Spacing.SM))
-        _make_button(cmd_row, text="Add Files", command=self._ingest_documents,
-                     fg_color=ColorTokens.primary(), hover_color=ColorTokens.primary_hover(),
-                     text_color=ColorTokens.text_on_primary()).pack(side="left", padx=(0, Spacing.SM))
-        _make_button(cmd_row, text="Clear All", command=self._clear_all_documents,
-                     fg_color=ColorTokens.danger(), hover_color=ColorTokens.danger_hover(),
-                     text_color="#ffffff").pack(side="left")
+        _make_button(
+            cmd_row,
+            text="Add Folder",
+            command=self._add_folder,
+            fg_color=ColorTokens.primary(),
+            hover_color=ColorTokens.primary_hover(),
+            text_color=ColorTokens.text_on_primary(),
+        ).pack(side="left", padx=(0, Spacing.SM))
+        _make_button(
+            cmd_row,
+            text="Add Files",
+            command=self._ingest_documents,
+            fg_color=ColorTokens.primary(),
+            hover_color=ColorTokens.primary_hover(),
+            text_color=ColorTokens.text_on_primary(),
+        ).pack(side="left", padx=(0, Spacing.SM))
+        _make_button(
+            cmd_row,
+            text="Clear All",
+            command=self._clear_all_documents,
+            fg_color=ColorTokens.danger(),
+            hover_color=ColorTokens.danger_hover(),
+            text_color="#ffffff",
+        ).pack(side="left")
 
         # Documents list area
         self.documents_frame = CTkScrollableFrame(self.documents_page)
@@ -960,53 +1151,96 @@ class DocumentQAApp(CTk):
         # --- Preset buttons ---
         preset_row = CTkFrame(self.settings_page, fg_color="transparent")
         preset_row.pack(fill="x", pady=(0, Spacing.LG))
-        CTkLabel(preset_row, text="Preset:", font=TypeScale.body()).pack(side="left", padx=(0, Spacing.SM))
-        _make_button(preset_row, text="Fast", width=70,
-                     command=lambda: self._apply_settings_preset(_PRESET_FAST),
-                     fg_color=ColorTokens.secondary(), hover_color=ColorTokens.secondary_hover(),
-                     text_color=ColorTokens.text_on_secondary()).pack(side="left", padx=Spacing.SM)
-        _make_button(preset_row, text="Balanced", width=80,
-                     command=lambda: self._apply_settings_preset(_PRESET_BALANCED),
-                     fg_color=ColorTokens.secondary(), hover_color=ColorTokens.secondary_hover(),
-                     text_color=ColorTokens.text_on_secondary()).pack(side="left", padx=Spacing.SM)
-        _make_button(preset_row, text="Quality", width=80,
-                     command=lambda: self._apply_settings_preset(_PRESET_QUALITY),
-                     fg_color=ColorTokens.secondary(), hover_color=ColorTokens.secondary_hover(),
-                     text_color=ColorTokens.text_on_secondary()).pack(side="left", padx=Spacing.SM)
+        CTkLabel(preset_row, text="Preset:", font=TypeScale.body()).pack(
+            side="left", padx=(0, Spacing.SM)
+        )
+        _make_button(
+            preset_row,
+            text="Fast",
+            width=70,
+            command=lambda: self._apply_settings_preset(_PRESET_FAST),
+            fg_color=ColorTokens.secondary(),
+            hover_color=ColorTokens.secondary_hover(),
+            text_color=ColorTokens.text_on_secondary(),
+        ).pack(side="left", padx=Spacing.SM)
+        _make_button(
+            preset_row,
+            text="Balanced",
+            width=80,
+            command=lambda: self._apply_settings_preset(_PRESET_BALANCED),
+            fg_color=ColorTokens.secondary(),
+            hover_color=ColorTokens.secondary_hover(),
+            text_color=ColorTokens.text_on_secondary(),
+        ).pack(side="left", padx=Spacing.SM)
+        _make_button(
+            preset_row,
+            text="Quality",
+            width=80,
+            command=lambda: self._apply_settings_preset(_PRESET_QUALITY),
+            fg_color=ColorTokens.secondary(),
+            hover_color=ColorTokens.secondary_hover(),
+            text_color=ColorTokens.text_on_secondary(),
+        ).pack(side="left", padx=Spacing.SM)
 
         # ── Model & Storage ────────────────────────────────────────────────
-        CTkLabel(self.settings_page, text="Model & Storage", font=TypeScale.h3()).pack(anchor="w", pady=(0, Spacing.SM))
+        CTkLabel(self.settings_page, text="Model & Storage", font=TypeScale.h3()).pack(
+            anchor="w", pady=(0, Spacing.SM)
+        )
         model_store_frame = CTkFrame(self.settings_page)
         model_store_frame.pack(fill="x", pady=(0, Spacing.LG))
 
         CTkLabel(model_store_frame, text="GGUF Model Path:").pack(anchor="w")
         model_path_row = CTkFrame(model_store_frame, fg_color="transparent")
         model_path_row.pack(fill="x", pady=(0, Spacing.MD))
-        self.settings_model_entry = CTkEntry(model_path_row, placeholder_text="./model.gguf")
-        self.settings_model_entry.pack(side="left", fill="x", expand=True, padx=(0, Spacing.SM))
-        _make_button(model_path_row, text="Browse", command=self._browse_settings_model, width=70).pack(side="left")
+        self.settings_model_entry = CTkEntry(
+            model_path_row, placeholder_text="./model.gguf"
+        )
+        self.settings_model_entry.pack(
+            side="left", fill="x", expand=True, padx=(0, Spacing.SM)
+        )
+        _make_button(
+            model_path_row, text="Browse", command=self._browse_settings_model, width=70
+        ).pack(side="left")
 
         CTkLabel(model_store_frame, text="Database Path:").pack(anchor="w")
         db_path_row = CTkFrame(model_store_frame, fg_color="transparent")
         db_path_row.pack(fill="x", pady=(0, Spacing.MD))
-        self.settings_db_path_entry = CTkEntry(db_path_row, placeholder_text="./chroma_db")
-        self.settings_db_path_entry.pack(side="left", fill="x", expand=True, padx=(0, Spacing.SM))
-        _make_button(db_path_row, text="Browse", command=self._browse_settings_db_path, width=70).pack(side="left")
+        self.settings_db_path_entry = CTkEntry(
+            db_path_row, placeholder_text="./chroma_db"
+        )
+        self.settings_db_path_entry.pack(
+            side="left", fill="x", expand=True, padx=(0, Spacing.SM)
+        )
+        _make_button(
+            db_path_row, text="Browse", command=self._browse_settings_db_path, width=70
+        ).pack(side="left")
 
-        CTkLabel(model_store_frame, text="Embedding Model (read-only):").pack(anchor="w")
+        CTkLabel(model_store_frame, text="Embedding Model (read-only):").pack(
+            anchor="w"
+        )
         self.settings_embedding_model_label = CTkLabel(
-            model_store_frame, text="—", font=TypeScale.body(), text_color=ColorTokens.text_muted(), anchor="w"
+            model_store_frame,
+            text="—",
+            font=TypeScale.body(),
+            text_color=ColorTokens.text_muted(),
+            anchor="w",
         )
         self.settings_embedding_model_label.pack(anchor="w", pady=(0, Spacing.MD))
 
         CTkLabel(model_store_frame, text="Reranker Model (read-only):").pack(anchor="w")
         self.settings_reranker_model_label = CTkLabel(
-            model_store_frame, text="—", font=TypeScale.body(), text_color=ColorTokens.text_muted(), anchor="w"
+            model_store_frame,
+            text="—",
+            font=TypeScale.body(),
+            text_color=ColorTokens.text_muted(),
+            anchor="w",
         )
         self.settings_reranker_model_label.pack(anchor="w", pady=(0, Spacing.SM))
 
         # ── Basic RAG Parameters ───────────────────────────────────────────
-        CTkLabel(self.settings_page, text="RAG Parameters", font=TypeScale.h3()).pack(anchor="w", pady=(Spacing.LG, Spacing.SM))
+        CTkLabel(self.settings_page, text="RAG Parameters", font=TypeScale.h3()).pack(
+            anchor="w", pady=(Spacing.LG, Spacing.SM)
+        )
         rag_frame = CTkFrame(self.settings_page)
         rag_frame.pack(fill="x", pady=(0, Spacing.LG))
 
@@ -1023,7 +1257,9 @@ class DocumentQAApp(CTk):
             setattr(self, attr, entry)
 
         # ── LLM Parameters ─────────────────────────────────────────────────
-        CTkLabel(self.settings_page, text="LLM Parameters", font=TypeScale.h3()).pack(anchor="w", pady=(Spacing.LG, Spacing.SM))
+        CTkLabel(self.settings_page, text="LLM Parameters", font=TypeScale.h3()).pack(
+            anchor="w", pady=(Spacing.LG, Spacing.SM)
+        )
         llm_frame = CTkFrame(self.settings_page)
         llm_frame.pack(fill="x", pady=(0, Spacing.LG))
 
@@ -1031,7 +1267,11 @@ class DocumentQAApp(CTk):
             ("Max Tokens:", "settings_max_tokens_entry", "512"),
             ("Temperature (0.0–2.0):", "settings_temperature_entry", "0.3"),
             ("GGUF Context Window (n_ctx):", "settings_gguf_n_ctx_entry", "4096"),
-            ("GGUF Threads (n_threads):", "settings_gguf_n_threads_entry", "4"),
+            (
+                "GGUF Threads (n_threads):",
+                "settings_gguf_n_threads_entry",
+                str(_DEFAULT_GGUF_THREADS),
+            ),
         ]:
             CTkLabel(llm_frame, text=label).pack(anchor="w")
             entry = CTkEntry(llm_frame, placeholder_text=placeholder)
@@ -1039,14 +1279,20 @@ class DocumentQAApp(CTk):
             setattr(self, attr, entry)
 
         # ── Advanced Retrieval ─────────────────────────────────────────────
-        CTkLabel(self.settings_page, text="Advanced Retrieval", font=TypeScale.h3()).pack(anchor="w", pady=(Spacing.LG, Spacing.SM))
+        CTkLabel(
+            self.settings_page, text="Advanced Retrieval", font=TypeScale.h3()
+        ).pack(anchor="w", pady=(Spacing.LG, Spacing.SM))
         adv_frame = CTkFrame(self.settings_page)
         adv_frame.pack(fill="x", pady=(0, Spacing.LG))
 
         for label, attr, placeholder in [
             ("Initial Retrieval Top-K:", "settings_initial_top_k_entry", "12"),
             ("Rerank Top-K:", "settings_rerank_top_k_entry", "4"),
-            ("Context Truncation (chars):", "settings_context_truncation_entry", "20000"),
+            (
+                "Context Truncation (chars):",
+                "settings_context_truncation_entry",
+                "20000",
+            ),
         ]:
             CTkLabel(adv_frame, text=label).pack(anchor="w")
             entry = CTkEntry(adv_frame, placeholder_text=placeholder)
@@ -1054,53 +1300,115 @@ class DocumentQAApp(CTk):
             setattr(self, attr, entry)
 
         # Toggle switches
-        self.settings_hybrid_var = tk.StringVar(value="on" if self.settings.get("hybrid_search", True) else "off")
-        CTkSwitch(adv_frame, text="Enable Hybrid Search",
-                  variable=self.settings_hybrid_var, onvalue="on", offvalue="off").pack(anchor="w", pady=Spacing.SM)
+        self.settings_hybrid_var = tk.StringVar(
+            value="on" if self.settings.get("hybrid_search", True) else "off"
+        )
+        CTkSwitch(
+            adv_frame,
+            text="Enable Hybrid Search",
+            variable=self.settings_hybrid_var,
+            onvalue="on",
+            offvalue="off",
+        ).pack(anchor="w", pady=Spacing.SM)
 
         # Reranking default is False (minimum-hardware safe)
-        self.settings_reranking_var = tk.StringVar(value="on" if self.settings.get("reranking_enabled", False) else "off")
-        CTkSwitch(adv_frame, text="Enable Reranking",
-                  variable=self.settings_reranking_var, onvalue="on", offvalue="off").pack(anchor="w", pady=Spacing.SM)
+        self.settings_reranking_var = tk.StringVar(
+            value="on" if self.settings.get("reranking_enabled", False) else "off"
+        )
+        CTkSwitch(
+            adv_frame,
+            text="Enable Reranking",
+            variable=self.settings_reranking_var,
+            onvalue="on",
+            offvalue="off",
+        ).pack(anchor="w", pady=Spacing.SM)
 
-        self.settings_query_transform_var = tk.StringVar(value="on" if self.settings.get("query_transformation_enabled", False) else "off")
-        CTkSwitch(adv_frame, text="Enable Query Transformation",
-                  variable=self.settings_query_transform_var, onvalue="on", offvalue="off").pack(anchor="w", pady=Spacing.SM)
+        self.settings_query_transform_var = tk.StringVar(
+            value="on"
+            if self.settings.get("query_transformation_enabled", False)
+            else "off"
+        )
+        CTkSwitch(
+            adv_frame,
+            text="Enable Query Transformation",
+            variable=self.settings_query_transform_var,
+            onvalue="on",
+            offvalue="off",
+        ).pack(anchor="w", pady=Spacing.SM)
 
         # ── Action buttons ─────────────────────────────────────────────────
         action_row = CTkFrame(self.settings_page, fg_color="transparent")
         action_row.pack(fill="x", pady=(Spacing.LG, Spacing.XXXL))
-        _make_button(action_row, text="Save Settings",
-                     command=self._save_settings_inline,
-                     fg_color=ColorTokens.primary(), hover_color=ColorTokens.primary_hover(),
-                     text_color=ColorTokens.text_on_primary()).pack(side="left", padx=(0, Spacing.SM))
+        _make_button(
+            action_row,
+            text="Save Settings",
+            command=self._save_settings_inline,
+            fg_color=ColorTokens.primary(),
+            hover_color=ColorTokens.primary_hover(),
+            text_color=ColorTokens.text_on_primary(),
+        ).pack(side="left", padx=(0, Spacing.SM))
 
     def _create_help_page(self):
         """Create the help/about page with runtime status and keyboard shortcuts."""
         self.help_page = CTkScrollableFrame(self.content_frame)
 
-        CTkLabel(self.help_page, text="Help & About", font=TypeScale.h2()).pack(anchor="w", pady=(0, Spacing.LG))
+        CTkLabel(self.help_page, text="Help & About", font=TypeScale.h2()).pack(
+            anchor="w", pady=(0, Spacing.LG)
+        )
 
         # Runtime Status section — labels updated dynamically in _refresh_help_status
-        CTkLabel(self.help_page, text="Runtime Status", font=TypeScale.h3()).pack(anchor="w", pady=(0, Spacing.SM))
+        CTkLabel(self.help_page, text="Runtime Status", font=TypeScale.h3()).pack(
+            anchor="w", pady=(0, Spacing.SM)
+        )
         status_frame = CTkFrame(self.help_page)
         status_frame.pack(fill="x", pady=(0, Spacing.LG))
 
-        self._help_version_label = CTkLabel(status_frame, text=f"Version: {self.VERSION}", font=TypeScale.body(), anchor="w")
+        self._help_version_label = CTkLabel(
+            status_frame,
+            text=f"Version: {self.VERSION}",
+            font=TypeScale.body(),
+            anchor="w",
+        )
         self._help_version_label.pack(anchor="w", padx=Spacing.LG, pady=Spacing.SM)
-        self._help_model_label = CTkLabel(status_frame, text="Model: —", font=TypeScale.body(), anchor="w")
+        self._help_model_label = CTkLabel(
+            status_frame, text="Model: —", font=TypeScale.body(), anchor="w"
+        )
         self._help_model_label.pack(anchor="w", padx=Spacing.LG)
-        self._help_gguf_path_label = CTkLabel(status_frame, text="GGUF Path: not configured", font=TypeScale.body(), anchor="w", text_color=ColorTokens.text_muted())
+        self._help_gguf_path_label = CTkLabel(
+            status_frame,
+            text="GGUF Path: not configured",
+            font=TypeScale.body(),
+            anchor="w",
+            text_color=ColorTokens.text_muted(),
+        )
         self._help_gguf_path_label.pack(anchor="w", padx=Spacing.LG)
-        self._help_db_path_label = CTkLabel(status_frame, text="Database: —", font=TypeScale.body(), anchor="w", text_color=ColorTokens.text_muted())
+        self._help_db_path_label = CTkLabel(
+            status_frame,
+            text="Database: —",
+            font=TypeScale.body(),
+            anchor="w",
+            text_color=ColorTokens.text_muted(),
+        )
         self._help_db_path_label.pack(anchor="w", padx=Spacing.LG)
-        self._help_log_path_label = CTkLabel(status_frame, text="Log: —", font=TypeScale.body(), anchor="w", text_color=ColorTokens.text_muted())
+        self._help_log_path_label = CTkLabel(
+            status_frame,
+            text="Log: —",
+            font=TypeScale.body(),
+            anchor="w",
+            text_color=ColorTokens.text_muted(),
+        )
         self._help_log_path_label.pack(anchor="w", padx=Spacing.LG)
-        self._help_doc_count_label = CTkLabel(status_frame, text="Documents: 0", font=TypeScale.body(), anchor="w")
-        self._help_doc_count_label.pack(anchor="w", padx=Spacing.LG, pady=(0, Spacing.SM))
+        self._help_doc_count_label = CTkLabel(
+            status_frame, text="Documents: 0", font=TypeScale.body(), anchor="w"
+        )
+        self._help_doc_count_label.pack(
+            anchor="w", padx=Spacing.LG, pady=(0, Spacing.SM)
+        )
 
         # Keyboard Shortcuts
-        CTkLabel(self.help_page, text="Keyboard Shortcuts", font=TypeScale.h3()).pack(anchor="w", pady=(0, Spacing.SM))
+        CTkLabel(self.help_page, text="Keyboard Shortcuts", font=TypeScale.h3()).pack(
+            anchor="w", pady=(0, Spacing.SM)
+        )
         shortcuts_frame = CTkFrame(self.help_page)
         shortcuts_frame.pack(fill="x", pady=(0, Spacing.LG))
         shortcuts = [
@@ -1112,12 +1420,23 @@ class DocumentQAApp(CTk):
         for key, desc in shortcuts:
             row = CTkFrame(shortcuts_frame, fg_color="transparent")
             row.pack(fill="x", padx=Spacing.LG, pady=Spacing.SM)
-            CTkLabel(row, text=key, font=TypeScale.body(), width=120, anchor="w",
-                     fg_color=ColorTokens.source_pill_bg(), corner_radius=4).pack(side="left", padx=(0, Spacing.MD))
-            CTkLabel(row, text=desc, font=TypeScale.body(), anchor="w").pack(side="left")
+            CTkLabel(
+                row,
+                text=key,
+                font=TypeScale.body(),
+                width=120,
+                anchor="w",
+                fg_color=ColorTokens.source_pill_bg(),
+                corner_radius=4,
+            ).pack(side="left", padx=(0, Spacing.MD))
+            CTkLabel(row, text=desc, font=TypeScale.body(), anchor="w").pack(
+                side="left"
+            )
 
         # Workflow
-        CTkLabel(self.help_page, text="Getting Started", font=TypeScale.h3()).pack(anchor="w", pady=(0, Spacing.SM))
+        CTkLabel(self.help_page, text="Getting Started", font=TypeScale.h3()).pack(
+            anchor="w", pady=(0, Spacing.SM)
+        )
         workflow_frame = CTkFrame(self.help_page)
         workflow_frame.pack(fill="x", pady=(0, Spacing.LG))
         steps = [
@@ -1127,8 +1446,13 @@ class DocumentQAApp(CTk):
             "4. Adjust Settings presets (Fast/Balanced/Quality) to tune performance",
         ]
         for step in steps:
-            CTkLabel(workflow_frame, text=step, font=TypeScale.body(), anchor="w",
-                     justify="left").pack(anchor="w", padx=Spacing.LG, pady=Spacing.SM)
+            CTkLabel(
+                workflow_frame,
+                text=step,
+                font=TypeScale.body(),
+                anchor="w",
+                justify="left",
+            ).pack(anchor="w", padx=Spacing.LG, pady=Spacing.SM)
 
     def _refresh_help_status(self):
         """Update runtime status labels on the Help page."""
@@ -1163,40 +1487,84 @@ class DocumentQAApp(CTk):
             self.documents_page.pack_forget()
             self.settings_page.pack_forget()
             self.help_page.pack_forget()
-            self.nav_chat_btn.configure(fg_color=ColorTokens.primary(), hover_color=ColorTokens.primary_hover())
-            self.nav_docs_btn.configure(fg_color=ColorTokens.secondary(), hover_color=ColorTokens.secondary_hover())
-            self.nav_settings_btn.configure(fg_color=ColorTokens.secondary(), hover_color=ColorTokens.secondary_hover())
-            self.nav_help_btn.configure(fg_color=ColorTokens.secondary(), hover_color=ColorTokens.secondary_hover())
+            self.nav_chat_btn.configure(
+                fg_color=ColorTokens.primary(), hover_color=ColorTokens.primary_hover()
+            )
+            self.nav_docs_btn.configure(
+                fg_color=ColorTokens.secondary(),
+                hover_color=ColorTokens.secondary_hover(),
+            )
+            self.nav_settings_btn.configure(
+                fg_color=ColorTokens.secondary(),
+                hover_color=ColorTokens.secondary_hover(),
+            )
+            self.nav_help_btn.configure(
+                fg_color=ColorTokens.secondary(),
+                hover_color=ColorTokens.secondary_hover(),
+            )
         elif page_name == "documents":
             self.chat_page.pack_forget()
             self.documents_page.pack(fill="both", expand=True)
             self.settings_page.pack_forget()
             self.help_page.pack_forget()
             self._refresh_documents_list()
-            self.nav_chat_btn.configure(fg_color=ColorTokens.secondary(), hover_color=ColorTokens.secondary_hover())
-            self.nav_docs_btn.configure(fg_color=ColorTokens.primary(), hover_color=ColorTokens.primary_hover())
-            self.nav_settings_btn.configure(fg_color=ColorTokens.secondary(), hover_color=ColorTokens.secondary_hover())
-            self.nav_help_btn.configure(fg_color=ColorTokens.secondary(), hover_color=ColorTokens.secondary_hover())
+            self.nav_chat_btn.configure(
+                fg_color=ColorTokens.secondary(),
+                hover_color=ColorTokens.secondary_hover(),
+            )
+            self.nav_docs_btn.configure(
+                fg_color=ColorTokens.primary(), hover_color=ColorTokens.primary_hover()
+            )
+            self.nav_settings_btn.configure(
+                fg_color=ColorTokens.secondary(),
+                hover_color=ColorTokens.secondary_hover(),
+            )
+            self.nav_help_btn.configure(
+                fg_color=ColorTokens.secondary(),
+                hover_color=ColorTokens.secondary_hover(),
+            )
         elif page_name == "settings":
             self.chat_page.pack_forget()
             self.documents_page.pack_forget()
             self.settings_page.pack(fill="both", expand=True)
             self.help_page.pack_forget()
             self._load_settings_into_form()
-            self.nav_chat_btn.configure(fg_color=ColorTokens.secondary(), hover_color=ColorTokens.secondary_hover())
-            self.nav_docs_btn.configure(fg_color=ColorTokens.secondary(), hover_color=ColorTokens.secondary_hover())
-            self.nav_settings_btn.configure(fg_color=ColorTokens.primary(), hover_color=ColorTokens.primary_hover())
-            self.nav_help_btn.configure(fg_color=ColorTokens.secondary(), hover_color=ColorTokens.secondary_hover())
+            self.nav_chat_btn.configure(
+                fg_color=ColorTokens.secondary(),
+                hover_color=ColorTokens.secondary_hover(),
+            )
+            self.nav_docs_btn.configure(
+                fg_color=ColorTokens.secondary(),
+                hover_color=ColorTokens.secondary_hover(),
+            )
+            self.nav_settings_btn.configure(
+                fg_color=ColorTokens.primary(), hover_color=ColorTokens.primary_hover()
+            )
+            self.nav_help_btn.configure(
+                fg_color=ColorTokens.secondary(),
+                hover_color=ColorTokens.secondary_hover(),
+            )
         elif page_name == "help":
             self.chat_page.pack_forget()
             self.documents_page.pack_forget()
             self.settings_page.pack_forget()
             self.help_page.pack(fill="both", expand=True)
             self._refresh_help_status()
-            self.nav_chat_btn.configure(fg_color=ColorTokens.secondary(), hover_color=ColorTokens.secondary_hover())
-            self.nav_docs_btn.configure(fg_color=ColorTokens.secondary(), hover_color=ColorTokens.secondary_hover())
-            self.nav_settings_btn.configure(fg_color=ColorTokens.secondary(), hover_color=ColorTokens.secondary_hover())
-            self.nav_help_btn.configure(fg_color=ColorTokens.primary(), hover_color=ColorTokens.primary_hover())
+            self.nav_chat_btn.configure(
+                fg_color=ColorTokens.secondary(),
+                hover_color=ColorTokens.secondary_hover(),
+            )
+            self.nav_docs_btn.configure(
+                fg_color=ColorTokens.secondary(),
+                hover_color=ColorTokens.secondary_hover(),
+            )
+            self.nav_settings_btn.configure(
+                fg_color=ColorTokens.secondary(),
+                hover_color=ColorTokens.secondary_hover(),
+            )
+            self.nav_help_btn.configure(
+                fg_color=ColorTokens.primary(), hover_color=ColorTokens.primary_hover()
+            )
 
     def _load_settings_into_form(self):
         """Load current settings into the inline settings form (all canonical fields)."""
@@ -1204,31 +1572,49 @@ class DocumentQAApp(CTk):
         entry_map = {
             self.settings_model_entry: s.get("gguf_path", ""),
             self.settings_db_path_entry: s.get("db_path", ""),
-            self.settings_chunk_size_entry: str(s.get("chunk_size", DEFAULT_CHUNK_SIZE)),
+            self.settings_chunk_size_entry: str(
+                s.get("chunk_size", DEFAULT_CHUNK_SIZE)
+            ),
             self.settings_chunk_overlap_entry: str(s.get("chunk_overlap", 100)),
             self.settings_n_results_entry: str(s.get("n_results", 4)),
             self.settings_min_similarity_entry: str(s.get("min_similarity", 0.3)),
             self.settings_retrieval_window_entry: str(s.get("retrieval_window", 1)),
-            self.settings_max_tokens_entry: str(s.get("max_tokens", DEFAULT_MAX_TOKENS)),
+            self.settings_max_tokens_entry: str(
+                s.get("max_tokens", DEFAULT_MAX_TOKENS)
+            ),
             self.settings_temperature_entry: str(s.get("temperature", 0.3)),
             self.settings_gguf_n_ctx_entry: str(s.get("gguf_n_ctx", 4096)),
-            self.settings_gguf_n_threads_entry: str(s.get("gguf_n_threads", 4)),
-            self.settings_initial_top_k_entry: str(s.get("initial_retrieval_top_k", 12)),
+            self.settings_gguf_n_threads_entry: str(
+                s.get("gguf_n_threads", _DEFAULT_GGUF_THREADS)
+            ),
+            self.settings_initial_top_k_entry: str(
+                s.get("initial_retrieval_top_k", 12)
+            ),
             self.settings_rerank_top_k_entry: str(s.get("rerank_top_k", 4)),
-            self.settings_context_truncation_entry: str(s.get("context_truncation", 20000)),
+            self.settings_context_truncation_entry: str(
+                s.get("context_truncation", 20000)
+            ),
         }
         for entry, value in entry_map.items():
             entry.delete(0, "end")
             entry.insert(0, value)
 
         # Read-only labels
-        self.settings_embedding_model_label.configure(text=s.get("embedding_model", "default"))
-        self.settings_reranker_model_label.configure(text=s.get("reranker_model", "default"))
+        self.settings_embedding_model_label.configure(
+            text=s.get("embedding_model", "default")
+        )
+        self.settings_reranker_model_label.configure(
+            text=s.get("reranker_model", "default")
+        )
 
         # Toggle switches — reranking defaults to False (minimum-hardware safe)
         self.settings_hybrid_var.set("on" if s.get("hybrid_search", True) else "off")
-        self.settings_reranking_var.set("on" if s.get("reranking_enabled", False) else "off")
-        self.settings_query_transform_var.set("on" if s.get("query_transformation_enabled", False) else "off")
+        self.settings_reranking_var.set(
+            "on" if s.get("reranking_enabled", False) else "off"
+        )
+        self.settings_query_transform_var.set(
+            "on" if s.get("query_transformation_enabled", False) else "off"
+        )
 
     def _browse_settings_model(self):
         """Browse for GGUF model in inline settings."""
@@ -1243,25 +1629,39 @@ class DocumentQAApp(CTk):
         """Populate settings form fields from a preset dict (does not save)."""
         s = preset
         entry_map = {
-            self.settings_chunk_size_entry: str(s.get("chunk_size", DEFAULT_CHUNK_SIZE)),
+            self.settings_chunk_size_entry: str(
+                s.get("chunk_size", DEFAULT_CHUNK_SIZE)
+            ),
             self.settings_chunk_overlap_entry: str(s.get("chunk_overlap", 100)),
             self.settings_n_results_entry: str(s.get("n_results", 4)),
             self.settings_min_similarity_entry: str(s.get("min_similarity", 0.3)),
             self.settings_retrieval_window_entry: str(s.get("retrieval_window", 1)),
-            self.settings_max_tokens_entry: str(s.get("max_tokens", DEFAULT_MAX_TOKENS)),
+            self.settings_max_tokens_entry: str(
+                s.get("max_tokens", DEFAULT_MAX_TOKENS)
+            ),
             self.settings_temperature_entry: str(s.get("temperature", 0.3)),
             self.settings_gguf_n_ctx_entry: str(s.get("gguf_n_ctx", 4096)),
-            self.settings_gguf_n_threads_entry: str(s.get("gguf_n_threads", 4)),
-            self.settings_initial_top_k_entry: str(s.get("initial_retrieval_top_k", 12)),
+            self.settings_gguf_n_threads_entry: str(
+                s.get("gguf_n_threads", _DEFAULT_GGUF_THREADS)
+            ),
+            self.settings_initial_top_k_entry: str(
+                s.get("initial_retrieval_top_k", 12)
+            ),
             self.settings_rerank_top_k_entry: str(s.get("rerank_top_k", 4)),
-            self.settings_context_truncation_entry: str(s.get("context_truncation", 20000)),
+            self.settings_context_truncation_entry: str(
+                s.get("context_truncation", 20000)
+            ),
         }
         for entry, value in entry_map.items():
             entry.delete(0, "end")
             entry.insert(0, value)
         self.settings_hybrid_var.set("on" if s.get("hybrid_search", False) else "off")
-        self.settings_reranking_var.set("on" if s.get("reranking_enabled", False) else "off")
-        self.settings_query_transform_var.set("on" if s.get("query_transformation_enabled", False) else "off")
+        self.settings_reranking_var.set(
+            "on" if s.get("reranking_enabled", False) else "off"
+        )
+        self.settings_query_transform_var.set(
+            "on" if s.get("query_transformation_enabled", False) else "off"
+        )
 
     def _browse_settings_db_path(self):
         """Browse for ChromaDB directory in inline settings."""
@@ -1281,10 +1681,14 @@ class DocumentQAApp(CTk):
             max_tokens = int(self.settings_max_tokens_entry.get() or DEFAULT_MAX_TOKENS)
             temperature = float(self.settings_temperature_entry.get() or 0.3)
             gguf_n_ctx = int(self.settings_gguf_n_ctx_entry.get() or 4096)
-            gguf_n_threads = int(self.settings_gguf_n_threads_entry.get() or 4)
+            gguf_n_threads = int(
+                self.settings_gguf_n_threads_entry.get() or _DEFAULT_GGUF_THREADS
+            )
             initial_top_k = int(self.settings_initial_top_k_entry.get() or 12)
             rerank_top_k = int(self.settings_rerank_top_k_entry.get() or 4)
-            context_truncation = int(self.settings_context_truncation_entry.get() or 20000)
+            context_truncation = int(
+                self.settings_context_truncation_entry.get() or 20000
+            )
         except ValueError as e:
             messagebox.showerror("Validation Error", f"Invalid numeric value: {e}")
             return
@@ -1318,32 +1722,39 @@ class DocumentQAApp(CTk):
             errors.append("Context Truncation must be 1000–500000")
 
         if errors:
-            messagebox.showerror("Validation Errors", "\n".join(f"• {e}" for e in errors))
+            messagebox.showerror(
+                "Validation Errors", "\n".join(f"• {e}" for e in errors)
+            )
             return
 
         prev_settings = dict(self.settings)
-        self.settings.update({
-            "gguf_path": self.settings_model_entry.get(),
-            "db_path": self.settings_db_path_entry.get(),
-            "chunk_size": chunk_size,
-            "chunk_overlap": chunk_overlap,
-            "n_results": n_results,
-            "min_similarity": min_similarity,
-            "retrieval_window": retrieval_window,
-            "max_tokens": max_tokens,
-            "temperature": temperature,
-            "hybrid_search": self.settings_hybrid_var.get() == "on",
-            "reranking_enabled": self.settings_reranking_var.get() == "on",
-            "query_transformation_enabled": self.settings_query_transform_var.get() == "on",
-            "gguf_n_ctx": gguf_n_ctx,
-            "gguf_n_threads": gguf_n_threads,
-            "initial_retrieval_top_k": initial_top_k,
-            "rerank_top_k": rerank_top_k,
-            "context_truncation": context_truncation,
-        })
+        self.settings.update(
+            {
+                "gguf_path": self.settings_model_entry.get(),
+                "db_path": self.settings_db_path_entry.get(),
+                "chunk_size": chunk_size,
+                "chunk_overlap": chunk_overlap,
+                "n_results": n_results,
+                "min_similarity": min_similarity,
+                "retrieval_window": retrieval_window,
+                "max_tokens": max_tokens,
+                "temperature": temperature,
+                "hybrid_search": self.settings_hybrid_var.get() == "on",
+                "reranking_enabled": self.settings_reranking_var.get() == "on",
+                "query_transformation_enabled": self.settings_query_transform_var.get()
+                == "on",
+                "gguf_n_ctx": gguf_n_ctx,
+                "gguf_n_threads": gguf_n_threads,
+                "initial_retrieval_top_k": initial_top_k,
+                "rerank_top_k": rerank_top_k,
+                "context_truncation": context_truncation,
+            }
+        )
         self._save_settings()
 
-        if messagebox.askyesno("Restart Required", "Settings changed. Restart the engine now?"):
+        if messagebox.askyesno(
+            "Restart Required", "Settings changed. Restart the engine now?"
+        ):
             self._prev_settings = prev_settings
             self._initialize_engine()
 
@@ -1355,8 +1766,9 @@ class DocumentQAApp(CTk):
 
         if not self.engine:
             CTkLabel(
-                self.documents_frame, text="Engine not initialized",
-                text_color=ColorTokens.text_muted()
+                self.documents_frame,
+                text="Engine not initialized",
+                text_color=ColorTokens.text_muted(),
             ).pack(pady=Spacing.LG)
             return
 
@@ -1364,8 +1776,9 @@ class DocumentQAApp(CTk):
             docs = self.engine.get_all_documents()
             if not docs:
                 CTkLabel(
-                    self.documents_frame, text="No documents loaded. Use 'Ingest Documents' to add files.",
-                    text_color=ColorTokens.text_muted()
+                    self.documents_frame,
+                    text="No documents loaded. Use 'Ingest Documents' to add files.",
+                    text_color=ColorTokens.text_muted(),
                 ).pack(pady=Spacing.LG)
                 return
 
@@ -1376,17 +1789,23 @@ class DocumentQAApp(CTk):
                 chunk_count = doc.get("chunk_count", doc.get("chunks", 0))
                 added_at = doc.get("added_at", "Unknown")
                 # Derive extension/type from source_path
-                ext = Path(source_path).suffix.upper().lstrip(".") if source_path else "?"
+                ext = (
+                    Path(source_path).suffix.upper().lstrip(".") if source_path else "?"
+                )
 
-                doc_frame = CTkFrame(self.documents_frame, fg_color=ColorTokens.bubble_system())
+                doc_frame = CTkFrame(
+                    self.documents_frame, fg_color=ColorTokens.bubble_system()
+                )
                 doc_frame.pack(fill="x", pady=Spacing.SM)
 
                 doc_info_frame = CTkFrame(doc_frame, fg_color="transparent")
                 doc_info_frame.pack(fill="x", padx=Spacing.LG, pady=(Spacing.SM, 0))
 
                 CTkLabel(
-                    doc_info_frame, text=f"📄  {display_name}",
-                    font=TypeScale.h3(), anchor="w"
+                    doc_info_frame,
+                    text=f"📄  {display_name}",
+                    font=TypeScale.h3(),
+                    anchor="w",
                 ).pack(anchor="w")
 
                 meta_parts = [f"{ext}", f"{chunk_count} chunks"]
@@ -1395,40 +1814,54 @@ class DocumentQAApp(CTk):
                 CTkLabel(
                     doc_info_frame,
                     text="  ·  ".join(meta_parts),
-                    font=TypeScale.small(), text_color=ColorTokens.text_muted()
+                    font=TypeScale.small(),
+                    text_color=ColorTokens.text_muted(),
                 ).pack(anchor="w")
 
                 if source_path:
                     CTkLabel(
-                        doc_info_frame, text=source_path,
-                        font=TypeScale.small(), text_color=ColorTokens.text_muted(), anchor="w"
+                        doc_info_frame,
+                        text=source_path,
+                        font=TypeScale.small(),
+                        text_color=ColorTokens.text_muted(),
+                        anchor="w",
                     ).pack(anchor="w", pady=(0, Spacing.SM))
 
                 action_row = CTkFrame(doc_info_frame, fg_color="transparent")
                 action_row.pack(anchor="w", pady=(Spacing.SM, Spacing.SM))
                 _make_button(
-                    action_row, text="Details", width=70,
-                    command=lambda dn=display_name, sp=source_path, cc=chunk_count, aa=added_at:
-                        messagebox.showinfo("Document Details",
-                            f"Name: {dn}\nPath: {sp}\nChunks: {cc}\nIndexed: {aa}"),
-                    fg_color=ColorTokens.secondary(), hover_color=ColorTokens.secondary_hover(),
-                    text_color=ColorTokens.text_on_secondary()
+                    action_row,
+                    text="Details",
+                    width=70,
+                    command=lambda dn=display_name, sp=source_path, cc=chunk_count, aa=added_at: messagebox.showinfo(  # noqa: E501
+                        "Document Details",
+                        f"Name: {dn}\nPath: {sp}\nChunks: {cc}\nIndexed: {aa}",
+                    ),
+                    fg_color=ColorTokens.secondary(),
+                    hover_color=ColorTokens.secondary_hover(),
+                    text_color=ColorTokens.text_on_secondary(),
                 ).pack(side="left", padx=(0, Spacing.SM))
                 _make_button(
-                    action_row, text="Delete", width=70,
-                    fg_color=ColorTokens.danger(), hover_color=ColorTokens.danger_hover(),
+                    action_row,
+                    text="Delete",
+                    width=70,
+                    fg_color=ColorTokens.danger(),
+                    hover_color=ColorTokens.danger_hover(),
                     text_color="#ffffff",
-                    command=lambda did=doc_id: self._delete_document(did)
+                    command=lambda did=doc_id: self._delete_document(did),
                 ).pack(side="left")
         except Exception as e:
             CTkLabel(
-                self.documents_frame, text=f"Error loading documents: {e}",
-                text_color=ColorTokens.danger()
+                self.documents_frame,
+                text=f"Error loading documents: {e}",
+                text_color=ColorTokens.danger(),
             ).pack(pady=Spacing.LG)
 
     def _delete_document(self, doc_id: str):
         """Delete a document from the database."""
-        if not messagebox.askyesno("Confirm Delete", "Are you sure you want to delete this document?"):
+        if not messagebox.askyesno(
+            "Confirm Delete", "Are you sure you want to delete this document?"
+        ):
             return
 
         if not self.engine:
@@ -1465,6 +1898,7 @@ class DocumentQAApp(CTk):
 
         def ingest():
             try:
+
                 def callback(msg, progress):
                     self.message_queue.put(("status", msg))
                     self.message_queue.put(("progress_show", progress))
@@ -1474,11 +1908,19 @@ class DocumentQAApp(CTk):
                 docs = result.get("documents", 0)
                 chunks = result.get("chunks_total", 0)
                 t = result.get("time_seconds", 0)
-                self.message_queue.put(("message", "system", f"✓ Ingested {docs} files ({chunks} chunks) in {t:.1f}s from {folder}"))
+                self.message_queue.put(
+                    (
+                        "message",
+                        "system",
+                        f"✓ Ingested {docs} files ({chunks} chunks) in {t:.1f}s from {folder}",
+                    )
+                )
                 stats = self.engine.get_stats()
                 self.message_queue.put(("doc_count", stats.get("document_count", 0)))
             except Exception as e:
-                self.message_queue.put(("message", "system", f"✗ Folder ingest failed: {e}"))
+                self.message_queue.put(
+                    ("message", "system", f"✗ Folder ingest failed: {e}")
+                )
             finally:
                 self._is_operation_active = False
                 self.message_queue.put(("cancel_button_hide",))
@@ -1489,8 +1931,10 @@ class DocumentQAApp(CTk):
 
     def _clear_all_documents(self):
         """Clear all documents from the database."""
-        if not messagebox.askyesno("Clear All Documents",
-                                   "This will delete ALL documents from the database. Continue?"):
+        if not messagebox.askyesno(
+            "Clear All Documents",
+            "This will delete ALL documents from the database. Continue?",
+        ):
             return
         if not self.engine:
             messagebox.showerror("Error", "Engine not initialized")
@@ -1499,11 +1943,15 @@ class DocumentQAApp(CTk):
             self.engine.clear_documents()
             self._refresh_documents_list()
             self.message_queue.put(("doc_count", 0))
-            messagebox.showinfo("Cleared", "All documents have been removed from the database.")
+            messagebox.showinfo(
+                "Cleared", "All documents have been removed from the database."
+            )
         except Exception as e:
             messagebox.showerror("Error", f"Failed to clear documents: {e}")
 
-    def _truncate_filename(self, filename: str, max_chars: int = _SOURCE_PILL_MAX_CHARS) -> str:
+    def _truncate_filename(
+        self, filename: str, max_chars: int = _SOURCE_PILL_MAX_CHARS
+    ) -> str:
         """Truncate filename to max_chars with ellipsis."""
         if len(filename) <= max_chars:
             return filename
@@ -1644,7 +2092,14 @@ class DocumentQAApp(CTk):
 
             self._expanded_pills[pill_key] = True
 
-    def _add_message(self, role: str, content: str, sources: list = None, timestamp: str = None, retrieved_chunks: list = None):
+    def _add_message(
+        self,
+        role: str,
+        content: str,
+        sources: list = None,
+        timestamp: str = None,
+        retrieved_chunks: list = None,
+    ):
         """Add a message to the chat area with role header and timestamp."""
         msg_frame = CTkFrame(self.chat_frame)
         msg_frame.pack(fill="x", pady=Spacing.SM, padx=Spacing.SM)
@@ -1687,11 +2142,13 @@ class DocumentQAApp(CTk):
         # Copy button for assistant messages
         if role == "assistant":
             copy_btn = _make_button(
-                msg_frame, text="Copy", width=60,
+                msg_frame,
+                text="Copy",
+                width=60,
                 command=lambda: self._copy_to_clipboard(content),
                 fg_color=ColorTokens.secondary(),
                 hover_color=ColorTokens.secondary_hover(),
-                text_color=ColorTokens.text_on_secondary()
+                text_color=ColorTokens.text_on_secondary(),
             )
             copy_btn.pack(anchor="w", padx=Spacing.LG, pady=(0, Spacing.SM))
 
@@ -1728,18 +2185,23 @@ class DocumentQAApp(CTk):
                 expanded_state[0] = True
 
         expander_label = CTkLabel(
-            expander_frame, text="Show Retrieved Chunks",
+            expander_frame,
+            text="Show Retrieved Chunks",
             font=TypeScale.small(),
             text_color=ColorTokens.primary(),
-            cursor="hand2"
+            cursor="hand2",
         )
         expander_label.pack(anchor="w")
         expander_label.bind("<Button-1>", lambda e: toggle_expander())
 
-        chunks_frame = CTkFrame(parent, fg_color=ColorTokens.bubble_system(), corner_radius=Spacing.SM)
+        chunks_frame = CTkFrame(
+            parent, fg_color=ColorTokens.bubble_system(), corner_radius=Spacing.SM
+        )
 
         for i, chunk in enumerate(chunks[:5], 1):  # Show first 5 chunks
-            chunk_text = chunk.get("text", "") if isinstance(chunk, dict) else str(chunk)
+            chunk_text = (
+                chunk.get("text", "") if isinstance(chunk, dict) else str(chunk)
+            )
             CTkLabel(
                 chunks_frame,
                 text=f"Chunk {i}: {chunk_text[:100]}...",
@@ -1747,7 +2209,7 @@ class DocumentQAApp(CTk):
                 text_color=ColorTokens.text_muted(),
                 justify="left",
                 anchor="w",
-                wraplength=400
+                wraplength=400,
             ).pack(fill="x", padx=Spacing.LG, pady=Spacing.SM)
 
     def _copy_to_clipboard(self, text: str):
@@ -1786,25 +2248,35 @@ class DocumentQAApp(CTk):
         center.place(relx=0.5, rely=0.5, anchor="center")
 
         CTkLabel(center, text="📄", font=(FONT_FAMILY, 48)).pack(pady=(0, Spacing.MD))
-        CTkLabel(center, text="No documents yet", font=TypeScale.h2()).pack(pady=(0, Spacing.SM))
+        CTkLabel(center, text="No documents yet", font=TypeScale.h2()).pack(
+            pady=(0, Spacing.SM)
+        )
         CTkLabel(
             center,
             text="Get started by adding documents, then ask questions about their content.",
-            font=TypeScale.body(), text_color=ColorTokens.text_muted(),
-            justify="center", wraplength=400,
+            font=TypeScale.body(),
+            text_color=ColorTokens.text_muted(),
+            justify="center",
+            wraplength=400,
         ).pack(pady=(0, Spacing.XXL))
 
         _make_button(
-            center, text="📂  Add Documents",
+            center,
+            text="📂  Add Documents",
             command=self._ingest_documents,
-            fg_color=ColorTokens.primary(), hover_color=ColorTokens.primary_hover(),
-            text_color=ColorTokens.text_on_primary(), width=200,
+            fg_color=ColorTokens.primary(),
+            hover_color=ColorTokens.primary_hover(),
+            text_color=ColorTokens.text_on_primary(),
+            width=200,
         ).pack(pady=(0, Spacing.SM))
         _make_button(
-            center, text="Open Documents Page",
+            center,
+            text="Open Documents Page",
             command=lambda: self._switch_page("documents"),
-            fg_color="transparent", text_color=ColorTokens.primary(),
-            hover_color=ColorTokens.bubble_system(), width=200,
+            fg_color="transparent",
+            text_color=ColorTokens.primary(),
+            hover_color=ColorTokens.bubble_system(),
+            width=200,
         ).pack()
 
     def _create_empty_state(self):
@@ -1865,9 +2337,7 @@ class DocumentQAApp(CTk):
             hover_color=ColorTokens.danger_hover(),
             text_color="#ffffff",
         )
-        self._clear_confirm_timer = self.after(
-            3000, self._revert_clear_button
-        )
+        self._clear_confirm_timer = self.after(3000, self._revert_clear_button)
 
     def _revert_clear_button(self):
         """Revert clear button from confirm-pending back to normal state."""
@@ -1933,9 +2403,15 @@ class DocumentQAApp(CTk):
                 while not self._message_processor_shutdown:
                     # DD-004: Validate message tuple structure before processing
                     msg = self.message_queue.get_nowait()
-                    if not isinstance(msg, tuple) or len(msg) < 1 or not isinstance(msg[0], str):
+                    if (
+                        not isinstance(msg, tuple)
+                        or len(msg) < 1
+                        or not isinstance(msg[0], str)
+                    ):
                         # Log and skip malformed messages to prevent crashes
-                        logging.getLogger("app_gui").warning(f"Skipping malformed message: {type(msg).__name__}")
+                        logging.getLogger("app_gui").warning(
+                            f"Skipping malformed message: {type(msg).__name__}"
+                        )
                         continue
                     if msg[0] == "status":
                         if self.winfo_exists() and hasattr(self, "status_label"):
@@ -1956,15 +2432,17 @@ class DocumentQAApp(CTk):
                         if self.winfo_exists():
                             self._hide_progress()
                     elif msg[0] == "progress_clear_delayed":
-                        # Clears the progress indicator after a short delay so the user briefly sees the final state. Runs on the main thread via the message queue — safe to call Tk/widget APIs here (not from worker threads).
+                        # Clears the progress indicator after a short delay so the user briefly sees the final state. Runs on the main thread via the message queue — safe to call Tk/widget APIs here (not from worker threads).  # noqa: E501
                         if self.winfo_exists():
                             self.after(3000, lambda: self._hide_progress())
                     elif msg[0] == "cancel_button_show":
-                        # Shows the cancel button (packs it) so the user can interrupt an in-progress operation. Runs on the main thread via the message queue — safe to call Tk/widget APIs here (not from worker threads).
+                        # Shows the cancel button (packs it) so the user can interrupt an in-progress operation. Runs on the main thread via the message queue — safe to call Tk/widget APIs here (not from worker threads).  # noqa: E501
                         if self.winfo_exists() and hasattr(self, "cancel_button"):
-                            self.cancel_button.pack(fill="x", padx=Spacing.LG, pady=(0, Spacing.SM))
+                            self.cancel_button.pack(
+                                fill="x", padx=Spacing.LG, pady=(0, Spacing.SM)
+                            )
                     elif msg[0] == "cancel_button_hide":
-                        # Hides the cancel button (pack_forget) once the operation completes or is no longer cancellable. Runs on the main thread via the message queue — safe to call Tk/widget APIs here (not from worker threads).
+                        # Hides the cancel button (pack_forget) once the operation completes or is no longer cancellable. Runs on the main thread via the message queue — safe to call Tk/widget APIs here (not from worker threads).  # noqa: E501
                         if self.winfo_exists() and hasattr(self, "cancel_button"):
                             self.cancel_button.pack_forget()
                     elif msg[0] == "assistant_token":
@@ -1995,15 +2473,19 @@ class DocumentQAApp(CTk):
                             if hasattr(self, "question_entry"):
                                 self.question_entry.configure(state="normal")
                     elif msg[0] == "hide_typing":
-                        # Hides the typing-indicator animation when a response finishes or is cancelled. Runs on the main thread via the message queue — safe to call Tk/widget APIs here (not from worker threads).
+                        # Hides the typing-indicator animation when a response finishes or is cancelled. Runs on the main thread via the message queue — safe to call Tk/widget APIs here (not from worker threads).  # noqa: E501
                         if self.winfo_exists():
                             self._hide_typing_indicator()
                     elif msg[0] == "stream_end":
-                        self._finalize_streaming_message(self._get_streaming_text(), destroy_frame=True)
+                        self._finalize_streaming_message(
+                            self._get_streaming_text(), destroy_frame=True
+                        )
                     elif msg[0] == "stream_destroy":
-                        self._finalize_streaming_message(self._get_streaming_text(), destroy_frame=True)
+                        self._finalize_streaming_message(
+                            self._get_streaming_text(), destroy_frame=True
+                        )
                     elif msg[0] == "model_label":
-                        # Updates the model status label text (e.g. loaded model name/size). Runs on the main thread via the message queue — safe to call Tk/widget APIs here (not from worker threads).
+                        # Updates the model status label text (e.g. loaded model name/size). Runs on the main thread via the message queue — safe to call Tk/widget APIs here (not from worker threads).  # noqa: E501
                         if self.winfo_exists() and hasattr(self, "model_label"):
                             self.model_label.configure(text=msg[1])
             except queue.Empty:
@@ -2022,12 +2504,19 @@ class DocumentQAApp(CTk):
                 logging.getLogger("app_gui").debug(f"Failed to get streaming text: {e}")
         return ""
 
-    def _finalize_streaming_message(self, accumulated_text: str, destroy_frame: bool = True) -> None:
+    def _finalize_streaming_message(
+        self, accumulated_text: str, destroy_frame: bool = True
+    ) -> None:
         """Finalize and persist a streaming assistant message, then optionally destroy the frame."""
         if not accumulated_text:
             return
         try:
-            self._add_message("assistant", accumulated_text, sources=None, timestamp=datetime.now().strftime("%H:%M"))
+            self._add_message(
+                "assistant",
+                accumulated_text,
+                sources=None,
+                timestamp=datetime.now().strftime("%H:%M"),
+            )
         except Exception as e:
             logging.getLogger("app_gui").error(f"Failed to add message to chat: {e}")
         if destroy_frame and self._streaming_message_frame is not None:
@@ -2035,7 +2524,9 @@ class DocumentQAApp(CTk):
                 if self._streaming_message_frame.winfo_exists():
                     self._streaming_message_frame.destroy()
             except Exception as e:
-                logging.getLogger("app_gui").debug(f"Failed to destroy streaming frame: {e}")
+                logging.getLogger("app_gui").debug(
+                    f"Failed to destroy streaming frame: {e}"
+                )
             self._streaming_message_ref = None
             self._streaming_message_frame = None
         self._streaming_finalized = True
@@ -2050,14 +2541,21 @@ class DocumentQAApp(CTk):
             try:
                 self.message_queue.put(("status", "Initializing RAG engine..."))
                 self.message_queue.put(("progress", 20))
-                self.message_queue.put(("progress_label", "20% — Initializing RAG engine..."))
+                self.message_queue.put(
+                    ("progress_label", "20% — Initializing RAG engine...")
+                )
 
-                if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
+                if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
                     torch_lib = os.path.join(sys._MEIPASS, "torch", "lib")
-                    logger.debug("Frozen mode detected, torch_lib exists=%s", os.path.isdir(torch_lib))
+                    logger.debug(
+                        "Frozen mode detected, torch_lib exists=%s",
+                        os.path.isdir(torch_lib),
+                    )
                     if os.path.isdir(torch_lib):
                         os.add_dll_directory(torch_lib)
-                        os.environ["PATH"] = torch_lib + os.pathsep + os.environ.get("PATH", "")
+                        os.environ["PATH"] = (
+                            torch_lib + os.pathsep + os.environ.get("PATH", "")
+                        )
                         logger.debug("torch DLL directory added to search path")
 
                 if self._operation_cancelled.is_set():
@@ -2072,20 +2570,26 @@ class DocumentQAApp(CTk):
                 except Exception as engine_error:
                     logger.error("Failed to initialize RAG engine: %s", engine_error)
                     # Rollback to previous settings if available
-                    if hasattr(self, "_prev_settings") and self._prev_settings is not None:
+                    if (
+                        hasattr(self, "_prev_settings")
+                        and self._prev_settings is not None
+                    ):
                         self.settings = self._prev_settings
                         self._prev_settings = None
                         self._save_settings()
                     self.message_queue.put(("status", "Engine initialization failed"))
-                    self.message_queue.put((
-                        "message", "system",
-                        f"Failed to initialize RAG engine: {engine_error}\n\n"
-                        "Please check:\n"
-                        "1. GGUF model path is correct in Settings\n\n"
-                        "Go to Settings to configure.",
-                        None,
-                        datetime.now().strftime("%H:%M"),
-                    ))
+                    self.message_queue.put(
+                        (
+                            "message",
+                            "system",
+                            f"Failed to initialize RAG engine: {engine_error}\n\n"
+                            "Please check:\n"
+                            "1. GGUF model path is correct in Settings\n\n"
+                            "Go to Settings to configure.",
+                            None,
+                            datetime.now().strftime("%H:%M"),
+                        )
+                    )
                     self._operation_cancelled.clear()
                     self._is_operation_active = False
                     self.message_queue.put(("cancel_button_hide",))
@@ -2097,7 +2601,9 @@ class DocumentQAApp(CTk):
 
                 self.message_queue.put(("doc_count", doc_count))
                 self.message_queue.put(("progress", 100))
-                self.message_queue.put(("progress_label", "80% — Engine ready, loading stats..."))
+                self.message_queue.put(
+                    ("progress_label", "80% — Engine ready, loading stats...")
+                )
 
                 backend = "No LLM"
                 model_name = ""
@@ -2107,7 +2613,9 @@ class DocumentQAApp(CTk):
                     model_name = info.get("model", "")
 
                 if model_name:
-                    self.message_queue.put(("status", f"Ready ({backend} / {model_name})"))
+                    self.message_queue.put(
+                        ("status", f"Ready ({backend} / {model_name})")
+                    )
                 else:
                     self.message_queue.put(("status", f"Ready ({backend})"))
                 self.message_queue.put(("progress_label", "100% — Ready"))
@@ -2124,7 +2632,9 @@ class DocumentQAApp(CTk):
                         file_size = os.path.getsize(gguf_path)
                         size_mb = file_size / (1024 * 1024)
                         filename = os.path.basename(gguf_path)
-                        self.message_queue.put(("model_label", f"Model: {filename} ({size_mb:.1f}MB)"))
+                        self.message_queue.put(
+                            ("model_label", f"Model: {filename} ({size_mb:.1f}MB)")
+                        )
                     except Exception as e:
                         logger.warning(
                             "Could not read model file info for %s: %s", gguf_path, e
@@ -2162,7 +2672,9 @@ class DocumentQAApp(CTk):
             return
         self._hide_typing_indicator()
 
-        self._typing_frame = CTkFrame(self.chat_frame, fg_color=ColorTokens.bubble_system())
+        self._typing_frame = CTkFrame(
+            self.chat_frame, fg_color=ColorTokens.bubble_system()
+        )
         self._typing_frame.pack(fill="x", pady=Spacing.SM, padx=Spacing.SM)
 
         self._typing_label = CTkLabel(
@@ -2190,7 +2702,10 @@ class DocumentQAApp(CTk):
 
     def _hide_typing_indicator(self):
         """Hide inline typing indicator and destroy its frame."""
-        if hasattr(self, "_typing_animation_id") and self._typing_animation_id is not None:
+        if (
+            hasattr(self, "_typing_animation_id")
+            and self._typing_animation_id is not None
+        ):
             self.after_cancel(self._typing_animation_id)
             self._typing_animation_id = None
         if hasattr(self, "_typing_frame") and self._typing_frame.winfo_exists():
@@ -2202,11 +2717,11 @@ class DocumentQAApp(CTk):
 
     def _handle_streaming_token(self, token: str):
         """Handle a streaming token from the LLM.
-        
+
         Creates a new assistant message on first token, then appends subsequent
         tokens to the message content label. All UI updates happen on the main
         thread via this method being called from the message processor.
-        
+
         Args:
             token: The token text to append to the current message.
         """
@@ -2215,11 +2730,13 @@ class DocumentQAApp(CTk):
             return
         if self._streaming_finalized:
             return
-        
+
         if self._streaming_message_ref is None:
             # First token — create the assistant message structure
             self._streaming_message_frame = CTkFrame(self.chat_frame)
-            self._streaming_message_frame.pack(fill="x", pady=Spacing.SM, padx=Spacing.SM)
+            self._streaming_message_frame.pack(
+                fill="x", pady=Spacing.SM, padx=Spacing.SM
+            )
 
             bg_color = ColorTokens.bubble_assistant()
             self._streaming_message_frame.configure(fg_color=bg_color)
@@ -2263,7 +2780,7 @@ class DocumentQAApp(CTk):
         if self._is_operation_active:
             if not messagebox.askyesno(
                 "Confirm Close",
-                "An operation is still running. Are you sure you want to close?"
+                "An operation is still running. Are you sure you want to close?",
             ):
                 return
         self._cancel_clear_confirm()
@@ -2347,28 +2864,62 @@ class DocumentQAApp(CTk):
                     self.message_queue.put(("progress_label", f"{progress}% — {msg}"))
 
                 for i, file_path in enumerate(files, 1):
-                    callback(f"Processing file {i} of {len(files)}: {os.path.basename(file_path)}", int((i / len(files)) * 100))
+                    callback(
+                        f"Processing file {i} of {len(files)}: {os.path.basename(file_path)}",
+                        int((i / len(files)) * 100),
+                    )
 
                     try:
                         source_name = os.path.basename(file_path)
-                        file_stats = self.engine.ingest_file(file_path, source_name=source_name)
+                        file_stats = self.engine.ingest_file(
+                            file_path, source_name=source_name
+                        )
                         if file_stats.get("success"):
                             total_documents += 1
                             total_chunks_added += file_stats.get("chunks_added", 0)
                             total_time_seconds += file_stats.get("time_seconds", 0)
                         else:
-                            failed_files.append((file_path, ValueError(file_stats.get("message", "No content extracted"))))
+                            failed_files.append(
+                                (
+                                    file_path,
+                                    ValueError(
+                                        file_stats.get(
+                                            "message", "No content extracted"
+                                        )
+                                    ),
+                                )
+                            )
                             self.message_queue.put(
-                                ("message", "system", f"Failed to ingest {os.path.basename(file_path)}: {file_stats.get('message', 'No content extracted')}", None, datetime.now().strftime("%H:%M"))
+                                (
+                                    "message",
+                                    "system",
+                                    f"Failed to ingest {os.path.basename(file_path)}: {file_stats.get('message', 'No content extracted')}",  # noqa: E501
+                                    None,
+                                    datetime.now().strftime("%H:%M"),
+                                )
                             )
                     except Exception as file_error:
                         failed_files.append((file_path, file_error))
                         self.message_queue.put(
-                            ("message", "system", f"Failed to ingest {os.path.basename(file_path)}: {file_error}", None, datetime.now().strftime("%H:%M"))
+                            (
+                                "message",
+                                "system",
+                                f"Failed to ingest {os.path.basename(file_path)}: {file_error}",
+                                None,
+                                datetime.now().strftime("%H:%M"),
+                            )
                         )
 
                     if self._operation_cancelled.is_set():
-                        self.message_queue.put(("message", "system", "Ingest cancelled by user.", None, datetime.now().strftime("%H:%M")))
+                        self.message_queue.put(
+                            (
+                                "message",
+                                "system",
+                                "Ingest cancelled by user.",
+                                None,
+                                datetime.now().strftime("%H:%M"),
+                            )
+                        )
                         self.message_queue.put(("progress_clear",))
                         self._operation_cancelled.clear()
                         self._is_operation_active = False
@@ -2421,7 +2972,15 @@ class DocumentQAApp(CTk):
 
             except Exception as e:
                 self.message_queue.put(("status", f"Error: {e}"))
-                self.message_queue.put(("message", "system", _classify_error(e, "ingest"), None, datetime.now().strftime("%H:%M")))
+                self.message_queue.put(
+                    (
+                        "message",
+                        "system",
+                        _classify_error(e, "ingest"),
+                        None,
+                        datetime.now().strftime("%H:%M"),
+                    )
+                )
                 self.message_queue.put(("enable_input", True))
                 self._operation_cancelled.clear()
                 self._is_operation_active = False
@@ -2462,7 +3021,15 @@ class DocumentQAApp(CTk):
                 self.engine._ensure_llm()
                 if not self.engine.llm:
                     # Queue error to run on main thread
-                    self.message_queue.put(("message", "system", "No LLM backend available. Check Settings.", None, datetime.now().strftime("%H:%M")))
+                    self.message_queue.put(
+                        (
+                            "message",
+                            "system",
+                            "No LLM backend available. Check Settings.",
+                            None,
+                            datetime.now().strftime("%H:%M"),
+                        )
+                    )
                     self.message_queue.put(("enable_input", True))
                     self.message_queue.put(("hide_typing",))
                     return
@@ -2472,7 +3039,7 @@ class DocumentQAApp(CTk):
                     question,
                     conversation_history=self.conversation_history,
                     stream_callback=on_token,
-                    cancellation_event=self._operation_cancelled
+                    cancellation_event=self._operation_cancelled,
                 )
 
                 if self._operation_cancelled.is_set():
@@ -2491,14 +3058,15 @@ class DocumentQAApp(CTk):
                 if self._streaming_message_ref is not None:
                     self.message_queue.put(("stream_end",))
 
-                # FR-002.3: Only append to conversation_history on successful (non-cancelled, non-empty) query result
+                # FR-002.3: Only append to conversation_history on successful (non-cancelled, non-empty) query result  # noqa: E501
                 if result.answer and result.answer != "[Cancelled]":
-                    self.conversation_history.append({"role": "user", "content": question})
+                    self.conversation_history.append(
+                        {"role": "user", "content": question}
+                    )
                     self.conversation_history.append(
                         {"role": "assistant", "content": result.answer}
                     )
                     self.conversation_history = self.conversation_history[-20:]
-
 
                 self.message_queue.put(
                     ("status", f"Ready ({result.inference_time:.1f}s)")
@@ -2510,10 +3078,18 @@ class DocumentQAApp(CTk):
                 self.message_queue.put(("hide_typing",))
 
             except Exception as e:
-                # Queue stream_destroy to run on main thread — preserves partial content via _add_message
+                # Queue stream_destroy to run on main thread — preserves partial content via _add_message  # noqa: E501
                 self.message_queue.put(("stream_destroy",))
                 self.message_queue.put(("status", f"Error: {e}"))
-                self.message_queue.put(("message", "system", _classify_error(e, "query"), None, datetime.now().strftime("%H:%M")))
+                self.message_queue.put(
+                    (
+                        "message",
+                        "system",
+                        _classify_error(e, "query"),
+                        None,
+                        datetime.now().strftime("%H:%M"),
+                    )
+                )
                 self.message_queue.put(("enable_input", True))
                 self._operation_cancelled.clear()
                 self._is_operation_active = False

--- a/app_gui.py
+++ b/app_gui.py
@@ -53,8 +53,9 @@ from config import (
 )
 from theme import FONT_FAMILY, ColorTokens, Spacing, TypeScale
 
-# Dynamic default (all CPUs up to 8), evaluated at import so the presets below
-# always match the config default on the machine running the app.
+# Dynamic default (all CPUs up to 8), evaluated at import so the Fast and
+# Balanced presets below always match the config default on the machine
+# running the app. Quality intentionally pins the 8-thread cap (issue #53).
 _DEFAULT_GGUF_THREADS = default_gguf_threads()
 
 # Canonical default values for UI presets (minimum-hardware safe)
@@ -320,11 +321,8 @@ def _classify_error(err: Exception, operation: str) -> str:
         if "Insufficient RAM" in msg:
             # A backend IS configured; the machine refused the load. Relay the
             # real numbers instead of the misdirecting "configure a backend".
-            return (
-                "Not enough free memory to load the model. "
-                + msg
-                + " Close other applications, or set RAG_FAST_PROFILE_PATH to a smaller model."
-            )
+            # msg itself ends with the remediation advice, so nothing appended.
+            return "Not enough free memory to load the model. " + msg
         if "timeout" in msg.lower():
             return "Request timed out. Try reducing Max Tokens in Settings."
         if "token" in msg.lower() and (

--- a/config.py
+++ b/config.py
@@ -5,11 +5,11 @@ Provides centralized configuration management with validation,
 type coercion, and environment variable support.
 """
 
+import os
 import threading
 
 from pydantic import AliasChoices, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
-
 
 # Chunk size constraints
 MIN_CHUNK_SIZE = 128
@@ -19,7 +19,18 @@ DEFAULT_CHUNK_SIZE = 512
 # Max tokens constraints
 MIN_MAX_TOKENS = 256
 MAX_MAX_TOKENS = 4096
-DEFAULT_MAX_TOKENS = 512  # matches RAGConfig/RAGSettings defaults for minimum-hardware targets
+DEFAULT_MAX_TOKENS = (
+    512  # matches RAGConfig/RAGSettings defaults for minimum-hardware targets
+)
+
+
+def default_gguf_threads() -> int:
+    """Default GGUF inference threads: all CPUs up to a sane cap of 8.
+
+    Single source of truth for every thread-default site (config, RAGConfig,
+    GUI presets, engine_factory) so they cannot drift apart.
+    """
+    return min(os.cpu_count() or 4, 8)
 
 
 class RAGSettings(BaseSettings):
@@ -29,35 +40,63 @@ class RAGSettings(BaseSettings):
     rag_db_path: str = Field(default="./doc_qa_db", validation_alias="RAG_DB_PATH")
 
     # Chunking settings
-    rag_chunk_size: int = Field(default=DEFAULT_CHUNK_SIZE, validation_alias="RAG_CHUNK_SIZE")
+    rag_chunk_size: int = Field(
+        default=DEFAULT_CHUNK_SIZE, validation_alias="RAG_CHUNK_SIZE"
+    )
     rag_chunk_overlap: int = Field(default=100, validation_alias="RAG_CHUNK_OVERLAP")
 
     # Retrieval settings
     rag_n_results: int = Field(default=4, validation_alias="RAG_N_RESULTS")
-    rag_min_similarity: float = Field(default=0.3, validation_alias="RAG_MIN_SIMILARITY")
-    rag_retrieval_window: int = Field(default=1, validation_alias="RAG_RETRIEVAL_WINDOW")
+    rag_min_similarity: float = Field(
+        default=0.3, validation_alias="RAG_MIN_SIMILARITY"
+    )
+    rag_retrieval_window: int = Field(
+        default=1, validation_alias="RAG_RETRIEVAL_WINDOW"
+    )
 
     # LLM settings
     rag_max_tokens: int = Field(default=512, validation_alias="RAG_MAX_TOKENS")
     rag_temperature: float = Field(default=0.3, validation_alias="RAG_TEMPERATURE")
 
     # Model settings
-    rag_embedding_model: str = Field(default="BAAI/bge-small-en-v1.5", validation_alias="RAG_EMBEDDING_MODEL")
+    rag_embedding_model: str = Field(
+        default="BAAI/bge-small-en-v1.5", validation_alias="RAG_EMBEDDING_MODEL"
+    )
     rag_hybrid_search: bool = Field(default=True, validation_alias="RAG_HYBRID_SEARCH")
-    rag_reranking_enabled: bool = Field(default=False, validation_alias="RAG_RERANKING_ENABLED")
-    rag_reranker_model: str = Field(default="cross-encoder/ms-marco-MiniLM-L6-v2", validation_alias="RAG_RERANKER_MODEL")
+    rag_reranking_enabled: bool = Field(
+        default=False, validation_alias="RAG_RERANKING_ENABLED"
+    )
+    rag_reranker_model: str = Field(
+        default="cross-encoder/ms-marco-MiniLM-L6-v2",
+        validation_alias="RAG_RERANKER_MODEL",
+    )
 
     # Context truncation settings
-    rag_context_truncation: int = Field(default=20000, validation_alias="RAG_CONTEXT_TRUNCATION")
-    rag_initial_retrieval_top_k: int = Field(default=12, validation_alias="RAG_INITIAL_RETRIEVAL_TOP_K")
+    rag_context_truncation: int = Field(
+        default=20000, validation_alias="RAG_CONTEXT_TRUNCATION"
+    )
+    rag_initial_retrieval_top_k: int = Field(
+        default=12, validation_alias="RAG_INITIAL_RETRIEVAL_TOP_K"
+    )
     rag_rerank_top_k: int = Field(default=4, validation_alias="RAG_RERANK_TOP_K")
 
     # GGUF model settings
-    rag_gguf_n_ctx: int = Field(default=4096, validation_alias=AliasChoices("rag_gguf_n_ctx", "RAG_GGUF_N_CTX"))
-    rag_gguf_n_threads: int = Field(default=4, validation_alias=AliasChoices("rag_gguf_n_threads", "RAG_GGUF_N_THREADS"))
+    rag_gguf_n_ctx: int = Field(
+        default=4096, validation_alias=AliasChoices("rag_gguf_n_ctx", "RAG_GGUF_N_CTX")
+    )
+    rag_gguf_n_threads: int = Field(
+        default_factory=default_gguf_threads,
+        validation_alias=AliasChoices("rag_gguf_n_threads", "RAG_GGUF_N_THREADS"),
+    )
+    rag_fast_profile_path: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("rag_fast_profile_path", "RAG_FAST_PROFILE_PATH"),
+    )
 
     # CORS settings
-    rag_cors_origins: str = Field(default="http://localhost,http://127.0.0.1", validation_alias="RAG_CORS_ORIGINS")
+    rag_cors_origins: str = Field(
+        default="http://localhost,http://127.0.0.1", validation_alias="RAG_CORS_ORIGINS"
+    )
 
     model_config = SettingsConfigDict(
         env_prefix="RAG_",
@@ -78,7 +117,9 @@ class RAGSettings(BaseSettings):
     def validate_chunk_size(cls, v):
         """Validate chunk_size is within valid range."""
         if not MIN_CHUNK_SIZE <= v <= MAX_CHUNK_SIZE:
-            raise ValueError(f"RAG_CHUNK_SIZE must be between {MIN_CHUNK_SIZE} and {MAX_CHUNK_SIZE}, got {v}")
+            raise ValueError(
+                f"RAG_CHUNK_SIZE must be between {MIN_CHUNK_SIZE} and {MAX_CHUNK_SIZE}, got {v}"
+            )
         return v
 
     @field_validator("rag_chunk_overlap")
@@ -99,7 +140,9 @@ class RAGSettings(BaseSettings):
     def validate_max_tokens(cls, v):
         """Validate max_tokens is within valid range."""
         if not MIN_MAX_TOKENS <= v <= MAX_MAX_TOKENS:
-            raise ValueError(f"RAG_MAX_TOKENS must be between {MIN_MAX_TOKENS} and {MAX_MAX_TOKENS}, got {v}")
+            raise ValueError(
+                f"RAG_MAX_TOKENS must be between {MIN_MAX_TOKENS} and {MAX_MAX_TOKENS}, got {v}"
+            )
         return v
 
     @field_validator("rag_temperature")
@@ -130,7 +173,7 @@ _settings_lock = threading.RLock()
 
 def get_settings() -> RAGSettings:
     """Lazily get or create the global settings instance with thread-safe initialization.
-    
+
     Uses RLock for reentrancy safety - single thread can acquire lock multiple times.
     """
     global _settings
@@ -155,7 +198,7 @@ class _SettingsProxy:
 
     def __setattr__(self, name, value):
         # Private attrs (starting with '_') are set on the proxy itself
-        if name.startswith('_'):
+        if name.startswith("_"):
             object.__setattr__(self, name, value)
         else:
             setattr(get_settings(), name, value)

--- a/contracts/api.openapi.yaml
+++ b/contracts/api.openapi.yaml
@@ -105,7 +105,7 @@ paths:
         "500":
           description: Processing error
         "503":
-          description: Engine not initialized / no LLM backend
+          description: Engine not initialized / no LLM backend (detail carries the model-load diagnostic when available)
   /ask/stream:
     post:
       tags: [ask]
@@ -137,7 +137,7 @@ paths:
         "422":
           description: Request validation failed
         "503":
-          description: Engine not initialized / no LLM backend
+          description: Engine not initialized / no LLM backend (detail carries the model-load diagnostic when available)
   /ingest:
     post:
       tags: [ingest]

--- a/engine_factory.py
+++ b/engine_factory.py
@@ -1,13 +1,12 @@
 """Unified engine factory for consistent RAGEngine construction across all entry points."""
 
-from typing import Optional, Dict, Any, TYPE_CHECKING
-from pathlib import Path
-from config import DEFAULT_MAX_TOKENS
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from app_paths import get_bundled_model_path
+from config import default_gguf_threads
 
 if TYPE_CHECKING:
-    from rag_engine import RAGEngine, RAGConfig
+    from rag_engine import RAGConfig, RAGEngine
 
 
 # Cache for lazy-loaded RAGEngine and RAGConfig classes
@@ -18,7 +17,8 @@ def _get_rag_classes():
     """Lazy import RAGEngine and RAGConfig with caching to avoid circular dependencies."""
     global _rag_classes_cache
     if _rag_classes_cache is None:
-        from rag_engine import RAGEngine, RAGConfig
+        from rag_engine import RAGConfig, RAGEngine
+
         _rag_classes_cache = (RAGEngine, RAGConfig)
     return _rag_classes_cache
 
@@ -138,7 +138,8 @@ def create_engine_from_settings(settings: Dict[str, Any]) -> "RAGEngine":
         context_truncation=_get("context_truncation", 20000),
         query_transformation_enabled=_get("query_transformation_enabled", False),
         gguf_n_ctx=_get("gguf_n_ctx", 4096),
-        gguf_n_threads=_get("gguf_n_threads", 4),
+        gguf_n_threads=_get("gguf_n_threads", default_gguf_threads()),
+        fast_profile_path=_get("fast_profile_path"),
     )
 
     return create_engine(
@@ -173,6 +174,7 @@ def create_engine_from_env() -> "RAGEngine":
         Configured RAGEngine instance
     """
     import os
+
     RAGEngine, RAGConfig = _get_rag_classes()
 
     # Helper function to parse boolean from env var
@@ -198,10 +200,13 @@ def create_engine_from_env() -> "RAGEngine":
         reranking_enabled=settings.rag_reranking_enabled,
         initial_retrieval_top_k=getattr(settings, "rag_initial_retrieval_top_k", 12),
         rerank_top_k=getattr(settings, "rag_rerank_top_k", 4),
-        reranker_model=getattr(settings, "rag_reranker_model", "cross-encoder/ms-marco-MiniLM-L6-v2"),
+        reranker_model=getattr(
+            settings, "rag_reranker_model", "cross-encoder/ms-marco-MiniLM-L6-v2"
+        ),
         context_truncation=settings.rag_context_truncation,
         gguf_n_ctx=getattr(settings, "rag_gguf_n_ctx", 4096),
-        gguf_n_threads=getattr(settings, "rag_gguf_n_threads", 4),
+        gguf_n_threads=getattr(settings, "rag_gguf_n_threads", default_gguf_threads()),
+        fast_profile_path=getattr(settings, "rag_fast_profile_path", None),
     )
 
     # Get GGUF path from env var or bundled model

--- a/llm_interface.py
+++ b/llm_interface.py
@@ -493,7 +493,16 @@ class SmartLLM:
         # Requirement = model file (mmap'd weights) + KV cache + runtime
         # overhead; the old flat 4x-file-size factor refused the bundled
         # ~3.1 GB model on 16 GB laptops with 8-11 GB free.
-        file_size = Path(model_path).stat().st_size
+        try:
+            file_size = Path(model_path).stat().st_size
+        except OSError as e:
+            # stat() can race with an external delete/move; wrap it like any
+            # other load failure so no raw OS error text reaches the user.
+            raise RuntimeError(
+                f"No GGUF backend available: loading GGUF model "
+                f"'{os.path.basename(model_path)}' failed: "
+                f"{_sanitize_error(str(e))}"
+            ) from e
         required = estimate_required_memory(file_size, n_ctx)
         available = psutil.virtual_memory().available
         if available < required:
@@ -515,9 +524,13 @@ class SmartLLM:
                 verbose=verbose,
             )
         except Exception as e:
+            # Sanitize the cause: backend constructors can embed absolute
+            # paths/username in their messages, and this text is relayed
+            # verbatim into GUI errors and API 503 details.
             raise RuntimeError(
                 f"No GGUF backend available: loading GGUF model "
-                f"'{os.path.basename(model_path)}' failed: {e}"
+                f"'{os.path.basename(model_path)}' failed: "
+                f"{_sanitize_error(str(e))}"
             ) from e
 
     def generate(self, prompt: str, config: Optional[InferenceConfig] = None) -> str:

--- a/llm_interface.py
+++ b/llm_interface.py
@@ -3,16 +3,16 @@ LLM Interface Module
 Provides unified interface for LLM inference using GGUF models only.
 """
 
+import logging
 import os
 import re
-import json
-import logging
-import psutil
 import threading
-from typing import Optional, Dict, Any, List, Callable
-from dataclasses import dataclass
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+import psutil
 
 logger = logging.getLogger(__name__)
 
@@ -20,9 +20,33 @@ logger = logging.getLogger(__name__)
 MAX_RESPONSE_SIZE = 10 * 1024 * 1024  # 10MB
 MAX_PROMPT_LENGTH = 24000  # was 16384; safe for 8192-token models with max_tokens=1024
 
+# Memory-budget constants (issue #53). The old flat "4x file size" heuristic
+# refused the bundled ~3.1 GB GGUF on 16 GB laptops with 8-11 GB free; the
+# realistic load requirement is the model file plus KV cache plus runtime
+# overhead. kv_estimate is a conservative constant pending measured
+# per-architecture numbers from the #52 benchmark harness.
+GGUF_KV_CACHE_ESTIMATE_BYTES = 1024**3  # 1 GiB conservative KV-cache allowance
+GGUF_LOAD_OVERHEAD_BYTES = 1024**3  # 1 GiB allocator/runtime overhead
+
+
+def kv_estimate(n_ctx: int) -> int:
+    """Estimate KV-cache memory for a context window.
+
+    Conservative constant for now; n_ctx is part of the signature so a
+    per-architecture formula can replace the constant without changing
+    callers.
+    """
+    return GGUF_KV_CACHE_ESTIMATE_BYTES
+
+
+def estimate_required_memory(file_size: int, n_ctx: int) -> int:
+    """Estimate free RAM needed to load a GGUF model of the given file size."""
+    return file_size + kv_estimate(n_ctx) + GGUF_LOAD_OVERHEAD_BYTES
+
 
 class QueryCancelled(Exception):
     """Raised when a user cancels an ongoing query."""
+
     pass
 
 
@@ -148,12 +172,19 @@ class GGUFBackend(BaseLLM):
         # Detect Qwen3 model for /no_think suppression and chat template use
         self.is_qwen3 = "qwen3" in self.model_path.name.lower()
         if self.is_qwen3:
-            logger.info("[OK] Qwen3 model detected — thinking mode suppressed via /no_think")
+            logger.info(
+                "[OK] Qwen3 model detected — thinking mode suppressed via /no_think"
+            )
 
         # Detect Gemma 4 model for <|think|> stop token suppression
-        self.is_gemma4 = "gemma-4" in self.model_path.name.lower() or "gemma_4" in self.model_path.name.lower()
+        self.is_gemma4 = (
+            "gemma-4" in self.model_path.name.lower()
+            or "gemma_4" in self.model_path.name.lower()
+        )
         if self.is_gemma4:
-            logger.info("[OK] Gemma 4 model detected — thinking mode suppressed via stop token")
+            logger.info(
+                "[OK] Gemma 4 model detected — thinking mode suppressed via stop token"
+            )
 
     def generate(
         self,
@@ -328,7 +359,9 @@ class GGUFBackend(BaseLLM):
                 message = choices[0].get("message") or {}
                 raw = message.get("content", "") or ""
                 # Strip think-tag blocks that Qwen3 may emit despite /no_think
-                cleaned = re.sub(r"<think>.*?</think>", "", raw, flags=re.DOTALL).strip()
+                cleaned = re.sub(
+                    r"<think>.*?</think>", "", raw, flags=re.DOTALL
+                ).strip()
                 return cleaned
         except Exception as e:
             # Preserve cancellation exceptions without wrapping
@@ -355,11 +388,14 @@ class RAGPromptBuilder:
         "You are a precise document assistant. "
         "Answer using ONLY the context supplied. "
         "If the context lacks the answer, respond exactly: "
-        '"I don\'t have enough information to answer that question based on the available documents." '
+        "\"I don't have enough information to answer that question "
+        'based on the available documents." '
         "Rules: "
         "(1) No speculation or information from outside the provided context. "
-        "(2) Include ALL relevant steps and details from the context — do not truncate or abbreviate. "
-        "(3) Use numbered lists for multi-step procedures; use bullet points for feature or option lists. "
+        "(2) Include ALL relevant steps and details from the context "
+        "— do not truncate or abbreviate. "
+        "(3) Use numbered lists for multi-step procedures; "
+        "use bullet points for feature or option lists. "
         "(4) Cite the source filename in brackets after relevant statements, e.g. [report.pdf]. "
         "(5) If multiple documents contain conflicting information, present all perspectives. "
         "(6) If the context contains a partial procedure, present all visible steps and note "
@@ -393,35 +429,96 @@ class SmartLLM:
         gguf_n_ctx: int = 8192,
         gguf_n_threads: Optional[int] = None,
         gguf_verbose: bool = False,
+        fast_profile_path: Optional[str] = None,
     ):
         self.backend: GGUFBackend = None
         self.prompt_builder = RAGPromptBuilder()
 
         if gguf_path and Path(gguf_path).exists():
-            # Memory budget check: verify sufficient RAM before attempting load
-            # GGUF/llama.cpp models need ~2x file size (weights + KV cache); use 4x safety factor for large context windows
-            file_size = Path(gguf_path).stat().st_size
-            required = int(file_size * 4)
-            available = psutil.virtual_memory().available
-            if available < required:
-                raise RuntimeError(
-                    f"Insufficient RAM to load GGUF model: need ~{required / (1024**3):.1f}GB "
-                    f"({required / file_size:.1f}x model file size for weights, KV cache, and overhead), "
-                    f"but only {available / (1024**3):.1f}GB available. "
-                    f"Close other applications or use a smaller model."
-                )
             try:
-                self.backend = GGUFBackend(
-                    gguf_path=gguf_path,
-                    n_ctx=gguf_n_ctx,
-                    n_threads=gguf_n_threads,
-                    verbose=gguf_verbose,
+                self.backend = self._load_backend(
+                    gguf_path, gguf_n_ctx, gguf_n_threads, gguf_verbose
                 )
-            except Exception as e:
-                logger.warning("GGUF backend initialization failed: %s", e)
+            except RuntimeError as primary_error:
+                # Only a RAM-gate refusal can be answered by a smaller
+                # fast-profile model; other load failures (corrupt file,
+                # missing llama-cpp) propagate immediately.
+                is_gate_refusal = "Insufficient RAM" in str(primary_error)
+                if not (is_gate_refusal and fast_profile_path):
+                    raise
+                if Path(fast_profile_path).exists():
+                    logger.info(
+                        "[WARN] Primary model refused by RAM gate; trying "
+                        "fast-profile fallback: %s",
+                        fast_profile_path,
+                    )
+                    try:
+                        self.backend = self._load_backend(
+                            fast_profile_path,
+                            gguf_n_ctx,
+                            gguf_n_threads,
+                            gguf_verbose,
+                        )
+                    except RuntimeError as fallback_error:
+                        raise RuntimeError(
+                            f"{primary_error} Fast-profile fallback "
+                            f"'{os.path.basename(fast_profile_path)}' also "
+                            f"failed: {fallback_error}"
+                        ) from fallback_error
+                else:
+                    logger.warning(
+                        "[WARN] Fast-profile model not found: %s",
+                        fast_profile_path,
+                    )
+                    raise
 
         if not self.backend:
             raise RuntimeError("No GGUF backend available. Provide a valid gguf_path.")
+
+    @staticmethod
+    def _load_backend(
+        model_path: str,
+        n_ctx: int,
+        n_threads: Optional[int],
+        verbose: bool,
+    ) -> GGUFBackend:
+        """Run the RAM gate for one model file, then construct its backend.
+
+        Raises RuntimeError naming the model file, the required and available
+        memory when the gate refuses; backend construction failures are
+        wrapped (keeping the established "No GGUF backend available" marker)
+        instead of being silently swallowed.
+        """
+        # Memory budget check: verify sufficient RAM before attempting load.
+        # Requirement = model file (mmap'd weights) + KV cache + runtime
+        # overhead; the old flat 4x-file-size factor refused the bundled
+        # ~3.1 GB model on 16 GB laptops with 8-11 GB free.
+        file_size = Path(model_path).stat().st_size
+        required = estimate_required_memory(file_size, n_ctx)
+        available = psutil.virtual_memory().available
+        if available < required:
+            raise RuntimeError(
+                f"Insufficient RAM to load GGUF model "
+                f"'{os.path.basename(model_path)}': "
+                f"need ~{required / (1024**3):.1f}GB "
+                f"(model file + ~{GGUF_KV_CACHE_ESTIMATE_BYTES / (1024**3):.0f}GB "
+                f"KV cache + ~{GGUF_LOAD_OVERHEAD_BYTES / (1024**3):.0f}GB overhead), "
+                f"but only {available / (1024**3):.1f}GB available. "
+                f"Close other applications, use a smaller model, or set "
+                f"RAG_FAST_PROFILE_PATH to a smaller model."
+            )
+        try:
+            return GGUFBackend(
+                gguf_path=model_path,
+                n_ctx=n_ctx,
+                n_threads=n_threads,
+                verbose=verbose,
+            )
+        except Exception as e:
+            raise RuntimeError(
+                f"No GGUF backend available: loading GGUF model "
+                f"'{os.path.basename(model_path)}' failed: {e}"
+            ) from e
 
     def generate(self, prompt: str, config: Optional[InferenceConfig] = None) -> str:
         """Generate a response using the GGUF backend."""
@@ -510,7 +607,12 @@ class SmartLLM:
                 raise
             # Fall back to generate() — no history_prefix since it was already in chat_complete
             prompt = self.prompt_builder.build_prompt(question, context, sources)
-            return self.backend.generate(prompt, config, stream_callback=stream_callback, cancellation_event=cancellation_event)
+            return self.backend.generate(
+                prompt,
+                config,
+                stream_callback=stream_callback,
+                cancellation_event=cancellation_event,
+            )
 
     def get_info(self) -> Dict[str, Any]:
         """Get backend information."""

--- a/rag_engine.py
+++ b/rag_engine.py
@@ -3,27 +3,27 @@ RAG Engine Module
 Combines document processing, vector store, and LLM for question answering.
 """
 
-import os
-import sys
 import json
-import time
-import threading
-from typing import Optional, List, Dict, Any, Tuple, Callable
-from pathlib import Path
-from dataclasses import dataclass
-import app_paths
 import logging
+import os
 import re
-from llm_interface import QueryCancelled
+import sys
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+import app_paths
+from config import default_gguf_threads
+from document_processor import DocumentProcessor
+from llm_interface import InferenceConfig, QueryCancelled, SmartLLM
+from vector_store import VectorStore
 
 logger = logging.getLogger(__name__)
 
 # Maximum characters of context to pass to LLM (~1 500 tokens within GGUF n_ctx budget)
 # Configurable via RAG_CONTEXT_TRUNCATION environment variable, defaults to 6000
-
-from document_processor import DocumentProcessor
-from vector_store import VectorStore
-from llm_interface import SmartLLM, InferenceConfig
 
 
 def _truncate_at_sentence(text: str, max_chars: int) -> str:
@@ -32,12 +32,12 @@ def _truncate_at_sentence(text: str, max_chars: int) -> str:
         return text
     # Scan backwards from cutoff for sentence boundary
     for i in range(max_chars - 1, max(0, max_chars - 300), -1):
-        if text[i] in {'.', '!', '?'}:
-            if i + 1 >= len(text) or text[i + 1] in {' ', '\n', '\t'}:
-                return text[:i + 1].strip()
+        if text[i] in {".", "!", "?"}:
+            if i + 1 >= len(text) or text[i + 1] in {" ", "\n", "\t"}:
+                return text[: i + 1].strip()
     # Fallback: word boundary
     for i in range(max_chars - 1, max(0, max_chars - 100), -1):
-        if text[i] == ' ':
+        if text[i] == " ":
             return text[:i].strip()
     return text[:max_chars].strip()
 
@@ -77,9 +77,12 @@ class RAGConfig:
         rerank_top_k: int = 4,
         context_truncation: int = 20000,
         gguf_n_ctx: int = 4096,
-        gguf_n_threads: int = 4,
+        gguf_n_threads: Optional[int] = None,
+        fast_profile_path: Optional[str] = None,
     ):
-        self.db_path = db_path if db_path is not None else str(app_paths.get_vector_db_path())
+        self.db_path = (
+            db_path if db_path is not None else str(app_paths.get_vector_db_path())
+        )
         self.chunk_size = chunk_size
         self.chunk_overlap = chunk_overlap
         self.n_results = n_results
@@ -96,7 +99,10 @@ class RAGConfig:
         self.rerank_top_k = rerank_top_k
         self.context_truncation = context_truncation
         self.gguf_n_ctx = gguf_n_ctx
-        self.gguf_n_threads = gguf_n_threads
+        self.gguf_n_threads = (
+            gguf_n_threads if gguf_n_threads is not None else default_gguf_threads()
+        )
+        self.fast_profile_path = fast_profile_path
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -118,6 +124,7 @@ class RAGConfig:
             "context_truncation": self.context_truncation,
             "gguf_n_ctx": self.gguf_n_ctx,
             "gguf_n_threads": self.gguf_n_threads,
+            "fast_profile_path": self.fast_profile_path,
         }
 
     @classmethod
@@ -145,7 +152,8 @@ class RAGConfig:
             rerank_top_k=data.get("rerank_top_k", 4),
             context_truncation=data.get("context_truncation", 20000),
             gguf_n_ctx=data.get("gguf_n_ctx", 4096),
-            gguf_n_threads=data.get("gguf_n_threads", 4),
+            gguf_n_threads=data.get("gguf_n_threads", default_gguf_threads()),
+            fast_profile_path=data.get("fast_profile_path"),
         )
 
 
@@ -184,6 +192,9 @@ class RAGEngine:
         )
 
         self.llm: Optional[SmartLLM] = None
+        # Diagnostic from the most recent failed lazy LLM init; surfaced to the
+        # GUI and the API 503 detail instead of a generic "not initialized".
+        self.llm_init_error: Optional[str] = None
         # LLM will be lazily initialized on first query() call
 
         # Lazy-init reranker only when reranking is enabled
@@ -201,9 +212,18 @@ class RAGEngine:
         """Initialize LLM with GGUF model only."""
         try:
             # Use root SmartLLM which auto-detects GGUF model
-            self.llm = SmartLLM(gguf_path=gguf_path, gguf_n_ctx=self.config.gguf_n_ctx, gguf_n_threads=self.config.gguf_n_threads)
+            self.llm = SmartLLM(
+                gguf_path=gguf_path,
+                gguf_n_ctx=self.config.gguf_n_ctx,
+                gguf_n_threads=self.config.gguf_n_threads,
+                fast_profile_path=getattr(self.config, "fast_profile_path", None),
+            )
+            self.llm_init_error = None
             logger.info("[OK] LLM initialized: %s", self.llm.get_info()["backend"])
         except Exception as e:
+            # Retain the real failure (RAM numbers, model name) for the GUI
+            # error message and the API 503 detail instead of discarding it.
+            self.llm_init_error = str(e)
             logger.warning("[WARN] LLM not available: %s", e)
             logger.info("  RAG engine will work for document ingestion only.")
             self.llm = None
@@ -215,15 +235,26 @@ class RAGEngine:
 
     def _ensure_query_transformer(self):
         """Lazily initialize QueryTransformer once."""
-        if self._query_transformer is None and not self._query_transformer_failed and self.config.query_transformation_enabled and self.llm:
+        if (
+            self._query_transformer is None
+            and not self._query_transformer_failed
+            and self.config.query_transformation_enabled
+            and self.llm
+        ):
             with self._init_lock:
-                if self._query_transformer is None and not self._query_transformer_failed:  # Double-check
+                if (
+                    self._query_transformer is None
+                    and not self._query_transformer_failed
+                ):  # Double-check
                     try:
                         from query_transformer import QueryTransformer
+
                         self._query_transformer = QueryTransformer(self.llm)
                     except Exception as e:
                         logger.warning("QueryTransformer init failed: %s", e)
-                        self._query_transformer_failed = True  # Mark as failed to avoid retry
+                        self._query_transformer_failed = (
+                            True  # Mark as failed to avoid retry
+                        )
 
     def _save_config(self):
         """Save configuration to database directory."""
@@ -232,7 +263,9 @@ class RAGEngine:
             with open(config_path, "w") as f:
                 json.dump(self.config.to_dict(), f, indent=2)
         except Exception as e:
-            logger.error("Failed to save configuration to %s: %s", self.config.db_path, e)
+            logger.error(
+                "Failed to save configuration to %s: %s", self.config.db_path, e
+            )
 
     def ingest_directory(self, directory: str, callback=None) -> Dict[str, Any]:
         """
@@ -335,8 +368,12 @@ class RAGEngine:
         """
         # Lazily initialize LLM on first query
         self._ensure_llm()
-        
+
         if not self.llm:
+            # Surface the real load diagnostic (RAM numbers, model name) that
+            # _init_llm recorded instead of a bare "not initialized" message.
+            if self.llm_init_error:
+                raise RuntimeError(f"LLM not initialized: {self.llm_init_error}")
             raise RuntimeError("LLM not initialized. Cannot answer questions.")
 
         start_time = time.time()
@@ -364,7 +401,9 @@ class RAGEngine:
             try:
                 retrieval_query = self._query_transformer.transform_step_back(question)
             except Exception as e:
-                logger.warning("Query transformation failed, using original query: %s", e)
+                logger.warning(
+                    "Query transformation failed, using original query: %s", e
+                )
                 retrieval_query = question
         else:
             retrieval_query = question
@@ -390,7 +429,10 @@ class RAGEngine:
                     question,
                     "",
                     [],
-                    config=InferenceConfig(max_tokens=self.config.max_tokens, temperature=self.config.temperature),
+                    config=InferenceConfig(
+                        max_tokens=self.config.max_tokens,
+                        temperature=self.config.temperature,
+                    ),
                     conversation_history=conversation_history,
                     stream_callback=stream_callback,
                     cancellation_event=cancellation_event,
@@ -422,7 +464,9 @@ class RAGEngine:
                 (
                     m.get("content", "")
                     for m in reversed(conversation_history)
-                    if isinstance(m, dict) and m.get("role") == "user" and m.get("content", "").strip()
+                    if isinstance(m, dict)
+                    and m.get("role") == "user"
+                    and m.get("content", "").strip()
                 ),
                 None,
             )
@@ -431,28 +475,46 @@ class RAGEngine:
                 should_combine = False
 
                 # Pattern 1: Pronoun/anaphora references
-                anaphora_pattern = r'\b(it|this|that|these|those|the above|the previous)\b'
+                anaphora_pattern = (
+                    r"\b(it|this|that|these|those|the above|the previous)\b"
+                )
                 if re.search(anaphora_pattern, question_lower):
                     should_combine = True
 
                 # Pattern 2: Very short non-wh questions
                 if len(question.split()) <= 4:
-                    wh_words = {'what', 'who', 'when', 'where', 'which', 'how', 'why'}
+                    wh_words = {"what", "who", "when", "where", "which", "how", "why"}
                     if not any(question_lower.startswith(w) for w in wh_words):
                         should_combine = True
 
                 # Pattern 3: Continuation keywords
                 followup_words = {
-                    'more', 'elaborate', 'detail', 'explain', 'expand', 'further',
-                    'also', 'another', 'compare', 'difference', 'versus', 'vs',
-                    'similar', 'unlike', 'elaborate', 'deeper',
+                    "more",
+                    "elaborate",
+                    "detail",
+                    "explain",
+                    "expand",
+                    "further",
+                    "also",
+                    "another",
+                    "compare",
+                    "difference",
+                    "versus",
+                    "vs",
+                    "similar",
+                    "unlike",
+                    "elaborate",
+                    "deeper",
                 }
                 if any(w in question_lower.split() for w in followup_words):
                     should_combine = True
 
                 if should_combine:
                     retrieval_query = f"{last_user_msg} {question}"
-                    logger.info("Follow-up detected — retrieval query: '%s'", retrieval_query[:80])
+                    logger.info(
+                        "Follow-up detected — retrieval query: '%s'",
+                        retrieval_query[:80],
+                    )
 
         # Will be populated by whichever retrieval path runs
         final_chunks_with_scores: List[Tuple[Any, Optional[float]]] = []
@@ -477,7 +539,9 @@ class RAGEngine:
                 inference_time=time.time() - start_time,
                 chunks_retrieved=0,
             )
-        effective_top_k = n_results if n_results is not None else self.config.rerank_top_k
+        effective_top_k = (
+            n_results if n_results is not None else self.config.rerank_top_k
+        )
 
         # Guard against effective_top_k <= 0
         if effective_top_k <= 0:
@@ -495,6 +559,7 @@ class RAGEngine:
             if self.reranker is None:
                 try:
                     from reranking import CrossEncoderReranker
+
                     self.reranker = CrossEncoderReranker(self.config.reranker_model)
                 except Exception as e:
                     logger.warning("Reranker initialization failed: %s", e)
@@ -505,22 +570,30 @@ class RAGEngine:
             reranked = None
             if rerank_chunks and self.reranker is not None:
                 try:
-                    reranked = self.reranker.rerank(question, rerank_chunks, top_k=effective_top_k)
+                    reranked = self.reranker.rerank(
+                        question, rerank_chunks, top_k=effective_top_k
+                    )
                 except Exception as rerank_err:
-                    logger.warning("Reranking failed, falling back to top-k: %s", rerank_err)
+                    logger.warning(
+                        "Reranking failed, falling back to top-k: %s", rerank_err
+                    )
                     reranked = None
 
             if reranked is not None:
                 # Reranker ran — if it returned nothing, build scored fallback with 0.0
                 if not reranked:
-                    reranked = [(chunk, 0.0) for chunk in rerank_chunks[:effective_top_k]]
+                    reranked = [
+                        (chunk, 0.0) for chunk in rerank_chunks[:effective_top_k]
+                    ]
                 context = "\n\n---\n\n".join(chunk.text for chunk, _ in reranked)
                 sources = list(dict.fromkeys(chunk.source for chunk, _ in reranked))
                 chunks_retrieved = len(reranked)
                 final_chunks_with_scores = [(chunk, score) for chunk, score in reranked]
             else:
                 # Reranker unavailable (init/rerank failed) or no chunks — top-k fallback
-                fallback_top_k = n_results if n_results is not None else self.config.n_results
+                fallback_top_k = (
+                    n_results if n_results is not None else self.config.n_results
+                )
                 if fallback_top_k <= 0:
                     fallback_top_k = 1
                 fallback = rerank_chunks[:fallback_top_k]
@@ -529,7 +602,6 @@ class RAGEngine:
                     sources = list(dict.fromkeys(chunk.source for chunk in fallback))
                 chunks_retrieved = len(fallback)
                 final_chunks_with_scores = [(chunk, None) for chunk in fallback]
-
 
         else:
             # Non-reranking path: truncate to n_results or config.n_results
@@ -577,7 +649,10 @@ class RAGEngine:
                 )
             return QueryResult(
                 question=question,
-                answer="I couldn't find any relevant information in the documents to answer your question.",
+                answer=(
+                    "I couldn't find any relevant information in the "
+                    "documents to answer your question."
+                ),
                 sources=[],
                 context_length=0,
                 inference_time=time.time() - start_time,
@@ -605,7 +680,10 @@ class RAGEngine:
                 question=question,
                 context=safe_context,
                 sources=sources,
-                config=InferenceConfig(max_tokens=self.config.max_tokens, temperature=self.config.temperature),
+                config=InferenceConfig(
+                    max_tokens=self.config.max_tokens,
+                    temperature=self.config.temperature,
+                ),
                 conversation_history=conversation_history,
                 stream_callback=stream_callback,
                 cancellation_event=cancellation_event,
@@ -623,8 +701,9 @@ class RAGEngine:
                 )
             raise
 
+        # Post-process: if the LLM says it can't find information but chunks
+        # were retrieved, provide a helpful fallback
 
-        # Post-process: if LLM says it can't find information but we retrieved chunks, provide helpful fallback
         fallback_phrases = [
             "i could not find this information",
             "i couldn't find any relevant information",
@@ -640,9 +719,12 @@ class RAGEngine:
             chunk_count = stats.get("chunk_count", 0)
 
             answer = (
-                f"I retrieved {len(sources)} relevant document(s) but couldn't find specific information to answer '{question}'. "
-                f"The database contains {doc_count} documents with {chunk_count} chunks total. "
-                f"Try asking a more specific question about the content of these documents: {', '.join(sources[:3])}"
+                f"I retrieved {len(sources)} relevant document(s) but couldn't "
+                f"find specific information to answer '{question}'. "
+                f"The database contains {doc_count} documents with "
+                f"{chunk_count} chunks total. "
+                f"Try asking a more specific question about the content "
+                f"of these documents: {', '.join(sources[:3])}"
             )
 
         chunk_details = [
@@ -720,8 +802,6 @@ class RAGEngine:
 
 
 if __name__ == "__main__":
-    import sys
-
     engine = RAGEngine()
 
     if len(sys.argv) > 1:

--- a/tests/regression/test_remediation_fixes.py
+++ b/tests/regression/test_remediation_fixes.py
@@ -4,13 +4,12 @@ Each test class maps to one numbered fix. Tests are designed to fail on the
 old code and pass on the fixed code, proving the bug was real and is now gone.
 """
 
-import hashlib
 import inspect
 import os
 import sys
 import tempfile
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -21,9 +20,10 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 # FIX 1: Canonical settings schema — rag_* prefixed keys must be consumed
 # ---------------------------------------------------------------------------
 
+
 def _build_config_from_settings(settings: dict):
-    """Helper: call create_engine_from_settings with a mocked RAGEngine and return the RAGConfig used."""
-    from rag_engine import RAGConfig
+    """Helper: call create_engine_from_settings with a mocked
+    RAGEngine and return the RAGConfig used."""
     import engine_factory
 
     captured_config = {}
@@ -50,13 +50,15 @@ class TestFix1CanonicalSettingsSchema:
 
     def test_rag_chunk_overlap_key_consumed(self):
         """Saving as 'rag_chunk_overlap' (GUI style) must produce correct RAGConfig."""
-        config = _build_config_from_settings({
-            "chunk_size": 512,
-            "rag_chunk_overlap": 250,
-        })
-        assert config.chunk_overlap == 250, (
-            "chunk_overlap from rag_-prefixed key was silently ignored — key mismatch bug"
+        config = _build_config_from_settings(
+            {
+                "chunk_size": 512,
+                "rag_chunk_overlap": 250,
+            }
         )
+        assert (
+            config.chunk_overlap == 250
+        ), "chunk_overlap from rag_-prefixed key was silently ignored — key mismatch bug"
 
     def test_rag_min_similarity_key_consumed(self):
         config = _build_config_from_settings({"rag_min_similarity": 0.7})
@@ -72,11 +74,15 @@ class TestFix1CanonicalSettingsSchema:
 
     def test_canonical_key_takes_precedence_over_legacy(self):
         """When both canonical and rag_-prefixed key are present, canonical wins."""
-        config = _build_config_from_settings({
-            "chunk_overlap": 100,
-            "rag_chunk_overlap": 999,
-        })
-        assert config.chunk_overlap == 100, "Canonical key must take precedence over rag_-prefixed"
+        config = _build_config_from_settings(
+            {
+                "chunk_overlap": 100,
+                "rag_chunk_overlap": 999,
+            }
+        )
+        assert (
+            config.chunk_overlap == 100
+        ), "Canonical key must take precedence over rag_-prefixed"
 
     def test_query_transformation_enabled_wired(self):
         config = _build_config_from_settings({"query_transformation_enabled": True})
@@ -99,40 +105,47 @@ class TestFix1CanonicalSettingsSchema:
 # FIX 2: context_truncation in RAGConfig
 # ---------------------------------------------------------------------------
 
+
 class TestFix2ContextTruncationInRAGConfig:
     """context_truncation must be a first-class RAGConfig field."""
 
     def test_ragconfig_has_context_truncation_param(self):
         from rag_engine import RAGConfig
+
         sig = inspect.signature(RAGConfig.__init__)
-        assert "context_truncation" in sig.parameters, (
-            "RAGConfig must accept context_truncation — it was formerly read from global settings"
-        )
+        assert (
+            "context_truncation" in sig.parameters
+        ), "RAGConfig must accept context_truncation — it was formerly read from global settings"
 
     def test_ragconfig_context_truncation_default_is_20000(self):
         from rag_engine import RAGConfig
+
         c = RAGConfig()
         assert c.context_truncation == 20000
 
     def test_ragconfig_context_truncation_custom_value(self):
         from rag_engine import RAGConfig
+
         c = RAGConfig(context_truncation=5000)
         assert c.context_truncation == 5000
 
     def test_ragconfig_to_dict_includes_context_truncation(self):
         from rag_engine import RAGConfig
+
         d = RAGConfig(context_truncation=7777).to_dict()
         assert "context_truncation" in d
         assert d["context_truncation"] == 7777
 
     def test_ragconfig_from_dict_restores_context_truncation(self):
         from rag_engine import RAGConfig
+
         c = RAGConfig.from_dict({"context_truncation": 3000})
         assert c.context_truncation == 3000
 
     def test_ragconfig_from_dict_backward_compat_default(self):
         """Old dicts without context_truncation get the default."""
         from rag_engine import RAGConfig
+
         c = RAGConfig.from_dict({})
         assert c.context_truncation == 20000
 
@@ -141,13 +154,13 @@ class TestFix2ContextTruncationInRAGConfig:
 # FIX 3: InferenceConfig temperature wired from RAGConfig
 # ---------------------------------------------------------------------------
 
+
 class TestFix3InferenceConfigTemperature:
     """RAGEngine must pass temperature from config, not use InferenceConfig default (0.7)."""
 
     def test_inference_config_uses_ragconfig_temperature(self):
         from llm_interface import InferenceConfig
         from rag_engine import RAGConfig
-        import rag_engine
 
         captured = {}
 
@@ -162,18 +175,22 @@ class TestFix3InferenceConfigTemperature:
         engine.llm = FakeLLM()
 
         # Verify that InferenceConfig constructed with config temperature matches
-        ic = InferenceConfig(max_tokens=config.max_tokens, temperature=config.temperature)
-        assert ic.temperature == 0.1, (
-            "InferenceConfig temperature must come from RAGConfig, not default 0.7"
+        ic = InferenceConfig(
+            max_tokens=config.max_tokens, temperature=config.temperature
         )
+        assert (
+            ic.temperature == 0.1
+        ), "InferenceConfig temperature must come from RAGConfig, not default 0.7"
 
     def test_inference_config_default_not_used(self):
         """The InferenceConfig default temperature (0.7) must not override config."""
         from llm_interface import InferenceConfig
+
         ic_default = InferenceConfig()
         assert ic_default.temperature == 0.7  # document the default
 
         from rag_engine import RAGConfig
+
         config = RAGConfig(temperature=0.3)
         ic_from_config = InferenceConfig(max_tokens=512, temperature=config.temperature)
         assert ic_from_config.temperature == 0.3
@@ -184,8 +201,10 @@ class TestFix3InferenceConfigTemperature:
 # FIX 4: BM25 rebuild triggered on hybrid search even when index is None
 # ---------------------------------------------------------------------------
 
+
 class TestFix4BM25RebuildOnNullIndex:
-    """_rebuild_bm25_if_needed() must be called when hybrid_search=True even if bm25_index is None."""
+    """_rebuild_bm25_if_needed() must be called when hybrid_search=True
+    even if bm25_index is None."""
 
     def test_rebuild_unconditional_when_hybrid_search(self):
         """get_context() must call _rebuild_bm25_if_needed unconditionally when hybrid_search=True.
@@ -195,34 +214,55 @@ class TestFix4BM25RebuildOnNullIndex:
         The fix removes the bm25_index guard: rebuild is called whenever hybrid_search=True.
         """
         import inspect
+
         from vector_store import VectorStore
+
         src = inspect.getsource(VectorStore.get_context)
         lines = src.split("\n")
 
         # Find the hybrid_search branch and verify rebuild is called WITHOUT a bm25_index guard
-        hybrid_idx = next((i for i, l in enumerate(lines) if "if hybrid_search" in l and "rebuild" not in l), None)
-        rebuild_idx = next((i for i, l in enumerate(lines) if "_rebuild_bm25_if_needed" in l), None)
+        hybrid_idx = next(
+            (
+                i
+                for i, l in enumerate(lines)
+                if "if hybrid_search" in l and "rebuild" not in l
+            ),
+            None,
+        )
+        rebuild_idx = next(
+            (i for i, l in enumerate(lines) if "_rebuild_bm25_if_needed" in l), None
+        )
 
-        assert rebuild_idx is not None, "_rebuild_bm25_if_needed must be called in get_context"
-        assert hybrid_idx is not None, "get_context must have an if hybrid_search branch"
+        assert (
+            rebuild_idx is not None
+        ), "_rebuild_bm25_if_needed must be called in get_context"
+        assert (
+            hybrid_idx is not None
+        ), "get_context must have an if hybrid_search branch"
 
         # Rebuild must be called BEFORE any self.bm25_index check (within the hybrid block)
         bm25_none_idx = next(
-            (i for i, l in enumerate(lines) if "bm25_index is None" in l or "not self.bm25_index" in l),
-            len(lines)
+            (
+                i
+                for i, l in enumerate(lines)
+                if "bm25_index is None" in l or "not self.bm25_index" in l
+            ),
+            len(lines),
         )
-        assert rebuild_idx < bm25_none_idx, (
-            "_rebuild_bm25_if_needed must be called BEFORE checking if bm25_index is None"
-        )
+        assert (
+            rebuild_idx < bm25_none_idx
+        ), "_rebuild_bm25_if_needed must be called BEFORE checking if bm25_index is None"
 
     def test_fallback_to_vector_when_rebuild_fails(self):
         """If BM25 rebuild fails and index remains None, must fall back to vector-only."""
         import inspect
+
         from vector_store import VectorStore
+
         src = inspect.getsource(VectorStore.get_context)
-        assert "bm25_index is None" in src or "hybrid_search = False" in src, (
-            "get_context must fall back to vector-only when BM25 rebuild fails"
-        )
+        assert (
+            "bm25_index is None" in src or "hybrid_search = False" in src
+        ), "get_context must fall back to vector-only when BM25 rebuild fails"
 
     def test_rebuild_called_on_fresh_instance(self):
         """A fresh VectorStore with bm25_index=None must call rebuild on first hybrid search."""
@@ -248,9 +288,9 @@ class TestFix4BM25RebuildOnNullIndex:
         vs.embedder = MagicMock()
         vs.embedder.encode = MagicMock(return_value=[[0.0] * 384])
         vs.collection = MagicMock()
-        vs.collection.query = MagicMock(return_value={
-            "documents": [[]], "metadatas": [[]], "distances": [[]]
-        })
+        vs.collection.query = MagicMock(
+            return_value={"documents": [[]], "metadatas": [[]], "distances": [[]]}
+        )
         vs.metadata = {}
 
         try:
@@ -258,25 +298,28 @@ class TestFix4BM25RebuildOnNullIndex:
         except Exception:
             pass
 
-        assert rebuild_calls, (
-            "_rebuild_bm25_if_needed must be called even when bm25_index starts as None"
-        )
+        assert (
+            rebuild_calls
+        ), "_rebuild_bm25_if_needed must be called even when bm25_index starts as None"
 
 
 # ---------------------------------------------------------------------------
 # FIX 5: Stable doc_id for document identity
 # ---------------------------------------------------------------------------
 
+
 class TestFix5StableDocumentIdentity:
     """Two files with the same basename must get different doc_ids."""
 
     def test_documentchunk_has_doc_id_field(self):
         from document_processor import DocumentChunk
+
         c = DocumentChunk(text="test", source="file.pdf")
         assert hasattr(c, "doc_id"), "DocumentChunk must have doc_id field"
 
     def test_documentchunk_has_source_path_field(self):
         from document_processor import DocumentChunk
+
         c = DocumentChunk(text="test", source="file.pdf")
         assert hasattr(c, "source_path"), "DocumentChunk must have source_path field"
 
@@ -324,9 +367,9 @@ class TestFix5StableDocumentIdentity:
             proc = DocumentProcessor(chunk_size=50, chunk_overlap=0)
             chunks_a = proc.process_file(fpath)
             chunks_b = proc.process_file(fpath)
-            assert chunks_a[0].doc_id == chunks_b[0].doc_id, (
-                "doc_id must be deterministic for the same file path"
-            )
+            assert (
+                chunks_a[0].doc_id == chunks_b[0].doc_id
+            ), "doc_id must be deterministic for the same file path"
         finally:
             os.unlink(fpath)
 
@@ -350,23 +393,26 @@ class TestFix5StableDocumentIdentity:
     def test_vector_store_chunk_id_uses_doc_id(self):
         """VectorStore.add_chunks() must use doc_id (not just source) for chunk IDs."""
         import inspect
+
         from vector_store import VectorStore
+
         src = inspect.getsource(VectorStore.add_chunks)
-        assert "doc_id" in src, (
-            "add_chunks must use doc_id in chunk ID generation to prevent collisions"
-        )
+        assert (
+            "doc_id" in src
+        ), "add_chunks must use doc_id in chunk ID generation to prevent collisions"
 
 
 # ---------------------------------------------------------------------------
 # FIX 7: CLI chunk-size and chunk-overlap wired to engine
 # ---------------------------------------------------------------------------
 
+
 class TestFix7CLIArgWiring:
     """--chunk-size and --chunk-overlap CLI args must set env vars for create_engine_from_env."""
 
     def test_chunk_size_arg_sets_env_var(self):
         """Passing --chunk-size must set RAG_CHUNK_SIZE env var."""
-        import importlib
+
         import main as m
 
         parser = m.create_parser()
@@ -408,17 +454,17 @@ class TestFix7CLIArgWiring:
         """main.py source must contain wiring for RAG_CHUNK_SIZE."""
         src = Path(__file__).parent.parent.parent / "main.py"
         content = src.read_text()
-        assert "RAG_CHUNK_SIZE" in content, (
-            "main.py must set RAG_CHUNK_SIZE env var from --chunk-size arg"
-        )
+        assert (
+            "RAG_CHUNK_SIZE" in content
+        ), "main.py must set RAG_CHUNK_SIZE env var from --chunk-size arg"
 
     def test_main_py_wires_chunk_overlap(self):
         """main.py source must contain wiring for RAG_CHUNK_OVERLAP."""
         src = Path(__file__).parent.parent.parent / "main.py"
         content = src.read_text()
-        assert "RAG_CHUNK_OVERLAP" in content, (
-            "main.py must set RAG_CHUNK_OVERLAP env var from --chunk-overlap arg"
-        )
+        assert (
+            "RAG_CHUNK_OVERLAP" in content
+        ), "main.py must set RAG_CHUNK_OVERLAP env var from --chunk-overlap arg"
 
     def test_create_engine_from_env_reads_chunk_size(self):
         """create_engine_from_env() must honour RAG_CHUNK_SIZE env var."""
@@ -426,8 +472,10 @@ class TestFix7CLIArgWiring:
         try:
             os.environ["RAG_CHUNK_SIZE"] = "128"
             import config
+
             config._settings = None  # reset cache
             from config import RAGSettings
+
             s = RAGSettings()
             assert s.rag_chunk_size == 128
         finally:
@@ -443,8 +491,10 @@ class TestFix7CLIArgWiring:
         try:
             os.environ["RAG_CHUNK_OVERLAP"] = "64"
             import config
+
             config._settings = None
             from config import RAGSettings
+
             s = RAGSettings()
             assert s.rag_chunk_overlap == 64
         finally:
@@ -459,56 +509,72 @@ class TestFix7CLIArgWiring:
 # FIX 8: Minimum-hardware defaults
 # ---------------------------------------------------------------------------
 
+
 class TestFix8MinimumHardwareDefaults:
     """RAGConfig and RAGSettings defaults must be conservative for 11th-gen i5 / 16 GB."""
 
     def test_ragconfig_reranking_disabled_by_default(self):
         from rag_engine import RAGConfig
-        assert RAGConfig().reranking_enabled is False, (
-            "reranking_enabled must default to False — reranker model is expensive to load"
-        )
+
+        assert (
+            RAGConfig().reranking_enabled is False
+        ), "reranking_enabled must default to False — reranker model is expensive to load"
 
     def test_ragconfig_initial_retrieval_top_k_default(self):
         from rag_engine import RAGConfig
-        assert RAGConfig().initial_retrieval_top_k == 12, (
-            "initial_retrieval_top_k must default to 12 (was 30)"
-        )
+
+        assert (
+            RAGConfig().initial_retrieval_top_k == 12
+        ), "initial_retrieval_top_k must default to 12 (was 30)"
 
     def test_ragconfig_rerank_top_k_default(self):
         from rag_engine import RAGConfig
+
         assert RAGConfig().rerank_top_k == 4
 
     def test_ragconfig_retrieval_window_default(self):
         from rag_engine import RAGConfig
+
         assert RAGConfig().retrieval_window == 1
 
     def test_ragconfig_n_results_default(self):
         from rag_engine import RAGConfig
+
         assert RAGConfig().n_results == 4
 
     def test_ragconfig_max_tokens_default(self):
         from rag_engine import RAGConfig
+
         assert RAGConfig().max_tokens == 512
 
     def test_ragconfig_gguf_n_ctx_default(self):
         from rag_engine import RAGConfig
+
         assert RAGConfig().gguf_n_ctx == 4096
 
     def test_ragconfig_gguf_n_threads_default(self):
+        # Issue #53 superseded the fixed minimum-hardware default of 4: the
+        # default is now min(os.cpu_count() or 4, 8) so 8-thread-capable CPUs
+        # use all of them while min-spec 4-core hardware keeps the old value.
+        import os
+
         from rag_engine import RAGConfig
+
         c = RAGConfig()
-        assert c.gguf_n_threads == 4, (
-            "gguf_n_threads must default to 4 (half of 8 cores on i5), not cpu_count()"
-        )
+        assert c.gguf_n_threads == min(
+            os.cpu_count() or 4, 8
+        ), "gguf_n_threads must default to min(os.cpu_count() or 4, 8)"
 
     def test_ragconfig_gguf_fields_in_to_dict(self):
         from rag_engine import RAGConfig
+
         d = RAGConfig().to_dict()
         assert "gguf_n_ctx" in d
         assert "gguf_n_threads" in d
 
     def test_ragconfig_gguf_fields_in_from_dict(self):
         from rag_engine import RAGConfig
+
         c = RAGConfig.from_dict({"gguf_n_ctx": 2048, "gguf_n_threads": 2})
         assert c.gguf_n_ctx == 2048
         assert c.gguf_n_threads == 2
@@ -516,9 +582,11 @@ class TestFix8MinimumHardwareDefaults:
     def test_config_py_defaults_match_ragconfig(self):
         """RAGSettings defaults must agree with RAGConfig defaults."""
         import config
+
         config._settings = None
         from config import RAGSettings
         from rag_engine import RAGConfig
+
         s = RAGSettings()
         c = RAGConfig()
         assert s.rag_n_results == c.n_results
@@ -530,20 +598,22 @@ class TestFix8MinimumHardwareDefaults:
 # FIX 9: BM25 tokenization strips punctuation
 # ---------------------------------------------------------------------------
 
+
 class TestFix9BM25Tokenization:
     """BM25 tokenizer must strip punctuation so 'procedure.' matches 'procedure'."""
 
     def _get_tokenizer(self):
         from vector_store import BM25Index
+
         b = BM25Index()
         return b._tokenize
 
     def test_punctuation_stripped(self):
         tokenize = self._get_tokenizer()
         tokens = tokenize("procedure.")
-        assert "procedure" in tokens, (
-            "'procedure.' must tokenize to 'procedure' — punctuation must be stripped"
-        )
+        assert (
+            "procedure" in tokens
+        ), "'procedure.' must tokenize to 'procedure' — punctuation must be stripped"
 
     def test_comma_stripped(self):
         tokenize = self._get_tokenizer()
@@ -563,72 +633,106 @@ class TestFix9BM25Tokenization:
         Note: BM25Okapi IDF=0 for terms in >=50% of a tiny corpus (2 docs),
         so we use 4 documents where only 1 contains 'procedure.' to get non-zero scores.
         """
-        pytest.importorskip("rank_bm25", reason="rank_bm25 not installed — BM25 search pipeline unavailable")
-        from vector_store import BM25Index
-        b = BM25Index()
-        b.build_index([
-            "The procedure. is critical.",
-            "Unrelated document about cats.",
-            "Dogs are friendly animals.",
-            "Birds can fly high.",
-        ])
-        results = b.search("procedure")
-        assert len(results) > 0, "BM25 must return results for 'procedure' matching 'procedure.'"
-        best_doc_idx = results[0][0]
-        assert best_doc_idx == 0, (
-            "The document containing 'procedure.' must rank first for query 'procedure'"
+        pytest.importorskip(
+            "rank_bm25",
+            reason="rank_bm25 not installed — BM25 search pipeline unavailable",
         )
+        from vector_store import BM25Index
+
+        b = BM25Index()
+        b.build_index(
+            [
+                "The procedure. is critical.",
+                "Unrelated document about cats.",
+                "Dogs are friendly animals.",
+                "Birds can fly high.",
+            ]
+        )
+        results = b.search("procedure")
+        assert (
+            len(results) > 0
+        ), "BM25 must return results for 'procedure' matching 'procedure.'"
+        best_doc_idx = results[0][0]
+        assert (
+            best_doc_idx == 0
+        ), "The document containing 'procedure.' must rank first for query 'procedure'"
 
     def test_tokenizer_uses_regex_not_split(self):
         """Verify tokenizer uses regex, not simple whitespace split."""
         import inspect
+
         from vector_store import BM25Index
+
         src = inspect.getsource(BM25Index._tokenize)
-        assert "findall" in src or "re." in src, (
-            "_tokenize must use regex (re.findall) not simple split()"
-        )
+        assert (
+            "findall" in src or "re." in src
+        ), "_tokenize must use regex (re.findall) not simple split()"
 
 
 # ---------------------------------------------------------------------------
 # FIX 10: QueryResult includes retrieved_chunks
 # ---------------------------------------------------------------------------
 
+
 class TestFix10QueryResultRetrievedChunks:
     """QueryResult must include retrieved_chunks with text snippets and metadata."""
 
     def test_queryresult_has_retrieved_chunks_field(self):
         from rag_engine import QueryResult
+
         qr = QueryResult(
-            question="q", answer="a", sources=[],
-            context_length=0, inference_time=0.0, chunks_retrieved=0
+            question="q",
+            answer="a",
+            sources=[],
+            context_length=0,
+            inference_time=0.0,
+            chunks_retrieved=0,
         )
-        assert hasattr(qr, "retrieved_chunks"), (
-            "QueryResult must have retrieved_chunks field"
-        )
+        assert hasattr(
+            qr, "retrieved_chunks"
+        ), "QueryResult must have retrieved_chunks field"
 
     def test_queryresult_retrieved_chunks_defaults_to_none(self):
         from rag_engine import QueryResult
+
         qr = QueryResult(
-            question="q", answer="a", sources=[],
-            context_length=0, inference_time=0.0, chunks_retrieved=0
+            question="q",
+            answer="a",
+            sources=[],
+            context_length=0,
+            inference_time=0.0,
+            chunks_retrieved=0,
         )
-        assert qr.retrieved_chunks is None, (
-            "retrieved_chunks must default to None for backward compatibility"
-        )
+        assert (
+            qr.retrieved_chunks is None
+        ), "retrieved_chunks must default to None for backward compatibility"
 
     def test_queryresult_retrieved_chunks_accepts_list(self):
         from rag_engine import QueryResult
-        chunk_data = [{"source_display": "doc.pdf", "page": 1, "chunk_index": 0, "snippet": "test"}]
+
+        chunk_data = [
+            {
+                "source_display": "doc.pdf",
+                "page": 1,
+                "chunk_index": 0,
+                "snippet": "test",
+            }
+        ]
         qr = QueryResult(
-            question="q", answer="a", sources=["doc.pdf"],
-            context_length=100, inference_time=0.5, chunks_retrieved=1,
-            retrieved_chunks=chunk_data
+            question="q",
+            answer="a",
+            sources=["doc.pdf"],
+            context_length=100,
+            inference_time=0.5,
+            chunks_retrieved=1,
+            retrieved_chunks=chunk_data,
         )
         assert qr.retrieved_chunks == chunk_data
 
     def test_queryresult_chunk_has_required_fields(self):
         """Each entry in retrieved_chunks must have source_display, page, chunk_index, snippet."""
         from rag_engine import QueryResult
+
         chunk = {
             "source_display": "manual.pdf",
             "doc_id": "abc123def456",
@@ -637,9 +741,13 @@ class TestFix10QueryResultRetrievedChunks:
             "snippet": "This is the chunk text...",
         }
         qr = QueryResult(
-            question="q", answer="a", sources=["manual.pdf"],
-            context_length=50, inference_time=0.1, chunks_retrieved=1,
-            retrieved_chunks=[chunk]
+            question="q",
+            answer="a",
+            sources=["manual.pdf"],
+            context_length=50,
+            inference_time=0.1,
+            chunks_retrieved=1,
+            retrieved_chunks=[chunk],
         )
         assert qr.retrieved_chunks[0]["source_display"] == "manual.pdf"
         assert qr.retrieved_chunks[0]["page"] == 3
@@ -649,8 +757,13 @@ class TestFix10QueryResultRetrievedChunks:
     def test_backward_compat_sources_list_still_present(self):
         """Existing sources field must still work after adding retrieved_chunks."""
         from rag_engine import QueryResult
+
         qr = QueryResult(
-            question="q", answer="a", sources=["doc1.pdf", "doc2.pdf"],
-            context_length=200, inference_time=1.0, chunks_retrieved=4
+            question="q",
+            answer="a",
+            sources=["doc1.pdf", "doc2.pdf"],
+            context_length=200,
+            inference_time=1.0,
+            chunks_retrieved=4,
         )
         assert qr.sources == ["doc1.pdf", "doc2.pdf"]

--- a/tests/regression/test_remediation_fixes.py
+++ b/tests/regression/test_remediation_fixes.py
@@ -556,14 +556,21 @@ class TestFix8MinimumHardwareDefaults:
         # Issue #53 superseded the fixed minimum-hardware default of 4: the
         # default is now min(os.cpu_count() or 4, 8) so 8-thread-capable CPUs
         # use all of them while min-spec 4-core hardware keeps the old value.
-        import os
+        # cpu_count is pinned both above and below the cap so the assertion
+        # discriminates on any host: a regressed hardcoded 4 fails the
+        # 16-core pin, a hardcoded 8 fails the 4-core pin.
+        from unittest.mock import patch
 
         from rag_engine import RAGConfig
 
-        c = RAGConfig()
-        assert c.gguf_n_threads == min(
-            os.cpu_count() or 4, 8
-        ), "gguf_n_threads must default to min(os.cpu_count() or 4, 8)"
+        with patch("os.cpu_count", return_value=16):
+            assert (
+                RAGConfig().gguf_n_threads == 8
+            ), "cpu_count above the cap must clamp the default to 8"
+        with patch("os.cpu_count", return_value=4):
+            assert (
+                RAGConfig().gguf_n_threads == 4
+            ), "4-core pin must keep the min-spec default of 4"
 
     def test_ragconfig_gguf_fields_in_to_dict(self):
         from rag_engine import RAGConfig

--- a/tests/security/test_api_asyncio_adversarial.py
+++ b/tests/security/test_api_asyncio_adversarial.py
@@ -10,22 +10,15 @@ Tests attack vectors against the asyncio.to_thread() wrapped endpoints:
 Phase 1.1: API & Thread Safety - asyncio.to_thread() adversarial testing
 """
 
-import pytest
 import asyncio
 import time
-import threading
-import traceback
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
+
+import pytest
 from fastapi.testclient import TestClient
-from httpx import AsyncClient, ASGITransport
+from httpx import ASGITransport, AsyncClient
 
-from api_server import (
-    app,
-    QuestionRequest,
-    SearchRequest,
-    IngestRequest,
-)
-
+from api_server import IngestRequest, QuestionRequest, SearchRequest, app
 
 pytestmark = pytest.mark.unit
 
@@ -33,6 +26,7 @@ pytestmark = pytest.mark.unit
 # =============================================================================
 # 1. THREAD POOL EXHAUSTION ATTACKS
 # =============================================================================
+
 
 class TestThreadPoolExhaustion:
     """Test thread pool exhaustion attacks against asyncio.to_thread endpoints."""
@@ -45,7 +39,7 @@ class TestThreadPoolExhaustion:
         With proper wrapping, requests should either queue or fail gracefully
         when thread pool is exhausted.
         """
-        with patch('api_server.engine') as mock_engine:
+        with patch("api_server.engine") as mock_engine:
             mock_engine.llm = MagicMock()
 
             # Very slow synchronous function to occupy thread pool
@@ -65,9 +59,14 @@ class TestThreadPoolExhaustion:
             num_requests = 50
             ask_request = QuestionRequest(question="What is Python?", n_results=3)
 
-            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test", timeout=30) as ac:
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test", timeout=30
+            ) as ac:
                 # Fire all requests concurrently
-                tasks = [ac.post("/ask", json=ask_request.model_dump()) for _ in range(num_requests)]
+                tasks = [  # noqa: F841 - pre-existing: created but never awaited
+                    ac.post("/ask", json=ask_request.model_dump())
+                    for _ in range(num_requests)
+                ]
 
                 # Wait for first batch to start
                 await asyncio.sleep(0.5)
@@ -77,7 +76,9 @@ class TestThreadPoolExhaustion:
                 health_response = await asyncio.wait_for(health_task, timeout=3.0)
 
                 # The critical assertion: event loop must remain responsive
-                assert health_response.status_code == 200, "Event loop blocked by thread pool exhaustion"
+                assert (
+                    health_response.status_code == 200
+                ), "Event loop blocked by thread pool exhaustion"
 
     @pytest.mark.asyncio
     async def test_rapid_fire_requests_no_hang(self):
@@ -86,7 +87,7 @@ class TestThreadPoolExhaustion:
         Tests that the server can handle a burst of requests without
         hanging or deadlocking the event loop.
         """
-        with patch('api_server.engine') as mock_engine:
+        with patch("api_server.engine") as mock_engine:
             mock_engine.llm = MagicMock()
             mock_engine.query.return_value = MagicMock(
                 question="test",
@@ -98,14 +99,20 @@ class TestThreadPoolExhaustion:
 
             ask_request = QuestionRequest(question="Test", n_results=3)
 
-            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test", timeout=10) as ac:
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test", timeout=10
+            ) as ac:
                 # Fire 20 rapid requests
-                tasks = [ac.post("/ask", json=ask_request.model_dump()) for _ in range(20)]
+                tasks = [
+                    ac.post("/ask", json=ask_request.model_dump()) for _ in range(20)
+                ]
                 responses = await asyncio.gather(*tasks, return_exceptions=True)
 
                 # All should succeed or fail gracefully - no hangs
                 for resp in responses:
-                    assert not isinstance(resp, asyncio.TimeoutError), "Request timed out - possible hang"
+                    assert not isinstance(
+                        resp, asyncio.TimeoutError
+                    ), "Request timed out - possible hang"
                     if isinstance(resp, Exception):
                         # Exceptions are acceptable (500, etc) but not timeouts
                         assert not isinstance(resp, asyncio.TimeoutError)
@@ -117,7 +124,7 @@ class TestThreadPoolExhaustion:
         Both endpoints use asyncio.to_thread() - they should be able to
         run concurrently without deadlock.
         """
-        with patch('api_server.engine') as mock_engine:
+        with patch("api_server.engine") as mock_engine:
             mock_engine.llm = MagicMock()
 
             def slow_query(*args, **kwargs):
@@ -140,21 +147,32 @@ class TestThreadPoolExhaustion:
             ask_request = QuestionRequest(question="What is Python?", n_results=3)
             search_request = SearchRequest(query="test query", n_results=5)
 
-            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test", timeout=5) as ac:
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test", timeout=5
+            ) as ac:
                 # Create parallel tasks
-                ask_task = asyncio.create_task(ac.post("/ask", json=ask_request.model_dump()))
-                search_task = asyncio.create_task(ac.post("/search", json=search_request.model_dump()))
+                ask_task = asyncio.create_task(
+                    ac.post("/ask", json=ask_request.model_dump())
+                )
+                search_task = asyncio.create_task(
+                    ac.post("/search", json=search_request.model_dump())
+                )
 
                 # Both should complete without deadlock
-                ask_resp, search_resp = await asyncio.gather(ask_task, search_task, return_exceptions=True)
+                ask_resp, search_resp = await asyncio.gather(
+                    ask_task, search_task, return_exceptions=True
+                )
 
                 assert not isinstance(ask_resp, Exception), f"Ask failed: {ask_resp}"
-                assert not isinstance(search_resp, Exception), f"Search failed: {search_resp}"
+                assert not isinstance(
+                    search_resp, Exception
+                ), f"Search failed: {search_resp}"
 
 
 # =============================================================================
 # 2. OVERSIZED PAYLOAD ATTACKS
 # =============================================================================
+
 
 class TestOversizedPayloads:
     """Test oversized payload attacks against asyncio.to_thread endpoints."""
@@ -172,7 +190,9 @@ class TestOversizedPayloads:
 
         # Should fail validation BEFORE reaching asyncio.to_thread
         # Send raw JSON directly to test validation at the FastAPI layer
-        response = client.post("/ask", json={"question": oversized_question, "n_results": 3})
+        response = client.post(
+            "/ask", json={"question": oversized_question, "n_results": 3}
+        )
 
         # Validation should reject this
         assert response.status_code == 422, "Oversized payload not rejected"
@@ -182,7 +202,7 @@ class TestOversizedPayloads:
         # Exactly 2000 characters
         boundary_question = "Q" * 2000
 
-        with patch('api_server.engine') as mock_engine:
+        with patch("api_server.engine") as mock_engine:
             mock_engine.llm = MagicMock()
             mock_engine.query.return_value = MagicMock(
                 question=boundary_question[:100],
@@ -201,7 +221,7 @@ class TestOversizedPayloads:
 
     def test_empty_question_rejected(self):
         """Empty question should be rejected by validation before asyncio.to_thread."""
-        with patch('api_server.engine') as mock_engine:
+        with patch("api_server.engine") as mock_engine:
             mock_engine.llm = MagicMock()
 
             # Empty string
@@ -212,12 +232,14 @@ class TestOversizedPayloads:
 
     def test_whitespace_only_question_rejected(self):
         """Whitespace-only question should be rejected by validator before asyncio.to_thread."""
-        with patch('api_server.engine') as mock_engine:
+        with patch("api_server.engine") as mock_engine:
             mock_engine.llm = MagicMock()
 
             # Whitespace only
             client = TestClient(app)
-            response = client.post("/ask", json={"question": "   \n\t  ", "n_results": 3})
+            response = client.post(
+                "/ask", json={"question": "   \n\t  ", "n_results": 3}
+            )
 
             assert response.status_code == 422
 
@@ -232,7 +254,9 @@ class TestOversizedPayloads:
         complex_unicode = "\u0300\u0301\u0302" * 1000  # Combining diacritics
 
         client = TestClient(app)
-        response = client.post("/ask", json={"question": complex_unicode, "n_results": 3})
+        response = client.post(
+            "/ask", json={"question": complex_unicode, "n_results": 3}
+        )
 
         # Should either pass validation (if under 2000 chars) or fail gracefully
         # The key is it shouldn't crash or hang
@@ -240,7 +264,7 @@ class TestOversizedPayloads:
 
     def test_null_bytes_in_question(self):
         """Null bytes in question should be rejected or sanitized."""
-        with patch('api_server.engine') as mock_engine:
+        with patch("api_server.engine") as mock_engine:
             mock_engine.llm = MagicMock()
             mock_engine.query.return_value = MagicMock(
                 question="test",
@@ -252,13 +276,15 @@ class TestOversizedPayloads:
 
             # Question with null byte - send raw JSON
             client = TestClient(app)
-            response = client.post("/ask", json={"question": "test\x00injection", "n_results": 3})
+            response = client.post(
+                "/ask", json={"question": "test\x00injection", "n_results": 3}
+            )
             # Validation or server should handle this
             assert response.status_code in [200, 422]
 
     def test_max_search_query_boundary(self):
         """Search query at max_length boundary (500 chars)."""
-        with patch('api_server.engine') as mock_engine:
+        with patch("api_server.engine") as mock_engine:
             mock_engine.search_documents.return_value = [
                 ("Document text", {"source": "doc1.txt"}, 0.85),
             ]
@@ -276,7 +302,9 @@ class TestOversizedPayloads:
         oversized_query = "X" * 1000
 
         client = TestClient(app)
-        response = client.post("/search", json={"query": oversized_query, "n_results": 5})
+        response = client.post(
+            "/search", json={"query": oversized_query, "n_results": 5}
+        )
 
         assert response.status_code == 422
 
@@ -284,6 +312,7 @@ class TestOversizedPayloads:
 # =============================================================================
 # 3. CANCELLATION / TIMEOUT ATTACKS
 # =============================================================================
+
 
 class TestCancellationTimeoutAttacks:
     """Test cancellation and timeout attacks against asyncio.to_thread."""
@@ -295,7 +324,7 @@ class TestCancellationTimeoutAttacks:
         When a client disconnects mid-request, the thread pool work should
         complete (or be cancelled) without crashing the server.
         """
-        with patch('api_server.engine') as mock_engine:
+        with patch("api_server.engine") as mock_engine:
             mock_engine.llm = MagicMock()
 
             # Slow query that might be cancelled
@@ -313,7 +342,9 @@ class TestCancellationTimeoutAttacks:
 
             ask_request = QuestionRequest(question="What is Python?", n_results=3)
 
-            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test", timeout=0.5) as ac:
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test", timeout=0.5
+            ) as ac:
                 # This should timeout, not crash the server
                 try:
                     response = await ac.post("/ask", json=ask_request.model_dump())
@@ -322,17 +353,21 @@ class TestCancellationTimeoutAttacks:
                 except Exception as e:
                     # Any exception should not crash the server
                     # Server should remain responsive
-                    assert not isinstance(e, (asyncio.CancelledError, KeyboardInterrupt))
+                    assert not isinstance(
+                        e, (asyncio.CancelledError, KeyboardInterrupt)
+                    )
 
             # Server should still be responsive after timeout
-            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test", timeout=5) as ac:
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test", timeout=5
+            ) as ac:
                 health = await ac.get("/")
                 assert health.status_code == 200
 
     @pytest.mark.asyncio
     async def test_multiple_rapid_cancellations_no_crash(self):
         """Multiple rapid client disconnections should not crash server."""
-        with patch('api_server.engine') as mock_engine:
+        with patch("api_server.engine") as mock_engine:
             mock_engine.llm = MagicMock()
 
             def very_slow_query(*args, **kwargs):
@@ -347,7 +382,9 @@ class TestCancellationTimeoutAttacks:
 
             mock_engine.query = very_slow_query
 
-            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test", timeout=0.1) as ac:
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test", timeout=0.1
+            ) as ac:
                 ask_request = QuestionRequest(question="test", n_results=3)
 
                 # Fire several requests that will all timeout
@@ -360,7 +397,9 @@ class TestCancellationTimeoutAttacks:
                     await asyncio.sleep(0.05)
 
             # Server should still be healthy
-            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test", timeout=5) as ac:
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test", timeout=5
+            ) as ac:
                 health = await ac.get("/")
                 assert health.status_code == 200
 
@@ -369,12 +408,13 @@ class TestCancellationTimeoutAttacks:
 # 4. EXCEPTION LEAKAGE THROUGH asyncio.to_thread ERROR PATHS
 # =============================================================================
 
+
 class TestExceptionLeakage:
     """Test that internal exceptions don't leak sensitive information through asyncio.to_thread."""
 
     def test_database_error_no_stack_trace_leak(self):
         """Database errors should not expose internal paths through asyncio.to_thread."""
-        with patch('api_server.engine') as mock_engine:
+        with patch("api_server.engine") as mock_engine:
             mock_engine.llm = MagicMock()
             # Simulate a database error with internal paths
             mock_engine.query.side_effect = RuntimeError(
@@ -395,7 +435,7 @@ class TestExceptionLeakage:
 
     def test_file_not_found_error_no_path_leak(self):
         """FileNotFoundError should not expose system paths."""
-        with patch('api_server.engine') as mock_engine:
+        with patch("api_server.engine") as mock_engine:
             mock_engine.llm = MagicMock()
             # Simulate file not found with internal path
             mock_engine.query.side_effect = FileNotFoundError(
@@ -415,7 +455,7 @@ class TestExceptionLeakage:
 
     def test_permission_error_no_sensitive_paths(self):
         """Permission errors should not expose sensitive file system info."""
-        with patch('api_server.engine') as mock_engine:
+        with patch("api_server.engine") as mock_engine:
             mock_engine.llm = MagicMock()
             # Simulate permission error with sensitive path
             mock_engine.query.side_effect = PermissionError(
@@ -434,7 +474,7 @@ class TestExceptionLeakage:
 
     def test_memory_error_no_heap_dump(self):
         """MemoryError should not leak heap/stack information."""
-        with patch('api_server.engine') as mock_engine:
+        with patch("api_server.engine") as mock_engine:
             mock_engine.llm = MagicMock()
             mock_engine.query.side_effect = MemoryError(
                 "Failed to allocate 16GB for embeddings at 0x7f8a2b3c4d5e"
@@ -452,7 +492,7 @@ class TestExceptionLeakage:
 
     def test_generic_exception_still_safe(self):
         """Generic exceptions should still not leak sensitive info."""
-        with patch('api_server.engine') as mock_engine:
+        with patch("api_server.engine") as mock_engine:
             mock_engine.llm = MagicMock()
             # Bare exception with internal info
             mock_engine.query.side_effect = Exception(
@@ -471,7 +511,7 @@ class TestExceptionLeakage:
 
     def test_search_error_no_stack_trace_leak(self):
         """Search endpoint errors should not leak stack traces."""
-        with patch('api_server.engine') as mock_engine:
+        with patch("api_server.engine") as mock_engine:
             mock_engine.search_documents.side_effect = RuntimeError(
                 "Index corrupted at /data/chroma/index.bin:0xDEADBEEF"
             )
@@ -488,8 +528,8 @@ class TestExceptionLeakage:
 
     def test_ingest_error_no_path_leak(self):
         """Ingest endpoint errors should not leak file system paths."""
-        with patch('api_server.engine') as mock_engine:
-            with patch('api_server.validate_directory') as mock_validate:
+        with patch("api_server.engine") as mock_engine:
+            with patch("api_server.validate_directory") as mock_validate:
                 mock_validate.return_value = "/var/data/documents"
                 mock_engine.ingest_directory.side_effect = OSError(
                     "Cannot read directory /var/data/documents at permission level 0x755"
@@ -507,7 +547,7 @@ class TestExceptionLeakage:
 
     def test_correlation_id_returned_on_error(self):
         """Errors should return a correlation ID for support, not sensitive data."""
-        with patch('api_server.engine') as mock_engine:
+        with patch("api_server.engine") as mock_engine:
             mock_engine.llm = MagicMock()
             mock_engine.query.side_effect = RuntimeError("Internal error")
 
@@ -530,42 +570,49 @@ class TestExceptionLeakage:
 # 5. BOUNDARY VIOLATIONS
 # =============================================================================
 
+
 class TestBoundaryViolations:
     """Test boundary violations against asyncio.to_thread endpoints."""
 
     def test_negative_n_results_rejected(self):
         """Negative n_results should be rejected by validation."""
-        with patch('api_server.engine') as mock_engine:
+        with patch("api_server.engine") as mock_engine:
             mock_engine.llm = MagicMock()
 
             client = TestClient(app)
-            response = client.post("/ask", json={"question": "Test question?", "n_results": -1})
+            response = client.post(
+                "/ask", json={"question": "Test question?", "n_results": -1}
+            )
 
             assert response.status_code == 422
 
     def test_zero_n_results_rejected(self):
         """Zero n_results should be rejected by validation."""
-        with patch('api_server.engine') as mock_engine:
+        with patch("api_server.engine") as mock_engine:
             mock_engine.llm = MagicMock()
 
             client = TestClient(app)
-            response = client.post("/ask", json={"question": "Test question?", "n_results": 0})
+            response = client.post(
+                "/ask", json={"question": "Test question?", "n_results": 0}
+            )
 
             assert response.status_code == 422
 
     def test_way_oversized_n_results_rejected(self):
         """n_results way beyond limit should be rejected."""
-        with patch('api_server.engine') as mock_engine:
+        with patch("api_server.engine") as mock_engine:
             mock_engine.llm = MagicMock()
 
             client = TestClient(app)
-            response = client.post("/ask", json={"question": "Test question?", "n_results": 999999})
+            response = client.post(
+                "/ask", json={"question": "Test question?", "n_results": 999999}
+            )
 
             assert response.status_code == 422
 
     def test_engine_uninitialized_returns_503_before_thread(self):
         """Uninitialized engine should return 503 before reaching asyncio.to_thread."""
-        with patch('api_server.engine', None):
+        with patch("api_server.engine", None):
             request = QuestionRequest(question="What is Python?", n_results=3)
             client = TestClient(app)
             response = client.post("/ask", json=request.model_dump())
@@ -576,8 +623,11 @@ class TestBoundaryViolations:
 
     def test_llm_unavailable_returns_503_before_thread(self):
         """No LLM backend should return 503 before reaching asyncio.to_thread."""
-        with patch('api_server.engine') as mock_engine:
+        with patch("api_server.engine") as mock_engine:
             mock_engine.llm = None  # LLM not available
+            # No load diagnostic recorded -> generic detail (issue #53: a bare
+            # MagicMock would auto-create a truthy llm_init_error).
+            mock_engine.llm_init_error = None
 
             request = QuestionRequest(question="What is Python?", n_results=3)
             client = TestClient(app)
@@ -591,6 +641,7 @@ class TestBoundaryViolations:
 # 6. INJECTION ATTEMPTS THROUGH asyncio.to_thread PAYLOADS
 # =============================================================================
 
+
 class TestInjectionThroughPayloads:
     """Test injection attacks passed through asyncio.to_thread to backend systems."""
 
@@ -598,7 +649,7 @@ class TestInjectionThroughPayloads:
         """SQL injection attempts in question should not reach backend."""
         # This tests that the API properly validates inputs before
         # passing to asyncio.to_thread wrapped functions
-        with patch('api_server.engine') as mock_engine:
+        with patch("api_server.engine") as mock_engine:
             mock_engine.llm = MagicMock()
             mock_engine.query.return_value = MagicMock(
                 question="test",
@@ -619,7 +670,7 @@ class TestInjectionThroughPayloads:
 
     def test_path_traversal_in_question(self):
         """Path traversal attempts in question should be handled safely."""
-        with patch('api_server.engine') as mock_engine:
+        with patch("api_server.engine") as mock_engine:
             mock_engine.llm = MagicMock()
             mock_engine.query.return_value = MagicMock(
                 question="test",
@@ -640,7 +691,7 @@ class TestInjectionThroughPayloads:
 
     def test_shell_injection_in_question(self):
         """Shell injection attempts should be handled safely."""
-        with patch('api_server.engine') as mock_engine:
+        with patch("api_server.engine") as mock_engine:
             mock_engine.llm = MagicMock()
             mock_engine.query.return_value = MagicMock(
                 question="test",
@@ -660,7 +711,7 @@ class TestInjectionThroughPayloads:
 
     def test_html_script_injection(self):
         """HTML/script injection should be handled safely."""
-        with patch('api_server.engine') as mock_engine:
+        with patch("api_server.engine") as mock_engine:
             mock_engine.llm = MagicMock()
             mock_engine.query.return_value = MagicMock(
                 question="test",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -124,6 +124,9 @@ class TestPostAsk:
         """Test asking question when no LLM backend available."""
         with patch("api_server.engine") as mock_engine:
             mock_engine.llm = None
+            # No load diagnostic recorded -> the generic detail is expected
+            # (a bare MagicMock would auto-create a truthy llm_init_error).
+            mock_engine.llm_init_error = None
             mock_engine.query.side_effect = RuntimeError("LLM not initialized")
 
             request = QuestionRequest(question="Test question")

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -147,6 +147,9 @@ class TestAskStreamEndpoint:
         """Test /ask/stream returns 503 when LLM backend is not available."""
         with patch("api_server.engine") as mock_engine:
             mock_engine.llm = None
+            # No load diagnostic recorded -> the generic detail is expected
+            # (a bare MagicMock would auto-create a truthy llm_init_error).
+            mock_engine.llm_init_error = None
 
             response = client.post("/ask/stream", json={"question": "What is Python?"})
 

--- a/tests/test_api_server_ragconfig_wiring.py
+++ b/tests/test_api_server_ragconfig_wiring.py
@@ -7,10 +7,10 @@ Verifies that:
 4. rag_context_truncation is NOT passed (RAGConfig has no such parameter).
 """
 
-import sys
 import os
+import sys
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -22,10 +22,12 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 # FIXTURES
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture(autouse=True)
 def reset_settings_cache():
     """Reset the settings cache before each test."""
     import config
+
     config._settings = None
     yield
     config._settings = None
@@ -70,6 +72,7 @@ def mock_settings():
 # ASYNC HELPER: actually enter the lifespan and capture RAGConfig call args
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def _build_ragconfig_via_lifespan_async(mock_settings_instance):
     """Actually enter the async lifespan context and capture RAGConfig kwargs."""
@@ -86,8 +89,9 @@ async def _build_ragconfig_via_lifespan_async(mock_settings_instance):
             with patch("api_server.RAGConfig") as mock_config_cls:
                 mock_config_cls.side_effect = capture_ragconfig
 
-                from api_server import lifespan
                 from fastapi import FastAPI
+
+                from api_server import lifespan
 
                 app = FastAPI()
                 ctx = lifespan(app)
@@ -104,6 +108,7 @@ async def _build_ragconfig_via_lifespan_async(mock_settings_instance):
 # ---------------------------------------------------------------------------
 # TEST: All 15 RAGConfig fields are wired correctly
 # ---------------------------------------------------------------------------
+
 
 class TestRAGConfigFieldWiring:
     """Every RAGConfig field is correctly populated from settings in lifespan."""
@@ -203,6 +208,7 @@ class TestRAGConfigFieldWiring:
 # TEST: No settings fields are silently dropped
 # ---------------------------------------------------------------------------
 
+
 class TestNoFieldsDropped:
     """Every field that appears in settings appears in the RAGConfig call."""
 
@@ -213,10 +219,20 @@ class TestNoFieldsDropped:
 
         # The 14 fields that come from settings (all except query_transformation_enabled)
         settings_fields = [
-            "db_path", "chunk_size", "n_results", "max_tokens", "temperature",
-            "embedding_model", "chunk_overlap", "min_similarity", "retrieval_window",
-            "hybrid_search", "reranking_enabled", "reranker_model",
-            "initial_retrieval_top_k", "rerank_top_k",
+            "db_path",
+            "chunk_size",
+            "n_results",
+            "max_tokens",
+            "temperature",
+            "embedding_model",
+            "chunk_overlap",
+            "min_similarity",
+            "retrieval_window",
+            "hybrid_search",
+            "reranking_enabled",
+            "reranker_model",
+            "initial_retrieval_top_k",
+            "rerank_top_k",
         ]
         for field in settings_fields:
             assert field in kwargs, f"Field '{field}' is missing from RAGConfig call"
@@ -226,13 +242,27 @@ class TestNoFieldsDropped:
         """All RAGConfig constructor parameters are passed (now 18 fields after fixes 2 and 8)."""
         kwargs = await _build_ragconfig_via_lifespan_async(mock_settings)
 
-        # Core 15 original fields plus 3 added in remediation (context_truncation, gguf_n_ctx, gguf_n_threads)
+        # Core 15 original fields plus 3 remediation additions
+        # (context_truncation, gguf_n_ctx, gguf_n_threads)
         required = {
-            "db_path", "chunk_size", "n_results", "max_tokens", "temperature",
-            "embedding_model", "chunk_overlap", "min_similarity", "retrieval_window",
-            "hybrid_search", "reranking_enabled", "reranker_model",
-            "query_transformation_enabled", "initial_retrieval_top_k", "rerank_top_k",
-            "context_truncation", "gguf_n_ctx", "gguf_n_threads",
+            "db_path",
+            "chunk_size",
+            "n_results",
+            "max_tokens",
+            "temperature",
+            "embedding_model",
+            "chunk_overlap",
+            "min_similarity",
+            "retrieval_window",
+            "hybrid_search",
+            "reranking_enabled",
+            "reranker_model",
+            "query_transformation_enabled",
+            "initial_retrieval_top_k",
+            "rerank_top_k",
+            "context_truncation",
+            "gguf_n_ctx",
+            "gguf_n_threads",
         }
         missing = required - set(kwargs.keys())
         assert not missing, f"Missing RAGConfig fields: {missing}"
@@ -242,12 +272,14 @@ class TestNoFieldsDropped:
 # TEST: rag_context_truncation NOT wired (RAGConfig has no such parameter)
 # ---------------------------------------------------------------------------
 
+
 class TestContextTruncationWired:
     """context_truncation is now a RAGConfig field — verify it is present and defaults correctly."""
 
     def test_rag_settings_has_rag_context_truncation(self):
         """Sanity check: RAGSettings does have rag_context_truncation."""
         from config import RAGSettings
+
         s = RAGSettings()
         assert hasattr(s, "rag_context_truncation")
         assert s.rag_context_truncation == 20000
@@ -255,23 +287,27 @@ class TestContextTruncationWired:
     def test_ragconfig_has_context_truncation_param(self):
         """RAGConfig.__init__ now has context_truncation parameter (fix 2)."""
         import inspect
+
         from rag_engine import RAGConfig
+
         sig = inspect.signature(RAGConfig.__init__)
         params = set(sig.parameters.keys())
-        assert "context_truncation" in params, (
-            "context_truncation must be a RAGConfig parameter — it was added in fix 2"
-        )
+        assert (
+            "context_truncation" in params
+        ), "context_truncation must be a RAGConfig parameter — it was added in fix 2"
         assert "rag_context_truncation" not in params
 
     def test_ragconfig_context_truncation_default(self):
         """RAGConfig.context_truncation defaults to 20000."""
         from rag_engine import RAGConfig
+
         c = RAGConfig()
         assert c.context_truncation == 20000
 
     def test_ragconfig_context_truncation_roundtrip(self):
         """context_truncation survives to_dict/from_dict roundtrip."""
         from rag_engine import RAGConfig
+
         c = RAGConfig(context_truncation=15000)
         d = c.to_dict()
         assert d["context_truncation"] == 15000
@@ -282,6 +318,7 @@ class TestContextTruncationWired:
 # ---------------------------------------------------------------------------
 # TEST: Default values flow through when settings are at defaults
 # ---------------------------------------------------------------------------
+
 
 class TestDefaultValuesFlowThrough:
     """When settings are at their defaults, RAGConfig receives correct default values."""
@@ -309,6 +346,9 @@ class TestDefaultValuesFlowThrough:
         mock.rag_rerank_top_k = 6
         mock.rag_gguf_n_ctx = 4096
         mock.rag_gguf_n_threads = 4
+        mock.rag_fast_profile_path = (
+            None  # issue #53 knob; not exercised by these tests
+        )
 
         kwargs = await _build_ragconfig_via_lifespan_async(mock)
 
@@ -332,6 +372,7 @@ class TestDefaultValuesFlowThrough:
 # ---------------------------------------------------------------------------
 # TEST: RAGConfig is used to instantiate RAGEngine
 # ---------------------------------------------------------------------------
+
 
 class TestRAGEngineReceivesRAGConfig:
     """The RAGConfig created in lifespan is passed to RAGEngine."""
@@ -359,6 +400,9 @@ class TestRAGEngineReceivesRAGConfig:
         mock.rag_rerank_top_k = 6
         mock.rag_gguf_n_ctx = 4096
         mock.rag_gguf_n_threads = 4
+        mock.rag_fast_profile_path = (
+            None  # issue #53 knob; not exercised by these tests
+        )
 
         captured_engine_calls = []
 
@@ -371,8 +415,9 @@ class TestRAGEngineReceivesRAGConfig:
                 with patch("api_server.RAGConfig") as mock_config_cls:
                     mock_config_cls.return_value = MagicMock()
 
-                    from api_server import lifespan
                     from fastapi import FastAPI
+
+                    from api_server import lifespan
 
                     app = FastAPI()
                     ctx = lifespan(app)
@@ -391,14 +436,16 @@ class TestRAGEngineReceivesRAGConfig:
 # TEST: GGUF path validation respects environment variable
 # ---------------------------------------------------------------------------
 
+
 class TestGGUFPathValidation:
     """GGUF path is validated when RAG_GGUF_PATH env var is set."""
 
     @pytest.mark.asyncio
     async def test_gguf_path_set_and_valid(self):
         """When RAG_GGUF_PATH is set to a valid path, it is passed to RAGEngine."""
-        from config import RAGSettings
         import tempfile
+
+        from config import RAGSettings
 
         mock = MagicMock(spec=RAGSettings)
         mock.rag_db_path = "./doc_qa_db"
@@ -418,6 +465,9 @@ class TestGGUFPathValidation:
         mock.rag_rerank_top_k = 6
         mock.rag_gguf_n_ctx = 4096
         mock.rag_gguf_n_threads = 4
+        mock.rag_fast_profile_path = (
+            None  # issue #53 knob; not exercised by these tests
+        )
 
         with tempfile.TemporaryDirectory() as tmpdir:
             fake_gguf = os.path.join(tmpdir, "model.gguf")
@@ -435,8 +485,9 @@ class TestGGUFPathValidation:
                         with patch("api_server.RAGConfig") as mock_config_cls:
                             mock_config_cls.return_value = MagicMock()
 
-                            from api_server import lifespan
                             from fastapi import FastAPI
+
+                            from api_server import lifespan
 
                             app = FastAPI()
                             ctx = lifespan(app)
@@ -473,13 +524,17 @@ class TestGGUFPathValidation:
         mock.rag_rerank_top_k = 6
         mock.rag_gguf_n_ctx = 4096
         mock.rag_gguf_n_threads = 4
+        mock.rag_fast_profile_path = (
+            None  # issue #53 knob; not exercised by these tests
+        )
 
         with patch.dict(os.environ, {"RAG_GGUF_PATH": "/nonexistent/path/model.gguf"}):
             with patch("api_server.settings", mock):
                 with patch("api_server.RAGEngine"):
                     with patch("api_server.RAGConfig"):
-                        from api_server import lifespan
                         from fastapi import FastAPI
+
+                        from api_server import lifespan
 
                         app = FastAPI()
                         ctx = lifespan(app)

--- a/tests/test_app_gui_message_queue_validation.py
+++ b/tests/test_app_gui_message_queue_validation.py
@@ -11,15 +11,17 @@ KEY BEHAVIORS TESTED:
 - Valid tuple messages → processed normally (no log, routed correctly)
 """
 
-import pytest
 import inspect
 import logging
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, call, patch
+
+import pytest
 
 
 def _import_app_gui():
     try:
         import app_gui
+
         return app_gui
     except ImportError:
         pytest.skip("customtkinter not installed")
@@ -28,6 +30,7 @@ def _import_app_gui():
 # ---------------------------------------------------------------------------
 # Test 1: Source code presence of validation guard
 # ---------------------------------------------------------------------------
+
 
 class TestValidationGuardPresence:
     """Verify the validation guard exists in process() source code."""
@@ -46,15 +49,15 @@ class TestValidationGuardPresence:
         source = inspect.getsource(app_gui.DocumentQAApp._start_message_processor)
 
         # The three-part guard must be present
-        assert "isinstance(msg, tuple)" in source, (
-            "process() must check isinstance(msg, tuple)"
-        )
-        assert "len(msg) < 1" in source or "not msg" in source, (
-            "process() must check len(msg) < 1 or not msg (empty tuple guard)"
-        )
-        assert "isinstance(msg[0], str)" in source, (
-            "process() must check isinstance(msg[0], str)"
-        )
+        assert (
+            "isinstance(msg, tuple)" in source
+        ), "process() must check isinstance(msg, tuple)"
+        assert (
+            "len(msg) < 1" in source or "not msg" in source
+        ), "process() must check len(msg) < 1 or not msg (empty tuple guard)"
+        assert (
+            "isinstance(msg[0], str)" in source
+        ), "process() must check isinstance(msg[0], str)"
 
     def test_guard_uses_continue(self):
         """
@@ -65,9 +68,9 @@ class TestValidationGuardPresence:
         source = inspect.getsource(app_gui.DocumentQAApp._start_message_processor)
 
         # After the guard check, must skip with `continue`
-        assert "continue" in source, (
-            "process() must use `continue` to skip malformed messages"
-        )
+        assert (
+            "continue" in source
+        ), "process() must use `continue` to skip malformed messages"
 
     def test_guard_logs_a_warning(self):
         """
@@ -77,12 +80,12 @@ class TestValidationGuardPresence:
         app_gui = _import_app_gui()
         source = inspect.getsource(app_gui.DocumentQAApp._start_message_processor)
 
-        assert ".warning(" in source or 'logging.warning' in source, (
-            "process() must call logger.warning() when skipping a malformed message"
-        )
-        assert "Skipping malformed message" in source, (
-            "The warning message must contain 'Skipping malformed message'"
-        )
+        assert (
+            ".warning(" in source or "logging.warning" in source
+        ), "process() must call logger.warning() when skipping a malformed message"
+        assert (
+            "Skipping malformed message" in source
+        ), "The warning message must contain 'Skipping malformed message'"
 
     def test_guard_order_not_tuple_first(self):
         """
@@ -101,23 +104,38 @@ class TestValidationGuardPresence:
                 guard_line_idx = i
                 break
 
-        assert guard_line_idx is not None, (
-            "Guard must check isinstance(msg, tuple)"
-        )
+        assert guard_line_idx is not None, "Guard must check isinstance(msg, tuple)"
 
-        # The guard line must contain the tuple check as a top-level conjunct
-        guard_line = source.splitlines()[guard_line_idx]
-        # Strip leading whitespace for clean check
-        guard_line_stripped = guard_line.strip()
-        assert guard_line_stripped.startswith("if not isinstance(msg, tuple)"), (
-            f"Guard check must start with 'not isinstance(msg, tuple)' "
-            f"(not e.g. len(msg) < 1 first), but found: {guard_line_stripped}"
+        # The guard must check the tuple type before anything that subscripts
+        # msg. black may wrap the condition across lines, and the
+        # isinstance-conjunct line may not be the `if` line itself, so walk
+        # back to the statement start, join through the terminating colon,
+        # and compare whitespace-insensitively.
+        raw_lines = source.splitlines()
+        stmt_start = guard_line_idx
+        for back in range(guard_line_idx, max(guard_line_idx - 5, -1), -1):
+            if raw_lines[back].strip().startswith("if"):
+                stmt_start = back
+                break
+        joined = ""
+        for line in raw_lines[stmt_start:]:
+            joined += " " + line.strip()
+            if line.rstrip().endswith(":"):
+                break
+        compact = "".join(joined.split())
+        starts_with_tuple_check = compact.startswith(
+            "if(notisinstance(msg,tuple)"
+        ) or compact.startswith("ifnotisinstance(msg,tuple)")
+        assert starts_with_tuple_check, (
+            f"Guard check must test 'not isinstance(msg, tuple)' first "
+            f"(not e.g. len(msg) < 1 first), but found: {joined.strip()}"
         )
 
 
 # ---------------------------------------------------------------------------
 # Test 2: Guard logic — standalone unit test of the guard condition
 # ---------------------------------------------------------------------------
+
 
 class TestValidationGuardLogic:
     """
@@ -132,8 +150,14 @@ class TestValidationGuardLogic:
         Returns the guard condition as a callable bool(msg) → True means SKIP.
         Mirrors:  if not isinstance(msg, tuple) or len(msg) < 1 or not isinstance(msg[0], str): skip
         """
+
         def should_skip(msg):
-            return not isinstance(msg, tuple) or len(msg) < 1 or not isinstance(msg[0], str)
+            return (
+                not isinstance(msg, tuple)
+                or len(msg) < 1
+                or not isinstance(msg[0], str)
+            )
+
         return should_skip
 
     # --- Non-tuple types → must be skipped ---
@@ -205,6 +229,7 @@ class TestValidationGuardLogic:
 # Test 3: Integration — process() handles each malformed type without crashing
 # ---------------------------------------------------------------------------
 
+
 class TestProcessSkipsMalformedMessages:
     """
     Test that the process() loop inside _start_message_processor
@@ -228,13 +253,16 @@ class TestProcessSkipsMalformedMessages:
         Returns True if the message was skipped (malformed), False if processed.
         """
         import queue
+
         mock_app.message_queue.get_nowait.side_effect = [msg, queue.Empty()]
 
         skipped = False
         try:
             m = mock_app.message_queue.get_nowait()
             if not isinstance(m, tuple) or len(m) < 1 or not isinstance(m[0], str):
-                logging.getLogger("app_gui").warning(f"Skipping malformed message: {type(m).__name__}")
+                logging.getLogger("app_gui").warning(
+                    f"Skipping malformed message: {type(m).__name__}"
+                )
                 skipped = True
             else:
                 # Would route normally; simulate by calling the appropriate handler
@@ -284,16 +312,25 @@ class TestProcessSkipsMalformedMessages:
 # Test 4: Logging output — each malformed type generates a warning
 # ---------------------------------------------------------------------------
 
+
 class TestValidationLogsWarning:
     """Verify that each malformed message type triggers a logger.warning call."""
 
     def test_string_message_logs_warning(self, caplog):
         with caplog.at_level(logging.WARNING, logger="app_gui"):
+
             def should_skip(msg):
-                return not isinstance(msg, tuple) or len(msg) < 1 or not isinstance(msg[0], str)
+                return (
+                    not isinstance(msg, tuple)
+                    or len(msg) < 1
+                    or not isinstance(msg[0], str)
+                )
+
             msg = "status:ready"
             if should_skip(msg):
-                logging.getLogger("app_gui").warning(f"Skipping malformed message: {type(msg).__name__}")
+                logging.getLogger("app_gui").warning(
+                    f"Skipping malformed message: {type(msg).__name__}"
+                )
 
         assert len(caplog.records) == 1
         assert caplog.records[0].levelno == logging.WARNING
@@ -302,11 +339,19 @@ class TestValidationLogsWarning:
 
     def test_int_message_logs_warning(self, caplog):
         with caplog.at_level(logging.WARNING, logger="app_gui"):
+
             def should_skip(msg):
-                return not isinstance(msg, tuple) or len(msg) < 1 or not isinstance(msg[0], str)
+                return (
+                    not isinstance(msg, tuple)
+                    or len(msg) < 1
+                    or not isinstance(msg[0], str)
+                )
+
             msg = 42
             if should_skip(msg):
-                logging.getLogger("app_gui").warning(f"Skipping malformed message: {type(msg).__name__}")
+                logging.getLogger("app_gui").warning(
+                    f"Skipping malformed message: {type(msg).__name__}"
+                )
 
         assert len(caplog.records) == 1
         assert caplog.records[0].levelno == logging.WARNING
@@ -315,11 +360,19 @@ class TestValidationLogsWarning:
 
     def test_empty_tuple_logs_warning(self, caplog):
         with caplog.at_level(logging.WARNING, logger="app_gui"):
+
             def should_skip(msg):
-                return not isinstance(msg, tuple) or len(msg) < 1 or not isinstance(msg[0], str)
+                return (
+                    not isinstance(msg, tuple)
+                    or len(msg) < 1
+                    or not isinstance(msg[0], str)
+                )
+
             msg = ()
             if should_skip(msg):
-                logging.getLogger("app_gui").warning(f"Skipping malformed message: {type(msg).__name__}")
+                logging.getLogger("app_gui").warning(
+                    f"Skipping malformed message: {type(msg).__name__}"
+                )
 
         assert len(caplog.records) == 1
         assert caplog.records[0].levelno == logging.WARNING
@@ -328,11 +381,19 @@ class TestValidationLogsWarning:
 
     def test_tuple_with_int_first_element_logs_warning(self, caplog):
         with caplog.at_level(logging.WARNING, logger="app_gui"):
+
             def should_skip(msg):
-                return not isinstance(msg, tuple) or len(msg) < 1 or not isinstance(msg[0], str)
+                return (
+                    not isinstance(msg, tuple)
+                    or len(msg) < 1
+                    or not isinstance(msg[0], str)
+                )
+
             msg = (42, "payload")
             if should_skip(msg):
-                logging.getLogger("app_gui").warning(f"Skipping malformed message: {type(msg).__name__}")
+                logging.getLogger("app_gui").warning(
+                    f"Skipping malformed message: {type(msg).__name__}"
+                )
 
         assert len(caplog.records) == 1
         assert caplog.records[0].levelno == logging.WARNING

--- a/tests/test_app_gui_streaming_callback.py
+++ b/tests/test_app_gui_streaming_callback.py
@@ -13,13 +13,14 @@ but app_gui._ask_question() passes stream_callback=on_token to query().
 This causes a TypeError: query() got an unexpected keyword argument 'stream_callback'.
 """
 
-import pytest
 import inspect
 
+import pytest
 
 # ---------------------------------------------------------------------------
 # Criterion 1: stream_callback puts tokens into message_queue
 # ---------------------------------------------------------------------------
+
 
 class TestStreamCallbackPutsTokensIntoQueue:
     """Task 4.2 Criterion 1: on_token closure puts tokens into message_queue."""
@@ -39,7 +40,7 @@ class TestStreamCallbackPutsTokensIntoQueue:
         # The on_token function must put ("assistant_token", token) into message_queue
         assert 'message_queue.put(("assistant_token", token))' in source, (
             "on_token callback must put ('assistant_token', token) tuple into message_queue. "
-            "Found: " + source[source.find("on_token"):source.find("on_token")+200]
+            "Found: " + source[source.find("on_token") : source.find("on_token") + 200]
         )
 
     def test_on_token_closure_uses_message_queue_put(self):
@@ -69,14 +70,15 @@ class TestStreamCallbackPutsTokensIntoQueue:
                         break
 
         on_token_body = "\n".join(on_token_lines)
-        assert "message_queue.put" in on_token_body, (
-            f"on_token callback must call message_queue.put(). Body found:\n{on_token_body}"
-        )
+        assert (
+            "message_queue.put" in on_token_body
+        ), f"on_token callback must call message_queue.put(). Body found:\n{on_token_body}"
 
 
 # ---------------------------------------------------------------------------
 # Criterion 2: message_processor handles "assistant_token"
 # ---------------------------------------------------------------------------
+
 
 class TestMessageProcessorHandlesAssistantToken:
     """Task 4.2 Criterion 2: message_processor dispatches 'assistant_token' to _handle_streaming_token."""
@@ -106,9 +108,9 @@ class TestMessageProcessorHandlesAssistantToken:
         )
 
         # Must extract token from msg[1]
-        assert "msg[1]" in source, (
-            "_start_message_processor must pass msg[1] (the token) to _handle_streaming_token."
-        )
+        assert (
+            "msg[1]" in source
+        ), "_start_message_processor must pass msg[1] (the token) to _handle_streaming_token."
 
     def test_assistant_token_branch_winxinfo_check(self):
         """
@@ -127,16 +129,17 @@ class TestMessageProcessorHandlesAssistantToken:
             assistant_token_idx = source.find("'assistant_token'")
 
         # Get the next ~200 chars after assistant_token check
-        chunk = source[assistant_token_idx:assistant_token_idx+300]
+        chunk = source[assistant_token_idx : assistant_token_idx + 300]
 
-        assert "winfo_exists()" in chunk, (
-            "assistant_token handler must check winfo_exists() before updating UI widgets."
-        )
+        assert (
+            "winfo_exists()" in chunk
+        ), "assistant_token handler must check winfo_exists() before updating UI widgets."
 
 
 # ---------------------------------------------------------------------------
 # Criterion 3: streaming message created when first token arrives
 # ---------------------------------------------------------------------------
+
 
 class TestStreamingMessageCreatedOnFirstToken:
     """Task 4.2 Criterion 3: _handle_streaming_token creates message frame on first token."""
@@ -154,7 +157,10 @@ class TestStreamingMessageCreatedOnFirstToken:
         source = inspect.getsource(app_gui.DocumentQAApp._handle_streaming_token)
 
         # Must check _streaming_message_ref is None
-        assert "_streaming_message_ref is None" in source or "_streaming_message_ref == None" in source, (
+        assert (
+            "_streaming_message_ref is None" in source
+            or "_streaming_message_ref == None" in source
+        ), (
             "_handle_streaming_token must check 'self._streaming_message_ref is None' "
             "to detect first token arrival. Found:\n" + source[:300]
         )
@@ -172,14 +178,14 @@ class TestStreamingMessageCreatedOnFirstToken:
         source = inspect.getsource(app_gui.DocumentQAApp._handle_streaming_token)
 
         # First token path must create _streaming_message_frame
-        assert "_streaming_message_frame" in source, (
-            "_handle_streaming_token must create _streaming_message_frame on first token."
-        )
+        assert (
+            "_streaming_message_frame" in source
+        ), "_handle_streaming_token must create _streaming_message_frame on first token."
 
         # First token path must create _streaming_message_ref (the text label)
-        assert "_streaming_message_ref" in source, (
-            "_handle_streaming_token must assign _streaming_message_ref on first token."
-        )
+        assert (
+            "_streaming_message_ref" in source
+        ), "_handle_streaming_token must assign _streaming_message_ref on first token."
 
     def test_subsequent_tokens_append_to_existing(self):
         """
@@ -194,14 +200,14 @@ class TestStreamingMessageCreatedOnFirstToken:
         source = inspect.getsource(app_gui.DocumentQAApp._handle_streaming_token)
 
         # Must have else branch for subsequent tokens
-        assert "else:" in source, (
-            "_handle_streaming_token must have an else branch for subsequent tokens."
-        )
+        assert (
+            "else:" in source
+        ), "_handle_streaming_token must have an else branch for subsequent tokens."
 
         # Subsequent tokens must get current text and append
-        assert "cget(\"text\")" in source or "cget('text')" in source, (
-            "Subsequent tokens must read current text via cget('text') and append token."
-        )
+        assert (
+            'cget("text")' in source or "cget('text')" in source
+        ), "Subsequent tokens must read current text via cget('text') and append token."
 
     def test_scroll_to_bottom_on_each_token(self):
         """
@@ -225,6 +231,7 @@ class TestStreamingMessageCreatedOnFirstToken:
 # ---------------------------------------------------------------------------
 # Criterion 4: typing indicator shown during streaming
 # ---------------------------------------------------------------------------
+
 
 class TestTypingIndicatorShownDuringStreaming:
     """Task 4.2 Criterion 4: cancel_button_show sent when worker starts (typing indicator shown)."""
@@ -277,9 +284,9 @@ class TestTypingIndicatorShownDuringStreaming:
         source = inspect.getsource(app_gui.DocumentQAApp._ask_question)
 
         # Must hide typing indicator on completion
-        assert "hide_typing" in source, (
-            "_ask_question must queue 'hide_typing' when streaming completes."
-        )
+        assert (
+            "hide_typing" in source
+        ), "_ask_question must queue 'hide_typing' when streaming completes."
 
     def test_hide_typing_in_message_processor(self):
         """
@@ -292,19 +299,22 @@ class TestTypingIndicatorShownDuringStreaming:
 
         source = inspect.getsource(app_gui.DocumentQAApp._start_message_processor)
 
-        assert '"hide_typing"' in source or "'hide_typing'" in source, (
-            "_start_message_processor must handle 'hide_typing' message to hide typing indicator."
-        )
+        assert (
+            '"hide_typing"' in source or "'hide_typing'" in source
+        ), "_start_message_processor must handle 'hide_typing' message to hide typing indicator."
 
 
 # ---------------------------------------------------------------------------
 # Criterion 5: streaming finalized when "message" tuple arrives
 # ---------------------------------------------------------------------------
 
+
 class TestStreamingFinalizedWhenMessageArrives:
     """Task 4.2 Criterion 5: streaming message refs cleared when final message tuple arrives."""
 
-    @pytest.mark.skip(reason="Attribute cleared via message queue in UI modernization (PR #10), not directly in _ask_question")
+    @pytest.mark.skip(
+        reason="Attribute cleared via message queue in UI modernization (PR #10), not directly in _ask_question"
+    )
     def test_query_clears_streaming_ref_on_completion(self):
         """
         In _ask_question, after engine.query() returns, the query() inner function
@@ -324,9 +334,9 @@ class TestStreamingFinalizedWhenMessageArrives:
         )
 
         # Must clear _streaming_message_frame too
-        assert "_streaming_message_frame = None" in source, (
-            "_ask_question must set _streaming_message_frame = None after streaming completes."
-        )
+        assert (
+            "_streaming_message_frame = None" in source
+        ), "_ask_question must set _streaming_message_frame = None after streaming completes."
 
     def test_streaming_ref_cleared_only_if_not_none(self):
         """
@@ -347,7 +357,9 @@ class TestStreamingFinalizedWhenMessageArrives:
             "before clearing streaming refs (guards against double-clear / non-streaming path)."
         )
 
-    @pytest.mark.skip(reason="Attribute cleared via message queue in UI modernization (PR #10), not directly in _ask_question")
+    @pytest.mark.skip(
+        reason="Attribute cleared via message queue in UI modernization (PR #10), not directly in _ask_question"
+    )
     def test_query_thread_clears_on_cancellation(self):
         """
         When query is cancelled, _streaming_message_ref and _streaming_message_frame
@@ -365,7 +377,7 @@ class TestStreamingFinalizedWhenMessageArrives:
         if "_operation_cancelled.is_set()" in source:
             # Extract ~500 chars around the cancellation check
             cancel_idx = source.find("_operation_cancelled.is_set()")
-            chunk = source[cancel_idx:cancel_idx+500]
+            chunk = source[cancel_idx : cancel_idx + 500]
 
             assert "_streaming_message_ref" in chunk and "None" in chunk, (
                 "Cancellation path must also clear _streaming_message_ref to avoid "
@@ -376,6 +388,7 @@ class TestStreamingFinalizedWhenMessageArrives:
 # ---------------------------------------------------------------------------
 # CRITICAL BUG TEST: stream_callback is NOT wired through rag_engine.query()
 # ---------------------------------------------------------------------------
+
 
 class TestStreamCallbackWiringBug:
     """
@@ -420,9 +433,9 @@ class TestStreamCallbackWiringBug:
         source = inspect.getsource(app_gui.DocumentQAApp._ask_question)
 
         # Verify that stream_callback IS passed to query
-        assert "stream_callback=on_token" in source, (
-            "app_gui._ask_question() must pass stream_callback=on_token to query()."
-        )
+        assert (
+            "stream_callback=on_token" in source
+        ), "app_gui._ask_question() must pass stream_callback=on_token to query()."
 
     def test_rag_engine_query_passes_stream_callback_to_answer_question(self):
         """
@@ -435,23 +448,26 @@ class TestStreamCallbackWiringBug:
 
         source = inspect.getsource(rag_engine.RAGEngine.query)
 
-        # Find the answer_question call
+        # Find the answer_question call. The window spans enough continuation
+        # lines to cover black-wrapped multi-line argument lists (the
+        # InferenceConfig(...) block alone spans 4 lines).
         if "answer_question" in source:
             # Get the answer_question call lines
             lines = source.split("\n")
             for i, line in enumerate(lines):
                 if "answer_question" in line and "self.llm" in line:
-                    # Get surrounding 3 lines
-                    call_chunk = "\n".join(lines[max(0,i-1):i+8])
-                    assert "stream_callback" in call_chunk, (
-                        f"BUG: answer_question call missing stream_callback:\n{call_chunk}"
-                    )
+                    # Get surrounding lines
+                    call_chunk = "\n".join(lines[max(0, i - 1) : i + 14])
+                    assert (
+                        "stream_callback" in call_chunk
+                    ), f"BUG: answer_question call missing stream_callback:\n{call_chunk}"
                     break
 
 
 # ---------------------------------------------------------------------------
 # Sanity checks: required instance variables exist
 # ---------------------------------------------------------------------------
+
 
 class TestRequiredInstanceVariables:
     """Verify DocumentQAApp has all required instance variables for streaming."""
@@ -464,11 +480,13 @@ class TestRequiredInstanceVariables:
             pytest.skip("customtkinter not installed")
 
         source = inspect.getsource(app_gui.DocumentQAApp.__init__)
-        assert "message_queue = queue.Queue()" in source, (
-            "__init__ must initialize self.message_queue = queue.Queue()"
-        )
+        assert (
+            "message_queue = queue.Queue()" in source
+        ), "__init__ must initialize self.message_queue = queue.Queue()"
 
-    @pytest.mark.skip(reason="Attribute initialized in __init__, not _create_widgets, in UI modernization (PR #10)")
+    @pytest.mark.skip(
+        reason="Attribute initialized in __init__, not _create_widgets, in UI modernization (PR #10)"
+    )
     def test_has_streaming_message_ref(self):
         """
         DocumentQAApp must initialize _streaming_message_ref as None.
@@ -480,11 +498,13 @@ class TestRequiredInstanceVariables:
             pytest.skip("customtkinter not installed")
 
         source = inspect.getsource(app_gui.DocumentQAApp._create_widgets)
-        assert "_streaming_message_ref" in source, (
-            "_create_widgets must initialize _streaming_message_ref = None"
-        )
+        assert (
+            "_streaming_message_ref" in source
+        ), "_create_widgets must initialize _streaming_message_ref = None"
 
-    @pytest.mark.skip(reason="Attribute initialized in __init__, not _create_widgets, in UI modernization (PR #10)")
+    @pytest.mark.skip(
+        reason="Attribute initialized in __init__, not _create_widgets, in UI modernization (PR #10)"
+    )
     def test_has_streaming_message_frame(self):
         """
         DocumentQAApp must initialize _streaming_message_frame as None.
@@ -496,9 +516,9 @@ class TestRequiredInstanceVariables:
             pytest.skip("customtkinter not installed")
 
         source = inspect.getsource(app_gui.DocumentQAApp._create_widgets)
-        assert "_streaming_message_frame" in source, (
-            "_create_widgets must initialize _streaming_message_frame = None"
-        )
+        assert (
+            "_streaming_message_frame" in source
+        ), "_create_widgets must initialize _streaming_message_frame = None"
 
 
 if __name__ == "__main__":

--- a/tests/test_app_gui_streaming_logging_fix.py
+++ b/tests/test_app_gui_streaming_logging_fix.py
@@ -14,6 +14,7 @@ _SOURCE_FILE = _SOURCE_FILE.replace("\\", "/")  # Normalize to forward slashes
 
 # Platform-agnostic resolution for Windows
 import os as _os
+
 _SOURCE_FILE = _os.path.normpath(
     _os.path.join(_os.path.dirname(_os.path.abspath(__file__)), "..", "app_gui.py")
 )
@@ -26,14 +27,17 @@ def _read_source() -> str:
 
 def _extract_function_body(source: str, func_name: str) -> str:
     """Extract the body of a method from the source code."""
+    # DOTALL: black may wrap the signature across lines
+    # (def f(\n    self, ...\n) -> None:), so the parameter list may contain
+    # newlines between the parens.
     pattern = rf"(?m)^\s+def {re.escape(func_name)}\(.*?\)\s*(?:->\s*\w+)?\s*:\n"
-    match = re.search(pattern, source)
+    match = re.search(pattern, source, re.DOTALL)
     if not match:
         raise ValueError(f"Function '{func_name}' not found in source")
     start = match.end()
 
     # Count leading whitespace of first line
-    first_line_match = re.search(r"(?m)^(\s+)", source[match.start():match.end()])
+    first_line_match = re.search(r"(?m)^(\s+)", source[match.start() : match.end()])
     base_indent = len(first_line_match.group(1)) if first_line_match else 0
 
     # Find end of function (next def/class at same or lower indent, or dedent)
@@ -44,7 +48,9 @@ def _extract_function_body(source: str, func_name: str) -> str:
             body_lines.append(line)
             continue
         indent = len(line) - len(line.lstrip())
-        if indent <= base_indent and (line.strip().startswith("def ") or line.strip().startswith("class ")):
+        if indent <= base_indent and (
+            line.strip().startswith("def ") or line.strip().startswith("class ")
+        ):
             break
         body_lines.append(line)
 
@@ -63,9 +69,9 @@ class TestStreamingExceptionLoggingFix:
         has_logger_call = bool(
             re.search(r'logging\.getLogger\(["\']app_gui["\']\)', body)
         )
-        assert has_logger_call, (
-            "_get_streaming_text: missing `logging.getLogger('app_gui')` call in exception handler"
-        )
+        assert (
+            has_logger_call
+        ), "_get_streaming_text: missing `logging.getLogger('app_gui')` call in exception handler"
 
         # Must call .debug() on that logger
         has_debug = bool(
@@ -78,8 +84,7 @@ class TestStreamingExceptionLoggingFix:
 
         # Must NOT contain silent `pass`
         silent_pass_pattern = re.compile(
-            r"except\s+Exception\s+as\s+\w+:\s+pass",
-            re.DOTALL
+            r"except\s+Exception\s+as\s+\w+:\s+pass", re.DOTALL
         )
         has_silent_pass = bool(silent_pass_pattern.search(body))
         assert not has_silent_pass, (
@@ -97,7 +102,7 @@ class TestStreamingExceptionLoggingFix:
         # then the except line capturing the handler body.
         add_message_exc_pattern = re.compile(
             r"try:\n\s+self\._add_message.*?\n\s+except\s+Exception\s+as\s+(\w+):\n((?:\s+.+\n)+)",
-            re.DOTALL
+            re.DOTALL,
         )
         match = re.search(add_message_exc_pattern, body)
         assert match, (
@@ -152,7 +157,7 @@ class TestStreamingExceptionLoggingFix:
         # then the except line capturing the handler body.
         destroy_exc_pattern = re.compile(
             r"try:\n\s+.*?\.destroy\(\).*?\n\s+except\s+Exception\s+as\s+(\w+):\n((?:\s+.+\n)+)",
-            re.DOTALL
+            re.DOTALL,
         )
         match = re.search(destroy_exc_pattern, body)
         assert match, (
@@ -236,7 +241,7 @@ class TestLoggerNameConsistency:
         # Extract all logging.getLogger calls from both functions
         logger_calls = re.findall(
             r'logging\.getLogger\(["\']([^"\']+)["\']\)',
-            body_finalize + "\n" + body_get
+            body_finalize + "\n" + body_get,
         )
 
         # All must be 'app_gui'

--- a/tests/test_full_council_adversarial.py
+++ b/tests/test_full_council_adversarial.py
@@ -1188,18 +1188,33 @@ def test_ask_question_no_llm_uses_message_queue_thread_safe():
 
     query_body = "\n".join(lines[query_def_line:query_end_line])
 
-    # After checking `if not self.engine.llm:`, error must use message_queue.put()
-    assert (
-        "message_queue.put" in query_body
-    ), "Error handling for llm=None must use message_queue.put() for thread-safety"
+    # The assertion must bind to the no-LLM branch itself, not the whole
+    # query() body: the generic except handler also calls
+    # message_queue.put(_classify_error(...)), which would otherwise satisfy
+    # the regex even if this branch regressed to a direct tkinter call.
+    branch_start = -1
+    for i in range(query_def_line, query_end_line):
+        if "if not self.engine.llm" in lines[i]:
+            branch_start = i
+            break
+    assert branch_start >= 0, "query() must guard on `if not self.engine.llm`"
+    branch_end = query_end_line
+    for i in range(branch_start, query_end_line):
+        if re.match(r"\s*return\b", lines[i]):
+            branch_end = i + 1
+            break
+    no_llm_branch = "\n".join(lines[branch_start:branch_end])
 
-    # The "No LLM" error must be sent via message_queue.put(), either as a
-    # literal "No LLM..." message or routed through _classify_error (issue
-    # #53 relays the real load diagnostic through the classifier). A direct
-    # messagebox.showerror() call remains forbidden (not thread-safe on
-    # Windows).
+    # Inside the no-LLM branch, the error must be queued via
+    # message_queue.put(), either as a literal "No LLM..." message or routed
+    # through _classify_error (issue #53 relays the real load diagnostic).
+    # A direct messagebox.showerror() call remains forbidden (not thread-safe
+    # on Windows).
+    assert (
+        "message_queue.put" in no_llm_branch
+    ), "Error handling for llm=None must use message_queue.put() for thread-safety"
     assert re.search(
-        r'message_queue\.put\([^)]*("No LLM[^"]*"|_classify_error\()', query_body
+        r'message_queue\.put\([^)]*("No LLM[^"]*"|_classify_error\()', no_llm_branch
     ), (
         "The 'No LLM backend available' error must be sent via message_queue.put(), "
         "not messagebox.showerror() (which is not thread-safe on Windows)"

--- a/tests/test_full_council_adversarial.py
+++ b/tests/test_full_council_adversarial.py
@@ -7,19 +7,21 @@ Tests must NOT pass on bad code.
 """
 
 import os
-import sys
+import queue
 import re
+import sys
 import tempfile
 import threading
-import queue
 from pathlib import Path
 from unittest import mock
-from unittest.mock import patch, MagicMock, AsyncMock
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 
 # ─────────────────────────────────────────────
 # A. RESIDUAL ONLINE REFERENCES (CRITICAL)
 # ─────────────────────────────────────────────
+
 
 def test_residual_online_references_search_all_files():
     """
@@ -31,11 +33,19 @@ def test_residual_online_references_search_all_files():
     import glob
 
     patterns = [
-        r'\bollama\b', r'\bopenvino\b', r'\bopenai\b',
-        r'\bapi_url\b', r'\bapi_model\b',
-        r'\bRAG_OLLAMA\b', r'\bRAG_API\b', r'\bRAG_MODEL_PATH\b',
-        r'\bOllamaLLM\b', r'\bOpenVINOLLM\b', r'\bOpenAICompatibleLLM\b',
-        r'\bRAG_OLLAMA_URL\b', r'\bRAG_OLLAMA_MODEL\b',
+        r"\bollama\b",
+        r"\bopenvino\b",
+        r"\bopenai\b",
+        r"\bapi_url\b",
+        r"\bapi_model\b",
+        r"\bRAG_OLLAMA\b",
+        r"\bRAG_API\b",
+        r"\bRAG_MODEL_PATH\b",
+        r"\bOllamaLLM\b",
+        r"\bOpenVINOLLM\b",
+        r"\bOpenAICompatibleLLM\b",
+        r"\bRAG_OLLAMA_URL\b",
+        r"\bRAG_OLLAMA_MODEL\b",
     ]
 
     violations = []
@@ -43,25 +53,38 @@ def test_residual_online_references_search_all_files():
 
     # Focus on source files (exclude tests/, tests\, __pycache__, .venv/, dist/)
     source_files = [
-        f for f in py_files
-        if not any(x in f for x in ['__pycache__', '.venv', 'venv', '.git', 'tests/', 'tests' + chr(92)])
-        and 'dist' not in f.split(os.sep)
+        f
+        for f in py_files
+        if not any(
+            x in f
+            for x in [
+                "__pycache__",
+                ".venv",
+                "venv",
+                ".git",
+                "tests/",
+                "tests" + chr(92),
+            ]
+        )
+        and "dist" not in f.split(os.sep)
         and os.path.isfile(f)
     ]
 
     for filepath in source_files:
         try:
-            with open(filepath, 'r', encoding='utf-8', errors='ignore') as f:
+            with open(filepath, "r", encoding="utf-8", errors="ignore") as f:
                 lines = f.readlines()
             for line_num, line in enumerate(lines, 1):
                 # Skip comment-only lines (lines that are only comments, not code with inline comments)
                 stripped = line.strip()
-                if stripped.startswith('#'):
+                if stripped.startswith("#"):
                     continue
                 for pattern in patterns:
                     matches = re.finditer(pattern, line, re.IGNORECASE)
                     for m in matches:
-                        violations.append(f"{filepath}:{line_num}: {line.strip()[:100]}")
+                        violations.append(
+                            f"{filepath}:{line_num}: {line.strip()[:100]}"
+                        )
         except Exception:
             pass  # Skip binary files etc.
 
@@ -69,54 +92,68 @@ def test_residual_online_references_search_all_files():
     critical_violations = []
     for v in violations:
         # Skip comment-only lines
-        if '# ' in v:
-            parts = v.split(':')
+        if "# " in v:
+            parts = v.split(":")
             if len(parts) >= 3:
-                code_part = ':'.join(parts[2:])
-                if code_part.strip().startswith('#'):
+                code_part = ":".join(parts[2:])
+                if code_part.strip().startswith("#"):
                     continue
 
         # Allow api_server.py lifespan env var reads (they're validation-only)
         # Also allow logger.error messages that reference Ollama/API config (informational only)
-        if 'api_server.py' in v:
+        if "api_server.py" in v:
             # Env var reads in lifespan are validation-only
-            if 'ollama_url' in v.lower() or 'api_url' in v.lower():
+            if "ollama_url" in v.lower() or "api_url" in v.lower():
                 continue
-            if 'RAG_OLLAMA' in v or 'RAG_API' in v:
+            if "RAG_OLLAMA" in v or "RAG_API" in v:
                 continue
-            if 'ollama_model' in v.lower() or 'api_model' in v.lower():
+            if "ollama_model" in v.lower() or "api_model" in v.lower():
                 continue
             # Ollama references in logger.error messages are informational
-            if 'Ollama' in v and 'logger.error' in v:
+            if "Ollama" in v and "logger.error" in v:
                 continue
             # RAG_MODEL_PATH in env var read
-            if 'RAG_MODEL_PATH' in v:
+            if "RAG_MODEL_PATH" in v:
                 continue
 
         # security.py comment about Ollama in allowed ports - informational only
-        if 'security.py' in v and 'Ollama' in v and 'DEFAULT_ALLOWED_PORTS' in v:
+        if "security.py" in v and "Ollama" in v and "DEFAULT_ALLOWED_PORTS" in v:
             continue
 
         critical_violations.append(v)
 
     # Also check rag_engine.py for RAGEngine constructor params
     from pathlib import Path as P
+
     rag_engine_path = P("rag_engine.py")
     if rag_engine_path.exists():
-        with open(rag_engine_path, 'r', encoding='utf-8') as f:
+        with open(rag_engine_path, "r", encoding="utf-8") as f:
             content = f.read()
         # RAGEngine should NOT have model_path, ollama_model, ollama_url, api_url, api_model, device params
-        bad_params = ['model_path', 'ollama_model', 'ollama_url', 'api_url', 'api_model', 'device']
+        bad_params = [
+            "model_path",
+            "ollama_model",
+            "ollama_url",
+            "api_url",
+            "api_model",
+            "device",
+        ]
         for param in bad_params:
             # Look for it in the __init__ definition
-            init_match = re.search(r'def __init__\([^)]*' + param + r'[^)]*\)', content)
+            init_match = re.search(r"def __init__\([^)]*" + param + r"[^)]*\)", content)
             if init_match:
-                critical_violations.append(f"rag_engine.py: RAGEngine.__init__ has forbidden param '{param}'")
+                critical_violations.append(
+                    f"rag_engine.py: RAGEngine.__init__ has forbidden param '{param}'"
+                )
 
     assert len(critical_violations) == 0, (
-        f"CRITICAL: Found {len(critical_violations)} residual online LLM references:\n" +
-        "\n".join(critical_violations[:20]) +
-        (f"\n... and {len(critical_violations)-20} more" if len(critical_violations) > 20 else "")
+        f"CRITICAL: Found {len(critical_violations)} residual online LLM references:\n"
+        + "\n".join(critical_violations[:20])
+        + (
+            f"\n... and {len(critical_violations)-20} more"
+            if len(critical_violations) > 20
+            else ""
+        )
     )
 
 
@@ -132,46 +169,56 @@ def test_engine_factory_does_not_accept_old_params():
     sig = inspect.signature(create_engine_from_settings)
     params = list(sig.parameters.keys())
 
-    forbidden = ['ollama_model', 'ollama_url', 'api_url', 'api_model', 'device', 'model_path']
+    forbidden = [
+        "ollama_model",
+        "ollama_url",
+        "api_url",
+        "api_model",
+        "device",
+        "model_path",
+    ]
 
     found_forbidden = [p for p in forbidden if p in params]
 
-    assert len(found_forbidden) == 0, (
-        f"engine_factory.create_engine_from_settings() still accepts forbidden params: {found_forbidden}"
-    )
+    assert (
+        len(found_forbidden) == 0
+    ), f"engine_factory.create_engine_from_settings() still accepts forbidden params: {found_forbidden}"
 
     # Also check the function body for any usage of these params
     source = inspect.getsource(create_engine_from_settings)
     for param in forbidden:
-        assert param not in source, (
-            f"engine_factory.create_engine_from_settings() references forbidden param '{param}' in body"
-        )
+        assert (
+            param not in source
+        ), f"engine_factory.create_engine_from_settings() references forbidden param '{param}' in body"
 
 
 # ─────────────────────────────────────────────
 # B. RUNTIME CRASH PATHS
 # ─────────────────────────────────────────────
 
+
 def test_app_instantiation_no_crash():
     """DocumentQAApp can be instantiated without crashing."""
-    if not hasattr(sys, 'frozen'):
+    if not hasattr(sys, "frozen"):
         sys.frozen = False
 
-    with mock.patch('builtins.__import__') as mock_import:
+    with mock.patch("builtins.__import__") as mock_import:
         # Simulate GUI_AVAILABLE = False to avoid tkinter crashes in headless env
         mock_import.side_effect = lambda name, *args, **kwargs: (
-            __import__('customtkinter', fromlist=['ctk'])
-            if 'customtkinter' in name else __import__(name, *args, **kwargs)
+            __import__("customtkinter", fromlist=["ctk"])
+            if "customtkinter" in name
+            else __import__(name, *args, **kwargs)
         )
 
     # Patch customtkinter to appear unavailable
-    with mock.patch.dict('sys.modules', {'customtkinter': None, 'tkinter': None}):
+    with mock.patch.dict("sys.modules", {"customtkinter": None, "tkinter": None}):
         # Test that importing the module doesn't crash even if GUI libs are missing
         pass  # Module already imported
 
     # Test DocumentQAApp instantiation with mocked dependencies
     # We can't fully instantiate it without tkinter, but we can test the class definition
     from app_gui import DocumentQAApp, _classify_error
+
     assert DocumentQAApp is not None
 
 
@@ -182,7 +229,7 @@ def test_initialize_engine_handles_create_engine_failure():
     from app_gui import DocumentQAApp
 
     # Patch create_engine_from_settings to raise
-    with patch('app_gui.create_engine_from_settings') as mock_create:
+    with patch("app_gui.create_engine_from_settings") as mock_create:
         mock_create.side_effect = RuntimeError("Engine creation failed")
 
         # We can't instantiate the full GUI, but we can test the error handling logic
@@ -201,15 +248,16 @@ def test_ask_question_handles_engine_none():
     _ask_question() handles engine=None gracefully.
     The method checks `if not self.engine` first, so it returns early.
     """
-    from app_gui import DocumentQAApp
-
     # Verify the source code has the guard
     import inspect
+
+    from app_gui import DocumentQAApp
+
     source = inspect.getsource(DocumentQAApp._ask_question)
 
-    assert 'if not self.engine:' in source, (
-        "_ask_question() must check 'if not self.engine:' before proceeding"
-    )
+    assert (
+        "if not self.engine:" in source
+    ), "_ask_question() must check 'if not self.engine:' before proceeding"
 
 
 def test_ask_question_handles_engine_llm_none():
@@ -217,33 +265,36 @@ def test_ask_question_handles_engine_llm_none():
     _ask_question() handles engine.llm=None gracefully.
     The method checks `if not self.engine.llm:` before proceeding.
     """
+    import inspect
+
     from app_gui import DocumentQAApp
 
-    import inspect
     source = inspect.getsource(DocumentQAApp._ask_question)
 
-    assert 'if not self.engine.llm:' in source, (
-        "_ask_question() must check 'if not self.engine.llm:' before proceeding"
-    )
+    assert (
+        "if not self.engine.llm:" in source
+    ), "_ask_question() must check 'if not self.engine.llm:' before proceeding"
 
 
 def test_ingest_handles_engine_none():
     """
     _ingest_documents() handles engine=None gracefully.
     """
+    import inspect
+
     from app_gui import DocumentQAApp
 
-    import inspect
     source = inspect.getsource(DocumentQAApp._ingest_documents)
 
-    assert 'if not self.engine:' in source, (
-        "_ingest_documents() must check 'if not self.engine:' before proceeding"
-    )
+    assert (
+        "if not self.engine:" in source
+    ), "_ingest_documents() must check 'if not self.engine:' before proceeding"
 
 
 # ─────────────────────────────────────────────
 # C. ERROR CLASSIFICATION
 # ─────────────────────────────────────────────
+
 
 def test_classify_error_connection_error_ingest_mentions_gguf():
     """_classify_error(ConnectionError, ingest) must mention GGUF, NOT Ollama."""
@@ -252,14 +303,14 @@ def test_classify_error_connection_error_ingest_mentions_gguf():
     err = ConnectionError("Failed to connect")
     msg = _classify_error(err, "ingest")
 
-    assert 'gguf' in msg.lower() or 'GGUF' in msg, (
-        f"ingest ConnectionError message must mention GGUF. Got: {msg}"
-    )
+    assert (
+        "gguf" in msg.lower() or "GGUF" in msg
+    ), f"ingest ConnectionError message must mention GGUF. Got: {msg}"
 
     # Must NOT mention Ollama
-    assert 'ollama' not in msg.lower(), (
-        f"ingest ConnectionError message must NOT mention Ollama. Got: {msg}"
-    )
+    assert (
+        "ollama" not in msg.lower()
+    ), f"ingest ConnectionError message must NOT mention Ollama. Got: {msg}"
 
 
 def test_classify_error_connection_error_query_mentions_gguf():
@@ -269,13 +320,13 @@ def test_classify_error_connection_error_query_mentions_gguf():
     err = ConnectionError("Failed to connect")
     msg = _classify_error(err, "query")
 
-    assert 'gguf' in msg.lower() or 'GGUF' in msg, (
-        f"query ConnectionError message must mention GGUF. Got: {msg}"
-    )
+    assert (
+        "gguf" in msg.lower() or "GGUF" in msg
+    ), f"query ConnectionError message must mention GGUF. Got: {msg}"
 
-    assert 'ollama' not in msg.lower(), (
-        f"query ConnectionError message must NOT mention Ollama. Got: {msg}"
-    )
+    assert (
+        "ollama" not in msg.lower()
+    ), f"query ConnectionError message must NOT mention Ollama. Got: {msg}"
 
 
 def test_classify_error_file_not_found_mentions_gguf():
@@ -285,9 +336,9 @@ def test_classify_error_file_not_found_mentions_gguf():
     err = FileNotFoundError("Model not found")
     msg = _classify_error(err, "ingest")
 
-    assert 'gguf' in msg.lower() or 'GGUF' in msg or 'path' in msg.lower(), (
-        f"FileNotFoundError message must mention GGUF or path. Got: {msg}"
-    )
+    assert (
+        "gguf" in msg.lower() or "GGUF" in msg or "path" in msg.lower()
+    ), f"FileNotFoundError message must mention GGUF or path. Got: {msg}"
 
 
 def test_classify_error_timeout_mentions_max_tokens():
@@ -300,160 +351,165 @@ def test_classify_error_timeout_mentions_max_tokens():
     # TimeoutError is caught by isinstance(err, (ConnectionError, TimeoutError)) and
     # routed to the connection error handler. The important thing is it does NOT
     # fall through to the generic "Make sure at least one LLM backend" message.
-    assert 'backend' not in msg.lower(), (
-        f"TimeoutError should not fall to generic handler. Got: {msg}"
-    )
-    assert 'gguf' in msg.lower(), (
-        f"TimeoutError message should mention GGUF. Got: {msg}"
-    )
+    assert (
+        "backend" not in msg.lower()
+    ), f"TimeoutError should not fall to generic handler. Got: {msg}"
+    assert (
+        "gguf" in msg.lower()
+    ), f"TimeoutError message should mention GGUF. Got: {msg}"
 
 
 def test_classify_error_no_ollama_references():
     """_classify_error must NEVER contain the word 'Ollama'."""
-    from app_gui import _classify_error
     import inspect
+
+    from app_gui import _classify_error
 
     source = inspect.getsource(_classify_error)
 
     # Normalize for case-insensitive check
-    assert 'ollama' not in source.lower(), (
-        f"_classify_error must never reference Ollama. Found in source:\n{source}"
-    )
+    assert (
+        "ollama" not in source.lower()
+    ), f"_classify_error must never reference Ollama. Found in source:\n{source}"
 
 
 # ─────────────────────────────────────────────
 # D. TYPING INDICATOR
 # ─────────────────────────────────────────────
 
+
 def test_show_typing_indicator_creates_widgets():
     """_show_typing_indicator() creates _typing_frame, _typing_label, _typing_dots, and calls _animate_typing."""
+    import inspect
+
     from app_gui import DocumentQAApp
 
-    import inspect
     source = inspect.getsource(DocumentQAApp._show_typing_indicator)
 
-    assert '_typing_frame' in source, (
-        "_show_typing_indicator() must create _typing_frame"
-    )
-    assert '_typing_label' in source, (
-        "_show_typing_indicator() must create _typing_label"
-    )
-    assert '_typing_dots' in source, (
-        "_show_typing_indicator() must initialize _typing_dots"
-    )
-    assert '_animate_typing' in source, (
-        "_show_typing_indicator() must call _animate_typing"
-    )
+    assert (
+        "_typing_frame" in source
+    ), "_show_typing_indicator() must create _typing_frame"
+    assert (
+        "_typing_label" in source
+    ), "_show_typing_indicator() must create _typing_label"
+    assert (
+        "_typing_dots" in source
+    ), "_show_typing_indicator() must initialize _typing_dots"
+    assert (
+        "_animate_typing" in source
+    ), "_show_typing_indicator() must call _animate_typing"
 
 
 def test_hide_typing_indicator_cancels_timer():
     """_hide_typing_indicator() cancels pending after() timer."""
+    import inspect
+
     from app_gui import DocumentQAApp
 
-    import inspect
     source = inspect.getsource(DocumentQAApp._hide_typing_indicator)
 
-    assert 'after_cancel' in source, (
-        "_hide_typing_indicator() must call after_cancel"
-    )
-    assert '_typing_animation_id' in source, (
-        "_hide_typing_indicator() must reference _typing_animation_id"
-    )
+    assert "after_cancel" in source, "_hide_typing_indicator() must call after_cancel"
+    assert (
+        "_typing_animation_id" in source
+    ), "_hide_typing_indicator() must reference _typing_animation_id"
 
 
 def test_hide_typing_indicator_is_idempotent():
     """_hide_typing_indicator() is safe to call twice (no error)."""
+    import inspect
+
     from app_gui import DocumentQAApp
 
-    import inspect
     source = inspect.getsource(DocumentQAApp._hide_typing_indicator)
 
     # The implementation uses `hasattr(self, "_typing_animation_id") and ... is not None`
     # which is already idempotent - calling twice is safe
-    assert 'hasattr' in source and '_typing_animation_id' in source, (
-        "_hide_typing_indicator() must guard with hasattr check on _typing_animation_id"
-    )
+    assert (
+        "hasattr" in source and "_typing_animation_id" in source
+    ), "_hide_typing_indicator() must guard with hasattr check on _typing_animation_id"
 
 
 def test_enable_input_stops_typing_indicator():
     """enable_input message stops the typing indicator."""
+    import inspect
+
     from app_gui import DocumentQAApp
 
-    import inspect
     # Check the message processor
     source = inspect.getsource(DocumentQAApp._start_message_processor)
 
-    assert 'enable_input' in source, (
-        "Message processor must handle 'enable_input' message"
-    )
-    assert '_hide_typing_indicator' in source, (
-        "Message processor must call _hide_typing_indicator on enable_input"
-    )
+    assert (
+        "enable_input" in source
+    ), "Message processor must handle 'enable_input' message"
+    assert (
+        "_hide_typing_indicator" in source
+    ), "Message processor must call _hide_typing_indicator on enable_input"
 
 
 # ─────────────────────────────────────────────
 # E. WM_DELETE_WINDOW
 # ─────────────────────────────────────────────
 
+
 def test_on_close_without_active_operation_calls_destroy():
     """_on_close() without active operation must call destroy()."""
+    import inspect
+
     from app_gui import DocumentQAApp
 
-    import inspect
     source = inspect.getsource(DocumentQAApp._on_close)
 
-    assert 'destroy()' in source, (
-        "_on_close() must call destroy()"
-    )
+    assert "destroy()" in source, "_on_close() must call destroy()"
 
 
 def test_on_close_with_active_operation_checks_askyesno():
     """_on_close() with active operation must call askyesno for confirmation."""
+    import inspect
+
     from app_gui import DocumentQAApp
 
-    import inspect
     source = inspect.getsource(DocumentQAApp._on_close)
 
-    assert '_is_operation_active' in source, (
-        "_on_close() must check _is_operation_active"
-    )
-    assert 'askyesno' in source, (
-        "_on_close() must call askyesno for user confirmation"
-    )
+    assert (
+        "_is_operation_active" in source
+    ), "_on_close() must check _is_operation_active"
+    assert "askyesno" in source, "_on_close() must call askyesno for user confirmation"
 
 
 def test_on_close_with_active_operation_user_confirms():
     """_on_close() with active operation, user confirms — must call destroy()."""
+    import inspect
+
     from app_gui import DocumentQAApp
 
-    import inspect
     source = inspect.getsource(DocumentQAApp._on_close)
 
     # After askyesno returns True, destroy should be called
     # The pattern should be: if _is_operation_active: if not askyesno: return
-    assert 'if not messagebox.askyesno' in source or 'askyesno' in source, (
-        "_on_close() must use askyesno for confirmation"
-    )
+    assert (
+        "if not messagebox.askyesno" in source or "askyesno" in source
+    ), "_on_close() must use askyesno for confirmation"
 
 
 def test_on_close_with_active_operation_user_cancels():
     """_on_close() with active operation, user cancels — must NOT call destroy()."""
+    import inspect
+
     from app_gui import DocumentQAApp
 
-    import inspect
     source = inspect.getsource(DocumentQAApp._on_close)
 
     # Pattern: if _is_operation_active: if not askyesno: return
     # The 'return' before destroy() ensures cancel works
-    lines = source.split('\n')
+    lines = source.split("\n")
     # Find the lines around askyesno
     for i, line in enumerate(lines):
-        if 'askyesno' in line:
+        if "askyesno" in line:
             # Should have 'return' in the next few lines
-            next_lines = '\n'.join(lines[i:i+5])
-            assert 'return' in next_lines, (
-                f"_on_close() must 'return' when user cancels. Found: {next_lines}"
-            )
+            next_lines = "\n".join(lines[i : i + 5])
+            assert (
+                "return" in next_lines
+            ), f"_on_close() must 'return' when user cancels. Found: {next_lines}"
             break
 
 
@@ -461,22 +517,23 @@ def test_on_close_with_active_operation_user_cancels():
 # F. ACCESSIBILITY
 # ─────────────────────────────────────────────
 
+
 def test_font_family_is_segoe_ui():
     """FONT_FAMILY must equal 'Segoe UI'."""
     from app_gui import FONT_FAMILY
 
-    assert FONT_FAMILY == "Segoe UI", (
-        f"FONT_FAMILY must be 'Segoe UI', got '{FONT_FAMILY}'"
-    )
+    assert (
+        FONT_FAMILY == "Segoe UI"
+    ), f"FONT_FAMILY must be 'Segoe UI', got '{FONT_FAMILY}'"
 
 
 def test_default_button_height_is_36():
     """DEFAULT_BUTTON_HEIGHT must equal 36."""
     from app_gui import DEFAULT_BUTTON_HEIGHT
 
-    assert DEFAULT_BUTTON_HEIGHT == 36, (
-        f"DEFAULT_BUTTON_HEIGHT must be 36, got {DEFAULT_BUTTON_HEIGHT}"
-    )
+    assert (
+        DEFAULT_BUTTON_HEIGHT == 36
+    ), f"DEFAULT_BUTTON_HEIGHT must be 36, got {DEFAULT_BUTTON_HEIGHT}"
 
 
 def test_make_button_returns_ctkbutton_with_height_36():
@@ -487,41 +544,42 @@ def test_make_button_returns_ctkbutton_with_height_36():
     mock_parent = MagicMock()
     mock_button = MagicMock()
 
-    with patch('app_gui.CTkButton', return_value=mock_button) as mock_ctk:
+    with patch("app_gui.CTkButton", return_value=mock_button) as mock_ctk:
         result = _make_button(mock_parent, "Test", lambda: None)
 
         # Verify CTkButton was called with height=36
         call_kwargs = mock_ctk.call_args
-        assert 'height' in call_kwargs.kwargs, (
-            "_make_button() must pass 'height' to CTkButton"
-        )
-        assert call_kwargs.kwargs['height'] == 36, (
-            f"_make_button() height must be 36, got {call_kwargs.kwargs['height']}"
-        )
+        assert (
+            "height" in call_kwargs.kwargs
+        ), "_make_button() must pass 'height' to CTkButton"
+        assert (
+            call_kwargs.kwargs["height"] == 36
+        ), f"_make_button() height must be 36, got {call_kwargs.kwargs['height']}"
 
 
 def test_no_bare_ctkbutton_calls_in_source():
     """No bare CTkButton() calls in app_gui.py source (all go through _make_button)."""
     pytest.skip("Source code inspection test — bare CTkButton found in _create_widgets")
     import inspect
+
     from app_gui import DocumentQAApp
 
     # Get source of _create_widgets
     source = inspect.getsource(DocumentQAApp._create_widgets)
 
     # Find all CTkButton calls
-    lines = source.split('\n')
+    lines = source.split("\n")
     violations = []
     for i, line in enumerate(lines):
-        if 'CTkButton(' in line and '_make_button' not in line:
+        if "CTkButton(" in line and "_make_button" not in line:
             # Check if it's not in a comment
             stripped = line.strip()
-            if not stripped.startswith('#'):
+            if not stripped.startswith("#"):
                 violations.append(f"Line {i+1}: {line.strip()}")
 
     assert len(violations) == 0, (
-        f"Found {len(violations)} bare CTkButton() calls not using _make_button:\n" +
-        "\n".join(violations)
+        f"Found {len(violations)} bare CTkButton() calls not using _make_button:\n"
+        + "\n".join(violations)
     )
 
 
@@ -529,105 +587,109 @@ def test_no_bare_ctkbutton_calls_in_source():
 # G. PROGRESS BAR
 # ─────────────────────────────────────────────
 
+
 def test_progress_label_widget_exists():
     """progress_label widget must be defined in _create_chat_page (nav-rail refactor moved it there)."""
+    import inspect
+
     from app_gui import DocumentQAApp
 
-    import inspect
     source = inspect.getsource(DocumentQAApp._create_chat_page)
 
-    assert 'progress_label' in source, (
-        "_create_chat_page() must create progress_label widget"
-    )
-    assert 'CTkLabel' in source, (
-        "progress_label must be a CTkLabel"
-    )
+    assert (
+        "progress_label" in source
+    ), "_create_chat_page() must create progress_label widget"
+    assert "CTkLabel" in source, "progress_label must be a CTkLabel"
 
 
 def test_progress_label_receives_progress_label_message():
     """progress_label receives 'progress_label' queue message."""
+    import inspect
+
     from app_gui import DocumentQAApp
 
-    import inspect
     source = inspect.getsource(DocumentQAApp._start_message_processor)
 
     # Check for progress_label message handling (source uses double quotes)
-    assert 'msg[0] == "progress_label"' in source, (
-        "Message processor must handle 'progress_label' messages"
-    )
+    assert (
+        'msg[0] == "progress_label"' in source
+    ), "Message processor must handle 'progress_label' messages"
     # Progress update goes through _show_progress helper or direct configure
-    assert '_show_progress' in source or 'progress_label.configure' in source, (
-        "Message processor must update progress_label via _show_progress or direct configure"
-    )
+    assert (
+        "_show_progress" in source or "progress_label.configure" in source
+    ), "Message processor must update progress_label via _show_progress or direct configure"
 
 
 def test_progress_label_clears_on_progress_clear_message():
     """progress_label clears on 'progress_clear' queue message."""
+    import inspect
+
     from app_gui import DocumentQAApp
 
-    import inspect
     source = inspect.getsource(DocumentQAApp._start_message_processor)
 
     # Source uses double quotes for string literals
-    assert 'msg[0] == "progress_clear"' in source, (
-        "Message processor must handle 'progress_clear' messages"
-    )
+    assert (
+        'msg[0] == "progress_clear"' in source
+    ), "Message processor must handle 'progress_clear' messages"
     # progress_clear should set text to empty
-    assert 'progress_clear' in source, (
-        "Message processor must handle progress_clear"
-    )
+    assert "progress_clear" in source, "Message processor must handle progress_clear"
 
 
 # ─────────────────────────────────────────────
 # H. LAZY INIT (vector_store)
 # ─────────────────────────────────────────────
 
+
 def test_embedding_model_local_files_only():
     """EmbeddingModel uses local_files_only=True in _model_args."""
+    import inspect
+
     from vector_store import EmbeddingModel
 
-    import inspect
     source = inspect.getsource(EmbeddingModel)
 
-    assert 'local_files_only' in source, (
-        "EmbeddingModel must set local_files_only parameter"
-    )
+    assert (
+        "local_files_only" in source
+    ), "EmbeddingModel must set local_files_only parameter"
 
 
 def test_bm25_lazy_rebuild_flag():
     """VectorStore sets _bm25_needs_rebuild flag based on chunk_count."""
+    import inspect
+
     from vector_store import VectorStore
 
-    import inspect
     source = inspect.getsource(VectorStore.__init__)
 
-    assert '_bm25_needs_rebuild' in source, (
-        "VectorStore.__init__ must set _bm25_needs_rebuild flag"
-    )
-    assert 'chunk_count' in source, (
-        "_bm25_needs_rebuild must be based on chunk_count"
-    )
+    assert (
+        "_bm25_needs_rebuild" in source
+    ), "VectorStore.__init__ must set _bm25_needs_rebuild flag"
+    assert "chunk_count" in source, "_bm25_needs_rebuild must be based on chunk_count"
 
 
 def test_rebuild_bm25_if_needed_is_lazy():
     """_rebuild_bm25_if_needed() only rebuilds when flag is True."""
+    import inspect
+
     from vector_store import VectorStore
 
-    import inspect
     source = inspect.getsource(VectorStore._rebuild_bm25_if_needed)
 
-    assert 'if not self._bm25_needs_rebuild:' in source or 'if self._bm25_needs_rebuild' in source, (
-        "_rebuild_bm25_if_needed() must check _bm25_needs_rebuild flag"
-    )
+    assert (
+        "if not self._bm25_needs_rebuild:" in source
+        or "if self._bm25_needs_rebuild" in source
+    ), "_rebuild_bm25_if_needed() must check _bm25_needs_rebuild flag"
     # Should reset flag after rebuild
-    assert '_bm25_needs_rebuild = False' in source, (
-        "_rebuild_bm25_if_needed() must reset flag after rebuild"
-    )
+    assert (
+        "_bm25_needs_rebuild = False" in source
+    ), "_rebuild_bm25_if_needed() must reset flag after rebuild"
 
 
 # ─────────────────────────────────────────────
 # I. SECURITY
 # ─────────────────────────────────────────────
+
 
 def test_security_rejects_ftp_scheme():
     """security.validate_url() rejects ftp:// scheme."""
@@ -698,12 +760,13 @@ def test_security_validate_url_type_error():
 # J. CONFIG PROXY
 # ─────────────────────────────────────────────
 
+
 def test_settings_proxy_raises_on_missing_attribute():
     """_SettingsProxy raises informative error on missing attribute."""
-    from config import settings, RAGSettings, get_settings
+    from config import RAGSettings, get_settings, settings
 
     # Mock get_settings to return a real RAGSettings instance
-    with patch('config.get_settings') as mock_get:
+    with patch("config.get_settings") as mock_get:
         mock_settings = RAGSettings()
         mock_get.return_value = mock_settings
 
@@ -713,16 +776,16 @@ def test_settings_proxy_raises_on_missing_attribute():
             pytest.fail("Should have raised AttributeError")
         except AttributeError as e:
             # Error message should be informative
-            assert 'nonexistent' in str(e).lower() or 'not have' in str(e).lower(), (
-                f"Error message should mention the missing attribute. Got: {e}"
-            )
+            assert (
+                "nonexistent" in str(e).lower() or "not have" in str(e).lower()
+            ), f"Error message should mention the missing attribute. Got: {e}"
 
 
 def test_settings_proxy_repr():
     """_SettingsProxy.__repr__ returns repr of settings."""
-    from config import settings, RAGSettings, get_settings
+    from config import RAGSettings, get_settings, settings
 
-    with patch('config.get_settings') as mock_get:
+    with patch("config.get_settings") as mock_get:
         mock_settings = RAGSettings()
         mock_get.return_value = mock_settings
 
@@ -734,28 +797,33 @@ def test_settings_proxy_repr():
 # K. ADDITIONAL ADVERSARIAL TESTS
 # ─────────────────────────────────────────────
 
+
 def test_llm_interface_no_online_backends():
     """llm_interface.py must NOT import OllamaLLM, OpenVINOLLM, or OpenAICompatibleLLM."""
     import inspect
+
     from llm_interface import SmartLLM
 
     source = inspect.getsource(SmartLLM)
 
-    assert 'OllamaLLM' not in source, "SmartLLM must not reference OllamaLLM"
-    assert 'OpenVINOLLM' not in source, "SmartLLM must not reference OpenVINOLLM"
-    assert 'OpenAICompatibleLLM' not in source, "SmartLLM must not reference OpenAICompatibleLLM"
+    assert "OllamaLLM" not in source, "SmartLLM must not reference OllamaLLM"
+    assert "OpenVINOLLM" not in source, "SmartLLM must not reference OpenVINOLLM"
+    assert (
+        "OpenAICompatibleLLM" not in source
+    ), "SmartLLM must not reference OpenAICompatibleLLM"
 
 
 def test_llm_interface_gemma4_detection():
     """llm_interface.py must detect Gemma 4 models."""
-    from llm_interface import GGUFBackend
     import inspect
+
+    from llm_interface import GGUFBackend
 
     source = inspect.getsource(GGUFBackend)
 
     # Gemma 4 detection should be present
-    assert 'gemma' in source.lower(), "GGUFBackend must detect Gemma models"
-    assert 'is_gemma4' in source, "GGUFBackend must have is_gemma4 flag"
+    assert "gemma" in source.lower(), "GGUFBackend must detect Gemma models"
+    assert "is_gemma4" in source, "GGUFBackend must have is_gemma4 flag"
 
 
 def test_query_transformer_error_handling():
@@ -770,27 +838,29 @@ def test_query_transformer_error_handling():
     result = transformer.transform_step_back("What is 2+2?")
 
     # Should return original query on error
-    assert result == "What is 2+2?", (
-        f"transform_step_back must return original query on error. Got: {result}"
-    )
+    assert (
+        result == "What is 2+2?"
+    ), f"transform_step_back must return original query on error. Got: {result}"
 
 
 def test_query_transformer_gating():
     """RAGEngine only uses QueryTransformer when query_transformation_enabled=True."""
-    from rag_engine import RAGEngine
     import inspect
+
+    from rag_engine import RAGEngine
 
     # Check the gating logic in _ensure_query_transformer, where the config flag is evaluated
     source = inspect.getsource(RAGEngine._ensure_query_transformer)
 
-    assert 'query_transformation_enabled' in source, (
-        "RAGEngine._ensure_query_transformer must check query_transformation_enabled"
-    )
+    assert (
+        "query_transformation_enabled" in source
+    ), "RAGEngine._ensure_query_transformer must check query_transformation_enabled"
 
 
 def test_api_server_ignores_ollama_params():
     """api_server.py lifespan should NOT pass ollama_model/ollama_url to RAGEngine."""
     import inspect
+
     from api_server import lifespan
 
     source = inspect.getsource(lifespan)
@@ -798,28 +868,39 @@ def test_api_server_ignores_ollama_params():
     # lifespan reads RAG_OLLAMA_* env vars but they should NOT be passed to RAGEngine
     # The RAGEngine constructor call should only use gguf_path
     # Look for the RAGEngine instantiation
-    if 'RAGEngine(' in source:
-        engine_call = source[source.find('RAGEngine('):source.find('RAGEngine(') + 500]
+    if "RAGEngine(" in source:
+        engine_call = source[
+            source.find("RAGEngine(") : source.find("RAGEngine(") + 500
+        ]
         # The old params should NOT be in the engine call
-        assert 'ollama_model' not in engine_call or '# ' in engine_call.split('ollama_model')[0].split('\n')[-1], (
-            f"api_server lifespan must not pass ollama_model to RAGEngine. Found:\n{engine_call}"
-        )
+        assert (
+            "ollama_model" not in engine_call
+            or "# " in engine_call.split("ollama_model")[0].split("\n")[-1]
+        ), f"api_server lifespan must not pass ollama_model to RAGEngine. Found:\n{engine_call}"
 
 
 def test_engine_factory_create_engine_signature():
     """engine_factory.create_engine() only accepts gguf_path, not device/api_url/etc."""
     import inspect
+
     from engine_factory import create_engine
 
     sig = inspect.signature(create_engine)
     params = list(sig.parameters.keys())
 
-    forbidden = ['ollama_model', 'ollama_url', 'api_url', 'api_model', 'device', 'model_path']
+    forbidden = [
+        "ollama_model",
+        "ollama_url",
+        "api_url",
+        "api_model",
+        "device",
+        "model_path",
+    ]
     found = [p for p in forbidden if p in params]
 
-    assert len(found) == 0, (
-        f"engine_factory.create_engine() has forbidden params: {found}"
-    )
+    assert (
+        len(found) == 0
+    ), f"engine_factory.create_engine() has forbidden params: {found}"
 
 
 def test_settings_proxy_getattr_error_message():
@@ -828,9 +909,9 @@ def test_settings_proxy_getattr_error_message():
 
     proxy = _SettingsProxy()
 
-    with patch('config.get_settings') as mock_get:
+    with patch("config.get_settings") as mock_get:
         mock_settings = MagicMock()
-        mock_settings.__class__ = type('RAGSettings', (), {})
+        mock_settings.__class__ = type("RAGSettings", (), {})
         mock_settings.does_not_exist = None  # Attribute doesn't exist
         del mock_settings.does_not_exist
         mock_get.return_value = mock_settings
@@ -841,42 +922,43 @@ def test_settings_proxy_getattr_error_message():
         except AttributeError as e:
             msg = str(e)
             # Message should be informative
-            assert 'RAGSettings' in msg or 'does_not_exist' in msg or 'not have' in msg, (
-                f"AttributeError message should be helpful. Got: {e}"
-            )
+            assert (
+                "RAGSettings" in msg or "does_not_exist" in msg or "not have" in msg
+            ), f"AttributeError message should be helpful. Got: {e}"
 
 
 def test_vector_store_bm25_optional():
     """VectorStore works when BM25 is unavailable (BM25_AVAILABLE=False)."""
+    import inspect
+
     from vector_store import VectorStore
 
-    import inspect
     source = inspect.getsource(VectorStore.add_chunks)
 
     # add_chunks should handle BM25 not being available
     # The code should check BM25_AVAILABLE or handle bm25_index being None
-    assert 'BM25_AVAILABLE' in source or 'bm25_index' in source, (
-        "VectorStore.add_chunks must handle optional BM25"
-    )
+    assert (
+        "BM25_AVAILABLE" in source or "bm25_index" in source
+    ), "VectorStore.add_chunks must handle optional BM25"
 
 
 def test_embedding_model_no_huggingface_download():
     """EmbeddingModel must NOT download models from HuggingFace (local_files_only=True)."""
-    from vector_store import EmbeddingModel
-
     import inspect
+
+    from vector_store import EmbeddingModel
 
     # Check __init__
     init_source = inspect.getsource(EmbeddingModel.__init__)
-    assert 'local_files_only' in init_source, (
-        "EmbeddingModel.__init__ must set local_files_only"
-    )
+    assert (
+        "local_files_only" in init_source
+    ), "EmbeddingModel.__init__ must set local_files_only"
 
     # Check _ensure_model_loaded
     ensure_source = inspect.getsource(EmbeddingModel._ensure_model_loaded)
-    assert 'local_files_only' in ensure_source, (
-        "EmbeddingModel._ensure_model_loaded must use local_files_only"
-    )
+    assert (
+        "local_files_only" in ensure_source
+    ), "EmbeddingModel._ensure_model_loaded must use local_files_only"
 
 
 def test_classify_error_token_limit_ingest():
@@ -886,9 +968,9 @@ def test_classify_error_token_limit_ingest():
     err = RuntimeError("Token limit exceeded")
     msg = _classify_error(err, "ingest")
 
-    assert 'token' in msg.lower() or 'chunk' in msg.lower() or 'Max Tokens' in msg, (
-        f"Token limit error in ingest should mention tokens or chunk settings. Got: {msg}"
-    )
+    assert (
+        "token" in msg.lower() or "chunk" in msg.lower() or "Max Tokens" in msg
+    ), f"Token limit error in ingest should mention tokens or chunk settings. Got: {msg}"
 
 
 def test_classify_error_token_limit_query():
@@ -898,9 +980,9 @@ def test_classify_error_token_limit_query():
     err = RuntimeError("Token limit exceeded")
     msg = _classify_error(err, "query")
 
-    assert 'token' in msg.lower() or 'Max Tokens' in msg, (
-        f"Token limit error in query should mention Max Tokens. Got: {msg}"
-    )
+    assert (
+        "token" in msg.lower() or "Max Tokens" in msg
+    ), f"Token limit error in query should mention Max Tokens. Got: {msg}"
 
 
 def test_security_allowed_schemes_default():
@@ -933,102 +1015,99 @@ def test_rag_config_query_transformation_disabled_by_default():
     from rag_engine import RAGConfig
 
     config = RAGConfig()
-    assert config.query_transformation_enabled == False, (
-        "query_transformation_enabled must default to False"
-    )
+    assert (
+        config.query_transformation_enabled == False
+    ), "query_transformation_enabled must default to False"
 
 
 def test_vector_store_delete_document_guard():
     """VectorStore.delete_document() has guard clause for empty/falsy doc_id."""
+    import inspect
+
     from vector_store import VectorStore
 
-    import inspect
     source = inspect.getsource(VectorStore.delete_document)
 
-    assert 'if not doc_id' in source, (
-        "delete_document must check 'if not doc_id' as guard clause"
-    )
+    assert (
+        "if not doc_id" in source
+    ), "delete_document must check 'if not doc_id' as guard clause"
 
 
 def test_vector_store_delete_document_returns_false_on_failure():
     """VectorStore.delete_document() returns False on failure (not raising)."""
+    import inspect
+
     from vector_store import VectorStore
 
-    import inspect
     source = inspect.getsource(VectorStore.delete_document)
 
     # Should have try/except that returns False
-    assert 'return False' in source, (
-        "delete_document must return False on failure, not raise"
-    )
+    assert (
+        "return False" in source
+    ), "delete_document must return False on failure, not raise"
 
 
 def test_api_server_windows_reserved_names():
     """api_server.py sanitizes Windows reserved filenames."""
-    from api_server import sanitize_filename, WINDOWS_RESERVED_NAMES
+    from api_server import WINDOWS_RESERVED_NAMES, sanitize_filename
 
     # Test a reserved name
     name, display = sanitize_filename("NUL")
-    assert name == "_NUL" or name == "NUL", (
-        f"sanitize_filename must handle Windows reserved names. Got: {name}"
-    )
+    assert (
+        name == "_NUL" or name == "NUL"
+    ), f"sanitize_filename must handle Windows reserved names. Got: {name}"
 
-    assert 'NUL' in WINDOWS_RESERVED_NAMES, (
-        "WINDOWS_RESERVED_NAMES must include 'NUL'"
-    )
+    assert "NUL" in WINDOWS_RESERVED_NAMES, "WINDOWS_RESERVED_NAMES must include 'NUL'"
 
 
 def test_app_gui_version_is_set():
     """DocumentQAApp.VERSION is set."""
     from app_gui import DocumentQAApp
 
-    assert hasattr(DocumentQAApp, 'VERSION'), (
-        "DocumentQAApp must have VERSION attribute"
-    )
-    assert isinstance(DocumentQAApp.VERSION, str), (
-        "VERSION must be a string"
-    )
+    assert hasattr(
+        DocumentQAApp, "VERSION"
+    ), "DocumentQAApp must have VERSION attribute"
+    assert isinstance(DocumentQAApp.VERSION, str), "VERSION must be a string"
 
 
 def test_app_gui_settings_file_is_set():
     """DocumentQAApp.SETTINGS_FILE is set."""
     from app_gui import DocumentQAApp
 
-    assert hasattr(DocumentQAApp, 'SETTINGS_FILE'), (
-        "DocumentQAApp must have SETTINGS_FILE attribute"
-    )
+    assert hasattr(
+        DocumentQAApp, "SETTINGS_FILE"
+    ), "DocumentQAApp must have SETTINGS_FILE attribute"
 
 
 def test_rag_engine_config_save():
     """RAGEngine saves config to rag_config.json."""
+    import inspect
+
     from rag_engine import RAGEngine
 
-    import inspect
     source = inspect.getsource(RAGEngine._save_config)
 
-    assert 'rag_config.json' in source or 'CONFIG_FILE' in source, (
-        "RAGEngine must save config to rag_config.json"
-    )
+    assert (
+        "rag_config.json" in source or "CONFIG_FILE" in source
+    ), "RAGEngine must save config to rag_config.json"
 
 
 def test_query_transformer_uses_inference_config():
     """QueryTransformer uses InferenceConfig with max_tokens=50."""
+    import inspect
+
     from query_transformer import QueryTransformer
 
-    import inspect
     source = inspect.getsource(QueryTransformer.transform_step_back)
 
-    assert 'InferenceConfig' in source, (
-        "transform_step_back must use InferenceConfig"
-    )
-    assert 'max_tokens=50' in source, (
-        "transform_step_back must use max_tokens=50"
-    )
+    assert "InferenceConfig" in source, "transform_step_back must use InferenceConfig"
+    assert "max_tokens=50" in source, "transform_step_back must use max_tokens=50"
 
 
 # ─────────────────────────────────────────────
 # L. GUI FREEZE FIX — _ensure_llm() IN BACKGROUND THREAD
 # ─────────────────────────────────────────────
+
 
 def test_ask_question_ensure_llm_called_inside_query_thread():
     """
@@ -1039,41 +1118,42 @@ def test_ask_question_ensure_llm_called_inside_query_thread():
     llama-cpp model loading blocks the event loop. The fix moves the call inside
     the background thread.
     """
-    from app_gui import DocumentQAApp
     import inspect
+
+    from app_gui import DocumentQAApp
 
     source = inspect.getsource(DocumentQAApp._ask_question)
 
     # Locate the query() nested function definition
-    lines = source.split('\n')
+    lines = source.split("\n")
     query_def_line = -1
     query_end_line = len(lines)
     for i, line in enumerate(lines):
-        if re.match(r'\s*def query\(', line):
+        if re.match(r"\s*def query\(", line):
             query_def_line = i
         # The threading.Thread call marks the end of the query() function body
-        if 'threading.Thread(target=query' in line and query_def_line >= 0:
+        if "threading.Thread(target=query" in line and query_def_line >= 0:
             query_end_line = i
             break
 
-    assert query_def_line >= 0, (
-        "_ask_question() must contain a nested def query() function"
-    )
+    assert (
+        query_def_line >= 0
+    ), "_ask_question() must contain a nested def query() function"
 
     # Extract the query() function body (everything from def query() to before threading.Thread)
-    query_body = '\n'.join(lines[query_def_line:query_end_line])
+    query_body = "\n".join(lines[query_def_line:query_end_line])
 
     # _ensure_llm() MUST be called inside query() body
-    assert 'self.engine._ensure_llm()' in query_body, (
+    assert "self.engine._ensure_llm()" in query_body, (
         "_ensure_llm() must be called INSIDE the query() function body "
         "(not on main UI thread) to prevent GUI freeze during llama-cpp loading"
     )
 
     # _ensure_llm() must NOT appear between the start of _ask_question and the query def
     # (i.e., not on the main thread)
-    before_query = '\n'.join(lines[:query_def_line])
+    before_query = "\n".join(lines[:query_def_line])
     # Check that _ensure_llm is NOT called before the query def (would block main thread)
-    matches_before = re.findall(r'self\.engine\._ensure_llm\(\)', before_query)
+    matches_before = re.findall(r"self\.engine\._ensure_llm\(\)", before_query)
     assert len(matches_before) == 0, (
         f"_ensure_llm() was called {len(matches_before)} time(s) on the main UI thread "
         "(before the query() function definition). This causes GUI freeze. "
@@ -1089,33 +1169,37 @@ def test_ask_question_no_llm_uses_message_queue_thread_safe():
     Bug: messagebox.showerror() called from a background thread can crash or hang on
     Windows. The fix uses message_queue.put() so the main thread displays the error.
     """
-    from app_gui import DocumentQAApp
     import inspect
+
+    from app_gui import DocumentQAApp
 
     source = inspect.getsource(DocumentQAApp._ask_question)
 
     # Locate the query() nested function body
-    lines = source.split('\n')
+    lines = source.split("\n")
     query_def_line = -1
     query_end_line = len(lines)
     for i, line in enumerate(lines):
-        if re.match(r'\s*def query\(', line):
+        if re.match(r"\s*def query\(", line):
             query_def_line = i
-        if 'threading.Thread(target=query' in line and query_def_line >= 0:
+        if "threading.Thread(target=query" in line and query_def_line >= 0:
             query_end_line = i
             break
 
-    query_body = '\n'.join(lines[query_def_line:query_end_line])
+    query_body = "\n".join(lines[query_def_line:query_end_line])
 
     # After checking `if not self.engine.llm:`, error must use message_queue.put()
-    assert 'message_queue.put' in query_body, (
-        "Error handling for llm=None must use message_queue.put() for thread-safety"
-    )
+    assert (
+        "message_queue.put" in query_body
+    ), "Error handling for llm=None must use message_queue.put() for thread-safety"
 
-    # The specific "No LLM" error message must be in a message_queue.put call
+    # The "No LLM" error must be sent via message_queue.put(), either as a
+    # literal "No LLM..." message or routed through _classify_error (issue
+    # #53 relays the real load diagnostic through the classifier). A direct
+    # messagebox.showerror() call remains forbidden (not thread-safe on
+    # Windows).
     assert re.search(
-        r'message_queue\.put\([^)]*"No LLM[^"]*"',
-        query_body
+        r'message_queue\.put\([^)]*("No LLM[^"]*"|_classify_error\()', query_body
     ), (
         "The 'No LLM backend available' error must be sent via message_queue.put(), "
         "not messagebox.showerror() (which is not thread-safe on Windows)"
@@ -1127,30 +1211,31 @@ def test_ask_question_ensure_llm_before_query_check():
     _ensure_llm() must be called BEFORE the `if not self.engine.llm:` check
     inside the query() function, so the LLM is initialized before checking availability.
     """
-    from app_gui import DocumentQAApp
     import inspect
+
+    from app_gui import DocumentQAApp
 
     source = inspect.getsource(DocumentQAApp._ask_question)
 
-    lines = source.split('\n')
+    lines = source.split("\n")
     query_def_line = -1
     query_end_line = len(lines)
     for i, line in enumerate(lines):
-        if re.match(r'\s*def query\(', line):
+        if re.match(r"\s*def query\(", line):
             query_def_line = i
-        if 'threading.Thread(target=query' in line and query_def_line >= 0:
+        if "threading.Thread(target=query" in line and query_def_line >= 0:
             query_end_line = i
             break
 
-    query_body = '\n'.join(lines[query_def_line:query_end_line])
-    query_lines = query_body.split('\n')
+    query_body = "\n".join(lines[query_def_line:query_end_line])
+    query_lines = query_body.split("\n")
 
     ensure_llm_idx = -1
     llm_check_idx = -1
     for i, line in enumerate(query_lines):
-        if 'self.engine._ensure_llm()' in line:
+        if "self.engine._ensure_llm()" in line:
             ensure_llm_idx = i
-        if 'if not self.engine.llm:' in line:
+        if "if not self.engine.llm:" in line:
             llm_check_idx = i
 
     assert ensure_llm_idx >= 0, "_ensure_llm() must be called inside query()"
@@ -1165,21 +1250,21 @@ def test_ask_question_ensure_llm_before_query_check():
 # SUMMARY TEST: Count total tests
 # ─────────────────────────────────────────────
 
+
 def test_total_test_count():
     """Verify we have 30+ tests in this file."""
     import inspect
+
     current_file = __file__
-    with open(current_file, 'r', encoding='utf-8') as f:
+    with open(current_file, "r", encoding="utf-8") as f:
         content = f.read()
 
     # Count test functions (def test_xxx)
-    test_functions = re.findall(r'^def (test_\w+)\(', content, re.MULTILINE)
+    test_functions = re.findall(r"^def (test_\w+)\(", content, re.MULTILINE)
     test_count = len(test_functions)
 
     print(f"\n=== TEST COUNT: {test_count} tests defined ===")
     for i, name in enumerate(test_functions, 1):
         print(f"  {i}. {name}")
 
-    assert test_count >= 30, (
-        f"Expected at least 30 tests, found only {test_count}"
-    )
+    assert test_count >= 30, f"Expected at least 30 tests, found only {test_count}"

--- a/tests/test_gui_llm_guard_wiring.py
+++ b/tests/test_gui_llm_guard_wiring.py
@@ -54,19 +54,34 @@ def test_load_settings_without_env_has_no_fast_profile_key(tmp_path):
 def test_chat_worker_routes_no_llm_error_through_classifier():
     """The llm=None guard must classify the real diagnostic and queue it.
 
-    The guard reads ``llm_init_error`` (issue #53's diagnostic relay), builds
-    the error, routes it through ``_classify_error(err, "query")``, and hands
-    the result to ``message_queue.put`` — the worker thread never touches
-    tkinter directly.
+    The assertion is scoped to the ``if not self.engine.llm:`` branch itself:
+    the generic except handler also calls message_queue.put with a classified
+    error, which would otherwise satisfy the check even if this branch
+    regressed to a direct tkinter call.
     """
     from app_gui import DocumentQAApp
 
     source = inspect.getsource(DocumentQAApp._ask_question)
+    lines = source.split("\n")
 
-    assert (
-        "llm_init_error" in source
-    ), "chat worker must surface the real load diagnostic (llm_init_error)"
-    assert re.search(r"message_queue\.put\([^)]*_classify_error\(", source), (
-        "the classified error must be queued via message_queue.put (worker "
-        "threads must not call tkinter directly)"
+    branch_start = -1
+    for i, line in enumerate(lines):
+        if "if not self.engine.llm" in line:
+            branch_start = i
+            break
+    assert branch_start >= 0, "query() must guard on `if not self.engine.llm`"
+    branch_end = len(lines)
+    for i in range(branch_start, len(lines)):
+        if re.match(r"\s*return\b", lines[i]):
+            branch_end = i + 1
+            break
+    branch = "\n".join(lines[branch_start:branch_end])
+
+    assert "llm_init_error" in branch, (
+        "the no-LLM branch must surface the real load diagnostic "
+        "(llm_init_error), not a generic message"
+    )
+    assert re.search(r"message_queue\.put\([^)]*_classify_error\(", branch), (
+        "the classified error must be queued via message_queue.put inside the "
+        "no-LLM branch (worker threads must not call tkinter directly)"
     )

--- a/tests/test_gui_llm_guard_wiring.py
+++ b/tests/test_gui_llm_guard_wiring.py
@@ -1,0 +1,72 @@
+"""
+Direct coverage for the two issue-#53 review-round-1 GUI fixes (PR #92).
+
+1. ``_load_settings`` must honor ``RAG_FAST_PROFILE_PATH`` from the
+   environment so the fast-profile fallback advised in RAM-gate errors is
+   actionable on the desktop entry point (engine_factory reads this key).
+2. The chat worker must route a failed LLM init through ``_classify_error``
+   inside a ``message_queue.put`` payload — never a direct tkinter call from
+   the worker thread.
+"""
+
+import inspect
+import os
+import re
+
+
+def test_load_settings_honors_rag_fast_profile_path_env(tmp_path):
+    from unittest.mock import patch
+
+    from app_gui import DocumentQAApp
+
+    app = DocumentQAApp.__new__(DocumentQAApp)
+    env_value = str(tmp_path / "fast.gguf")
+    with patch.object(
+        DocumentQAApp,
+        "_get_settings_path",
+        return_value=str(tmp_path / "settings.json"),
+    ), patch.dict(os.environ, {"RAG_FAST_PROFILE_PATH": env_value}):
+        settings = app._load_settings()
+
+    assert settings.get("fast_profile_path") == env_value, (
+        "RAG_FAST_PROFILE_PATH must be injected into default_settings so the "
+        "desktop entry point can reach the fast-profile fallback"
+    )
+
+
+def test_load_settings_without_env_has_no_fast_profile_key(tmp_path):
+    from unittest.mock import patch
+
+    from app_gui import DocumentQAApp
+
+    app = DocumentQAApp.__new__(DocumentQAApp)
+    clean_env = {k: v for k, v in os.environ.items() if k != "RAG_FAST_PROFILE_PATH"}
+    with patch.object(
+        DocumentQAApp,
+        "_get_settings_path",
+        return_value=str(tmp_path / "settings.json"),
+    ), patch.dict(os.environ, clean_env, clear=True):
+        settings = app._load_settings()
+
+    assert "fast_profile_path" not in settings
+
+
+def test_chat_worker_routes_no_llm_error_through_classifier():
+    """The llm=None guard must classify the real diagnostic and queue it.
+
+    The guard reads ``llm_init_error`` (issue #53's diagnostic relay), builds
+    the error, routes it through ``_classify_error(err, "query")``, and hands
+    the result to ``message_queue.put`` — the worker thread never touches
+    tkinter directly.
+    """
+    from app_gui import DocumentQAApp
+
+    source = inspect.getsource(DocumentQAApp._ask_question)
+
+    assert (
+        "llm_init_error" in source
+    ), "chat worker must surface the real load diagnostic (llm_init_error)"
+    assert re.search(r"message_queue\.put\([^)]*_classify_error\(", source), (
+        "the classified error must be queued via message_queue.put (worker "
+        "threads must not call tkinter directly)"
+    )

--- a/tests/test_keyboard_shortcuts_styling.py
+++ b/tests/test_keyboard_shortcuts_styling.py
@@ -9,9 +9,22 @@ Tests verify:
 - FR-704b: Button styling (primary/secondary)
 """
 
-import pytest
-from unittest.mock import MagicMock, patch
 import inspect
+import re
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _binding_in_source(source: str, sequence: str) -> bool:
+    """True when source binds `sequence`, tolerating black-wrapped calls.
+
+    black may reformat ``widget.bind("<Key>", ...)`` as a multi-line call
+    (``bind(\\n        "<Key>",``), so a literal ``bind("<Key>"`` match is
+    format-sensitive; match the call open and the sequence with any
+    whitespace between them.
+    """
+    return re.search(r'bind\(\s*"' + re.escape(sequence) + '"', source) is not None
 
 
 def test_ctrl_enter_binding_exists():
@@ -23,10 +36,10 @@ def test_ctrl_enter_binding_exists():
 
     # Check that the binding method exists and has correct implementation
     source = inspect.getsource(app_gui.DocumentQAApp._create_chat_page)
-    assert 'bind("<Control-Return>"' in source, \
-        "Missing <Control-Return> binding for Ctrl+Enter question submission"
-    assert "_ask_question" in source, \
-        "Ctrl+Enter binding must call _ask_question"
+    assert _binding_in_source(
+        source, "<Control-Return>"
+    ), "Missing <Control-Return> binding for Ctrl+Enter question submission"
+    assert "_ask_question" in source, "Ctrl+Enter binding must call _ask_question"
 
 
 def test_ctrl_l_binding_exists():
@@ -37,10 +50,12 @@ def test_ctrl_l_binding_exists():
         pytest.skip("customtkinter not installed")
 
     source = inspect.getsource(app_gui.DocumentQAApp._create_chat_page)
-    assert 'bind("<Control-l>"' in source, \
-        "Missing <Control-l> binding for Ctrl+L clear chat"
-    assert "_confirm_clear_chat" in source, \
-        "Ctrl+L binding must call _confirm_clear_chat"
+    assert (
+        'bind("<Control-l>"' in source
+    ), "Missing <Control-l> binding for Ctrl+L clear chat"
+    assert (
+        "_confirm_clear_chat" in source
+    ), "Ctrl+L binding must call _confirm_clear_chat"
 
 
 def test_ctrl_comma_binding_exists():
@@ -51,8 +66,9 @@ def test_ctrl_comma_binding_exists():
         pytest.skip("customtkinter not installed")
 
     source = inspect.getsource(app_gui.DocumentQAApp._create_chat_page)
-    assert 'bind("<Control-comma>"' in source, \
-        "Missing <Control-comma> binding for Ctrl+, settings"
+    assert (
+        'bind("<Control-comma>"' in source
+    ), "Missing <Control-comma> binding for Ctrl+, settings"
 
 
 def test_enter_key_allows_newline():
@@ -63,14 +79,17 @@ def test_enter_key_allows_newline():
         pytest.skip("customtkinter not installed")
 
     source = inspect.getsource(app_gui.DocumentQAApp._create_chat_page)
-    assert 'question_entry.bind("<Return>"' in source, \
-        "Missing <Return> binding on question_entry"
+    assert _binding_in_source(
+        source, "<Return>"
+    ), "Missing <Return> binding on question_entry"
     # In multiline mode, Return should allow newlines (not submit)
-    assert 'lambda e: None' in source or 'allow' in source.lower(), \
-        "Return key must allow newlines in multiline mode"
+    assert (
+        "lambda e: None" in source or "allow" in source.lower()
+    ), "Return key must allow newlines in multiline mode"
     # Ctrl+Return should be the submit key instead
-    assert 'bind("<Control-Return>"' in source, \
-        "Ctrl+Return must be the submit key in multiline mode"
+    assert _binding_in_source(
+        source, "<Control-Return>"
+    ), "Ctrl+Return must be the submit key in multiline mode"
 
 
 def test_escape_key_clears_or_cancels():
@@ -81,10 +100,10 @@ def test_escape_key_clears_or_cancels():
         pytest.skip("customtkinter not installed")
 
     source = inspect.getsource(app_gui.DocumentQAApp._create_chat_page)
-    assert 'question_entry.bind("<Escape>"' in source, \
-        "Missing <Escape> binding on question_entry"
-    assert "_handle_escape" in source, \
-        "Escape binding must call _handle_escape"
+    assert (
+        'question_entry.bind("<Escape>"' in source
+    ), "Missing <Escape> binding on question_entry"
+    assert "_handle_escape" in source, "Escape binding must call _handle_escape"
 
 
 def test_clear_chat_requires_confirmation():
@@ -95,15 +114,18 @@ def test_clear_chat_requires_confirmation():
         pytest.skip("customtkinter not installed")
 
     # Verify _confirm_clear_chat method exists
-    assert hasattr(app_gui.DocumentQAApp, '_confirm_clear_chat'), \
-        "_confirm_clear_chat method must exist"
+    assert hasattr(
+        app_gui.DocumentQAApp, "_confirm_clear_chat"
+    ), "_confirm_clear_chat method must exist"
 
     # Verify it uses the inline confirm pattern (not messagebox.askyesno)
     source = inspect.getsource(app_gui.DocumentQAApp._confirm_clear_chat)
-    assert "_clear_confirm_pending" in source, \
-        "_confirm_clear_chat must use _clear_confirm_pending flag for inline confirm state"
-    assert "_do_clear_chat" in source, \
-        "_confirm_clear_chat must call _do_clear_chat when confirmed"
+    assert (
+        "_clear_confirm_pending" in source
+    ), "_confirm_clear_chat must use _clear_confirm_pending flag for inline confirm state"
+    assert (
+        "_do_clear_chat" in source
+    ), "_confirm_clear_chat must call _do_clear_chat when confirmed"
 
 
 def test_ask_button_has_primary_style():
@@ -115,16 +137,18 @@ def test_ask_button_has_primary_style():
 
     source = inspect.getsource(app_gui.DocumentQAApp._create_chat_page)
     # Find the ask_button creation block (now uses _make_button helper)
-    assert 'text="Ask"' in source, \
-        "ask_button must be created with _make_button"
+    assert 'text="Ask"' in source, "ask_button must be created with _make_button"
 
     # Verify primary styling uses ColorTokens methods
-    assert 'ColorTokens.primary()' in source, \
-        "ask_button must use ColorTokens.primary()"
-    assert 'ColorTokens.primary_hover()' in source, \
-        "ask_button must use ColorTokens.primary_hover()"
-    assert 'ColorTokens.text_on_primary()' in source, \
-        "ask_button must use ColorTokens.text_on_primary()"
+    assert (
+        "ColorTokens.primary()" in source
+    ), "ask_button must use ColorTokens.primary()"
+    assert (
+        "ColorTokens.primary_hover()" in source
+    ), "ask_button must use ColorTokens.primary_hover()"
+    assert (
+        "ColorTokens.text_on_primary()" in source
+    ), "ask_button must use ColorTokens.text_on_primary()"
 
 
 def test_clear_button_has_secondary_style():
@@ -136,14 +160,15 @@ def test_clear_button_has_secondary_style():
 
     source = inspect.getsource(app_gui.DocumentQAApp._create_chat_page)
     # Find the clear_button creation block (now uses _make_button helper)
-    assert 'text="Clear"' in source, \
-        "clear_button must be created with _make_button"
+    assert 'text="Clear"' in source, "clear_button must be created with _make_button"
 
     # Verify secondary styling uses ColorTokens methods
-    assert 'ColorTokens.secondary()' in source, \
-        "clear_button must use ColorTokens.secondary()"
-    assert 'ColorTokens.secondary_hover()' in source, \
-        "clear_button must use ColorTokens.secondary_hover()"
+    assert (
+        "ColorTokens.secondary()" in source
+    ), "clear_button must use ColorTokens.secondary()"
+    assert (
+        "ColorTokens.secondary_hover()" in source
+    ), "clear_button must use ColorTokens.secondary_hover()"
 
 
 def test_settings_save_button_has_primary_style():
@@ -156,25 +181,29 @@ def test_settings_save_button_has_primary_style():
     # Get SettingsDialog source
     source = inspect.getsource(app_gui.SettingsDialog)
     # Button uses _make_button with positional text arg
-    assert 'Save' in source and '_make_button' in source, \
-        "SettingsDialog must have Save button"
+    assert (
+        "Save" in source and "_make_button" in source
+    ), "SettingsDialog must have Save button"
 
-    # Find the Save button _make_button call
-    # Look for the pattern: _make_button(..., "Save", ..., fg_color=...)
+    # Find the Save button _make_button call. black may wrap the call, so the
+    # label and _make_button may be on different lines; scan each _make_button
+    # call's argument block (next ~10 lines) for the label.
+    source_lines = source.split("\n")
     save_button_match = None
-    for line_idx, line in enumerate(source.split('\n')):
-        if '"Save"' in line and '_make_button' in line:
-            # Get surrounding context (the button creation spans multiple lines)
-            context = '\n'.join(source.split('\n')[max(0, line_idx-2):line_idx+3])
-            save_button_match = context
-            break
+    for line_idx, line in enumerate(source_lines):
+        if "_make_button(" in line:
+            context = "\n".join(source_lines[line_idx : line_idx + 10])
+            if '"Save"' in context:
+                save_button_match = context
+                break
 
-    assert save_button_match is not None, \
-        "Save button _make_button creation not found"
-    assert 'ColorTokens.primary()' in save_button_match, \
-        "Save button must use ColorTokens.primary()"
-    assert 'ColorTokens.primary_hover()' in save_button_match, \
-        "Save button must use ColorTokens.primary_hover()"
+    assert save_button_match is not None, "Save button _make_button creation not found"
+    assert (
+        "ColorTokens.primary()" in save_button_match
+    ), "Save button must use ColorTokens.primary()"
+    assert (
+        "ColorTokens.primary_hover()" in save_button_match
+    ), "Save button must use ColorTokens.primary_hover()"
 
 
 def test_settings_cancel_button_has_secondary_style():
@@ -187,22 +216,28 @@ def test_settings_cancel_button_has_secondary_style():
     # Get SettingsDialog source
     source = inspect.getsource(app_gui.SettingsDialog)
     # Button uses _make_button with positional text arg
-    assert 'Cancel' in source and '_make_button' in source, \
-        "SettingsDialog must have Cancel button"
+    assert (
+        "Cancel" in source and "_make_button" in source
+    ), "SettingsDialog must have Cancel button"
 
-    # Find the Cancel button _make_button call
-    # Look for the pattern: _make_button(..., "Cancel", ..., fg_color=...)
+    # Find the Cancel button _make_button call. black may wrap the call, so
+    # the label and _make_button may be on different lines; scan each
+    # _make_button call's argument block (next ~10 lines) for the label.
+    source_lines = source.split("\n")
     cancel_button_match = None
-    for line_idx, line in enumerate(source.split('\n')):
-        if '"Cancel"' in line and '_make_button' in line:
-            context = '\n'.join(source.split('\n')[max(0, line_idx-2):line_idx+3])
-            cancel_button_match = context
-            break
+    for line_idx, line in enumerate(source_lines):
+        if "_make_button(" in line:
+            context = "\n".join(source_lines[line_idx : line_idx + 10])
+            if '"Cancel"' in context:
+                cancel_button_match = context
+                break
 
-    assert cancel_button_match is not None, \
-        "Cancel button _make_button creation not found"
-    assert 'ColorTokens.secondary()' in cancel_button_match, \
-        "Cancel button must use ColorTokens.secondary()"
+    assert (
+        cancel_button_match is not None
+    ), "Cancel button _make_button creation not found"
+    assert (
+        "ColorTokens.secondary()" in cancel_button_match
+    ), "Cancel button must use ColorTokens.secondary()"
 
 
 def test_confirm_clear_chat_calls_do_clear_on_yes():
@@ -213,19 +248,23 @@ def test_confirm_clear_chat_calls_do_clear_on_yes():
         pytest.skip("customtkinter not installed")
 
     # Verify _do_clear_chat method exists
-    assert hasattr(app_gui.DocumentQAApp, '_do_clear_chat'), \
-        "_do_clear_chat method must exist for actual clearing"
+    assert hasattr(
+        app_gui.DocumentQAApp, "_do_clear_chat"
+    ), "_do_clear_chat method must exist for actual clearing"
 
     # Verify _confirm_clear_chat uses the inline two-click pattern
     source = inspect.getsource(app_gui.DocumentQAApp._confirm_clear_chat)
     # The inline pattern uses _clear_confirm_pending flag and calls _do_clear_chat on second click
-    assert "_clear_confirm_pending" in source, \
-        "_confirm_clear_chat must use _clear_confirm_pending flag to track confirm state"
-    assert "_do_clear_chat()" in source, \
-        "_confirm_clear_chat must call _do_clear_chat() on second click (confirmation)"
+    assert (
+        "_clear_confirm_pending" in source
+    ), "_confirm_clear_chat must use _clear_confirm_pending flag to track confirm state"
+    assert (
+        "_do_clear_chat()" in source
+    ), "_confirm_clear_chat must call _do_clear_chat() on second click (confirmation)"
     # Verify the timer-based auto-revert mechanism exists
-    assert "after(" in source, \
-        "_confirm_clear_chat must use after() to start auto-revert timer"
+    assert (
+        "after(" in source
+    ), "_confirm_clear_chat must use after() to start auto-revert timer"
 
 
 def test_no_old_clear_chat_method():
@@ -236,8 +275,9 @@ def test_no_old_clear_chat_method():
         pytest.skip("customtkinter not installed")
 
     # The old method should not exist
-    assert not hasattr(app_gui.DocumentQAApp, '_clear_chat'), \
-        "Old _clear_chat method should be removed - use _confirm_clear_chat instead"
+    assert not hasattr(
+        app_gui.DocumentQAApp, "_clear_chat"
+    ), "Old _clear_chat method should be removed - use _confirm_clear_chat instead"
 
 
 def test_do_clear_chat_removes_widgets():
@@ -248,7 +288,9 @@ def test_do_clear_chat_removes_widgets():
         pytest.skip("customtkinter not installed")
 
     source = inspect.getsource(app_gui.DocumentQAApp._do_clear_chat)
-    assert "chat_frame.winfo_children()" in source, \
-        "_do_clear_chat must iterate over chat_frame children"
-    assert "widget.destroy()" in source, \
-        "_do_clear_chat must call destroy() on each widget"
+    assert (
+        "chat_frame.winfo_children()" in source
+    ), "_do_clear_chat must iterate over chat_frame children"
+    assert (
+        "widget.destroy()" in source
+    ), "_do_clear_chat must call destroy() on each widget"

--- a/tests/test_llm_interface_memory_budget.py
+++ b/tests/test_llm_interface_memory_budget.py
@@ -24,6 +24,10 @@ GIB = 1024**3
 BUNDLED_MODEL_PATH = "models/gemma-4-E2B-it-Q5_K_M.gguf"
 # Documented size of the bundled Gemma 4 E2B Q5_K_M GGUF (~3.1 GB, decimal GB)
 BUNDLED_MODEL_SIZE = int(3.1 * 1e9)
+# Fast-profile class model (the RAG_FAST_PROFILE_PATH target): ~1.5 GB
+# Qwen2.5-1.5B per CONFIGURATION.md's model-selection list
+FAST_MODEL_PATH = "models/qwen2.5-1.5b-instruct-q4_k_m.gguf"
+FAST_MODEL_SIZE = int(1.5 * 1e9)
 
 
 class MockVirtualMemory:
@@ -94,6 +98,28 @@ class TestBundledModelScenarios:
             total_bytes=max(free_gib, 16) * GIB,
             gguf_path=BUNDLED_MODEL_PATH,
             gguf_file_size=BUNDLED_MODEL_SIZE,
+        )
+        assert llm.backend is not None
+
+    @pytest.mark.parametrize("free_gib", [8, 16, 32])
+    @patch("llm_interface.GGUFBackend")
+    @patch("psutil.virtual_memory")
+    def test_fast_profile_model_loads_on_target_hardware(
+        self, mock_vm, mock_gguf_backend, free_gib
+    ):
+        """8/16/32 GB free must also load the ~1.5 GB fast-profile class.
+
+        Issue #53 exit gate requires the budget sweep to cover TWO models;
+        the fast-profile class (Qwen2.5-1.5B per CONFIGURATION.md) is the
+        model RAG_FAST_PROFILE_PATH would point at.
+        """
+        llm = _make_smart_llm_with_mocked_deps(
+            mock_vm,
+            mock_gguf_backend,
+            available_bytes=free_gib * GIB,
+            total_bytes=max(free_gib, 16) * GIB,
+            gguf_path=FAST_MODEL_PATH,
+            gguf_file_size=FAST_MODEL_SIZE,
         )
         assert llm.backend is not None
 

--- a/tests/test_llm_interface_memory_budget.py
+++ b/tests/test_llm_interface_memory_budget.py
@@ -1,11 +1,29 @@
 """
-Tests for memory budget check before GGUF model load in SmartLLM.
-Covers: llm_interface.py lines 400-409
+Tests for the SmartLLM memory budget check (issue #53 contract).
+
+Rewritten from the old flat "model_size * 4" heuristic to the realistic
+estimate: required = file_size + kv_estimate(n_ctx) + 1 GiB overhead
+(llm_interface.estimate_required_memory). The bundled ~3.1 GB Gemma 4 E2B
+GGUF must load with 8-11 GB free (the issue's target hardware), and the
+refusal error must name the model, the required memory, and the available
+memory.
+
+Scenario table: the bundled-class 3.1 GB model against 8/16/32 GB free-RAM
+machines. A separate artifact-gated test uses the REAL bundled GGUF's actual
+size when it is staged locally (operator-acquired artifact, absent in CI).
 """
 
-import pytest
-from unittest.mock import patch, MagicMock
 from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from llm_interface import estimate_required_memory
+
+GIB = 1024**3
+BUNDLED_MODEL_PATH = "models/gemma-4-E2B-it-Q5_K_M.gguf"
+# Documented size of the bundled Gemma 4 E2B Q5_K_M GGUF (~3.1 GB, decimal GB)
+BUNDLED_MODEL_SIZE = int(3.1 * 1e9)
 
 
 class MockVirtualMemory:
@@ -16,45 +34,136 @@ class MockVirtualMemory:
         self.total = total
 
 
-class TestSmartLLMMemoryBudget:
-    """Memory budget check tests for SmartLLM.__init__."""
+def _make_smart_llm_with_mocked_deps(
+    mock_vm,
+    mock_gguf_backend,
+    available_bytes: int,
+    total_bytes: int,
+    gguf_path: str = "fake_model.gguf",
+    gguf_file_size: int = 4 * GIB,
+):
+    """Helper: create SmartLLM with psutil and GGUFBackend mocked, path exists=True."""
+    mock_vm.return_value = MockVirtualMemory(
+        available=available_bytes, total=total_bytes
+    )
 
-    def _make_smart_llm_with_mocked_deps(
-        self,
-        mock_vm,
-        mock_gguf_backend,
-        available_bytes: int,
-        total_bytes: int,
-        gguf_path: str = "fake_model.gguf",
-        gguf_file_size: int = 4 * 1024**3,
+    with patch("llm_interface.Path") as mock_path_cls:
+        mock_path_instance = MagicMock()
+        mock_path_instance.exists.return_value = True
+        mock_path_instance.stat.return_value = MagicMock(st_size=gguf_file_size)
+        mock_path_cls.return_value = mock_path_instance
+
+        from llm_interface import SmartLLM
+
+        return SmartLLM(gguf_path=gguf_path, gguf_n_ctx=4096)
+
+
+class TestEstimateRequiredMemory:
+    """The estimator replaces the flat 4x-file-size heuristic."""
+
+    def test_bundled_model_estimate_is_realistic_not_4x(self):
+        """3.1 GB file must estimate ~5-6 GB, far below the old 12.4 GB claim."""
+        estimate = estimate_required_memory(BUNDLED_MODEL_SIZE, 4096)
+
+        assert estimate < int(
+            BUNDLED_MODEL_SIZE * 4
+        ), "estimate must be well under the old 4x claim of ~12.4 GB"
+        assert BUNDLED_MODEL_SIZE + GIB <= estimate <= BUNDLED_MODEL_SIZE + 4 * GIB
+
+    def test_estimate_scales_with_file_size(self):
+        """Larger models require strictly more memory."""
+        assert estimate_required_memory(8 * GIB, 4096) > estimate_required_memory(
+            2 * GIB, 4096
+        )
+
+
+class TestBundledModelScenarios:
+    """The bundled 3.1 GB model against 8/16/32 GB free-RAM scenarios."""
+
+    @pytest.mark.parametrize("free_gib", [8, 16, 32])
+    @patch("llm_interface.GGUFBackend")
+    @patch("psutil.virtual_memory")
+    def test_bundled_model_loads_on_target_hardware(
+        self, mock_vm, mock_gguf_backend, free_gib
     ):
-        """Helper: create SmartLLM with psutil and GGUFBackend mocked, path exists=True."""
-        mock_vm.return_value = MockVirtualMemory(available=available_bytes, total=total_bytes)
+        """8/16/32 GB free must all load the bundled ~3.1 GB model (n_ctx=4096)."""
+        llm = _make_smart_llm_with_mocked_deps(
+            mock_vm,
+            mock_gguf_backend,
+            available_bytes=free_gib * GIB,
+            total_bytes=max(free_gib, 16) * GIB,
+            gguf_path=BUNDLED_MODEL_PATH,
+            gguf_file_size=BUNDLED_MODEL_SIZE,
+        )
+        assert llm.backend is not None
 
-        with patch("llm_interface.Path") as mock_path_cls:
-            mock_path_instance = MagicMock()
-            mock_path_instance.exists.return_value = True
-            mock_path_instance.stat.return_value = MagicMock(st_size=gguf_file_size)
-            mock_path_cls.return_value = mock_path_instance
+    @patch("llm_interface.GGUFBackend")
+    @patch("psutil.virtual_memory")
+    def test_bundled_model_refused_when_free_ram_below_estimate(
+        self, mock_vm, mock_gguf_backend
+    ):
+        """Below the realistic estimate the gate still refuses, with a diagnostic."""
+        estimate = estimate_required_memory(BUNDLED_MODEL_SIZE, 4096)
+        available = estimate - (512 * 1024**2)  # half a GB short
 
-            from llm_interface import SmartLLM
+        with pytest.raises(RuntimeError) as exc_info:
+            _make_smart_llm_with_mocked_deps(
+                mock_vm,
+                mock_gguf_backend,
+                available_bytes=available,
+                total_bytes=estimate,
+                gguf_path=BUNDLED_MODEL_PATH,
+                gguf_file_size=BUNDLED_MODEL_SIZE,
+            )
 
-            return SmartLLM(gguf_path=gguf_path)
+        error_msg = str(exc_info.value)
+        assert "Insufficient RAM" in error_msg
+        assert "gemma-4-E2B-it-Q5_K_M.gguf" in error_msg
+        assert f"{estimate / GIB:.1f}GB" in error_msg
+        assert f"{available / GIB:.1f}GB" in error_msg
+
+    def test_real_bundled_model_scenarios_when_staged(self):
+        """Artifact-gated: the REAL bundled GGUF against 8/16/32 GB free.
+
+        Skips inline when the operator has not staged the model (CI working
+        trees never contain it); with it staged, the gate must accept the
+        actual file size at 8 GB free and above.
+        """
+        bundled = Path(BUNDLED_MODEL_PATH)
+        if not bundled.exists():
+            pytest.skip("bundled GGUF not staged: " + BUNDLED_MODEL_PATH)
+        actual_size = bundled.stat().st_size
+        assert actual_size > GIB, "staged file is not a plausibly real GGUF"
+
+        with patch("psutil.virtual_memory") as mock_vm, patch(
+            "llm_interface.GGUFBackend"
+        ):
+            for free_gib in (8, 16, 32):
+                mock_vm.return_value = MockVirtualMemory(
+                    available=free_gib * GIB, total=free_gib * GIB
+                )
+                from llm_interface import SmartLLM
+
+                llm = SmartLLM(gguf_path=BUNDLED_MODEL_PATH, gguf_n_ctx=4096)
+                assert llm.backend is not None
+
+
+class TestSmartLLMMemoryBudget:
+    """Gate semantics preserved from the original suite, on the new contract."""
 
     @patch("llm_interface.GGUFBackend")
     @patch("psutil.virtual_memory")
     def test_raises_runtime_error_when_available_ram_below_required(
         self, mock_vm, mock_gguf_backend
     ):
-        """Test: SmartLLM.__init__ raises RuntimeError when available RAM < model_size * 4."""
-        # Model file is 4GB, requires 16GB (4 * 4), but only 12GB available
-        gguf_file_size = 4 * 1024**3
-        required_memory = int(gguf_file_size * 4)  # 16GB
-        available_bytes = 12 * 1024**3
-        total_bytes = 16 * 1024**3
+        """SmartLLM.__init__ raises RuntimeError when available RAM < required."""
+        gguf_file_size = 4 * GIB
+        required_memory = estimate_required_memory(gguf_file_size, 4096)
+        available_bytes = required_memory - GIB  # 1 GB short
+        total_bytes = required_memory * 2
 
         with pytest.raises(RuntimeError) as exc_info:
-            self._make_smart_llm_with_mocked_deps(
+            _make_smart_llm_with_mocked_deps(
                 mock_vm,
                 mock_gguf_backend,
                 available_bytes,
@@ -69,41 +178,40 @@ class TestSmartLLMMemoryBudget:
     def test_error_message_includes_available_and_required_ram(
         self, mock_vm, mock_gguf_backend
     ):
-        """Test: Error message includes available RAM and required RAM based on model size."""
-        gguf_file_size = 4 * 1024**3
-        required_memory = int(gguf_file_size * 4)  # 16GB
-        available_bytes = 10 * 1024**3
-        total_bytes = 16 * 1024**3
+        """Error message includes available RAM, required RAM, and the model name."""
+        gguf_file_size = 4 * GIB
+        required_memory = estimate_required_memory(gguf_file_size, 4096)
+        available_bytes = required_memory - GIB
+        total_bytes = required_memory * 2
 
         with pytest.raises(RuntimeError) as exc_info:
-            self._make_smart_llm_with_mocked_deps(
+            _make_smart_llm_with_mocked_deps(
                 mock_vm,
                 mock_gguf_backend,
                 available_bytes,
                 total_bytes,
+                gguf_path="models/test-model.gguf",
                 gguf_file_size=gguf_file_size,
             )
 
         error_msg = str(exc_info.value)
-        # Check "Insufficient RAM" is present
         assert "Insufficient RAM" in error_msg
-        # Check required memory is mentioned (based on model file size)
-        assert f"{required_memory / (1024**3):.1f}GB" in error_msg
-        # Check available RAM is mentioned
-        assert f"{available_bytes / (1024**3):.1f}GB" in error_msg
+        assert f"{required_memory / GIB:.1f}GB" in error_msg
+        assert f"{available_bytes / GIB:.1f}GB" in error_msg
+        assert "test-model.gguf" in error_msg
 
     @patch("llm_interface.GGUFBackend")
     @patch("psutil.virtual_memory")
     def test_proceeds_normally_when_available_ram_exceeds_required(
         self, mock_vm, mock_gguf_backend
     ):
-        """Test: SmartLLM.__init__ proceeds normally when available RAM >= model_size * 4."""
-        # Model file is 4GB, requires 16GB, and 20GB is available
-        gguf_file_size = 4 * 1024**3
-        available_bytes = 20 * 1024**3
-        total_bytes = 16 * 1024**3
+        """SmartLLM.__init__ proceeds when available RAM >= required."""
+        gguf_file_size = 4 * GIB
+        required_memory = estimate_required_memory(gguf_file_size, 4096)
+        available_bytes = required_memory + 4 * GIB
+        total_bytes = available_bytes * 2
 
-        llm = self._make_smart_llm_with_mocked_deps(
+        llm = _make_smart_llm_with_mocked_deps(
             mock_vm,
             mock_gguf_backend,
             available_bytes,
@@ -117,12 +225,13 @@ class TestSmartLLMMemoryBudget:
     def test_memory_check_before_gguf_backend_constructor(
         self, mock_vm, mock_gguf_backend
     ):
-        """Test: Memory check is evaluated BEFORE GGUFBackend constructor is called."""
-        # Model file is 4GB, requires 16GB, but only 10GB available
-        gguf_file_size = 4 * 1024**3
-        available_bytes = 10 * 1024**3
-        total_bytes = 16 * 1024**3
-        mock_vm.return_value = MockVirtualMemory(available=available_bytes, total=total_bytes)
+        """Memory check is evaluated BEFORE GGUFBackend constructor is called."""
+        gguf_file_size = 100 * GIB  # refused under any sane formula
+        available_bytes = 8 * GIB
+        total_bytes = 16 * GIB
+        mock_vm.return_value = MockVirtualMemory(
+            available=available_bytes, total=total_bytes
+        )
 
         with patch("llm_interface.Path") as mock_path_cls:
             mock_path_instance = MagicMock()
@@ -133,7 +242,7 @@ class TestSmartLLMMemoryBudget:
             from llm_interface import SmartLLM
 
             with pytest.raises(RuntimeError):
-                SmartLLM(gguf_path="fake_model.gguf")
+                SmartLLM(gguf_path="fake_model.gguf", gguf_n_ctx=4096)
 
             # Verify GGUFBackend was NEVER called — memory check threw before constructor
             mock_gguf_backend.assert_not_called()
@@ -143,14 +252,13 @@ class TestSmartLLMMemoryBudget:
     def test_available_ram_exactly_at_required_boundary_accepted(
         self, mock_vm, mock_gguf_backend
     ):
-        """Test: Available RAM exactly at required boundary is accepted (>= not >)."""
-        # Model file is 4GB, requires exactly 16GB (4 * 4)
-        gguf_file_size = 4 * 1024**3
-        required_memory = int(gguf_file_size * 4)
+        """Available RAM exactly at the required boundary is accepted (>= not >)."""
+        gguf_file_size = 4 * GIB
+        required_memory = estimate_required_memory(gguf_file_size, 4096)
         available_bytes = required_memory
-        total_bytes = 16 * 1024**3
+        total_bytes = required_memory * 2
 
-        llm = self._make_smart_llm_with_mocked_deps(
+        llm = _make_smart_llm_with_mocked_deps(
             mock_vm,
             mock_gguf_backend,
             available_bytes,
@@ -164,11 +272,14 @@ class TestSmartLLMMemoryBudget:
     def test_gguf_backend_called_when_memory_sufficient(
         self, mock_vm, mock_gguf_backend
     ):
-        """Verify GGUFBackend constructor is actually invoked when memory check passes."""
-        gguf_file_size = 4 * 1024**3
-        available_bytes = 18 * 1024**3
-        total_bytes = 32 * 1024**3
-        mock_vm.return_value = MockVirtualMemory(available=available_bytes, total=total_bytes)
+        """GGUFBackend constructor is actually invoked when the memory check passes."""
+        gguf_file_size = 4 * GIB
+        required_memory = estimate_required_memory(gguf_file_size, 4096)
+        available_bytes = required_memory + 2 * GIB
+        total_bytes = available_bytes * 2
+        mock_vm.return_value = MockVirtualMemory(
+            available=available_bytes, total=total_bytes
+        )
 
         with patch("llm_interface.Path") as mock_path_cls:
             mock_path_instance = MagicMock()
@@ -178,7 +289,7 @@ class TestSmartLLMMemoryBudget:
 
             from llm_interface import SmartLLM
 
-            llm = SmartLLM(gguf_path="fake_model.gguf")
+            SmartLLM(gguf_path="fake_model.gguf", gguf_n_ctx=4096)
             # Verify GGUFBackend was called (meaning we passed the memory check)
             mock_gguf_backend.assert_called_once()
 
@@ -187,29 +298,35 @@ class TestSmartLLMMemoryBudget:
     def test_different_model_sizes_have_different_thresholds(
         self, mock_vm, mock_gguf_backend
     ):
-        """Test: Larger models require more memory, smaller models require less."""
-        # Small model: 2GB file → requires 8GB, 10GB available is enough
-        small_model_size = 2 * 1024**3
-        # Large model: 8GB file → requires 32GB, 20GB available is not enough
-        large_model_size = 8 * 1024**3
-
-        # Small model should pass with 10GB available (2GB * 4 = 8GB required)
-        llm_small = self._make_smart_llm_with_mocked_deps(
+        """Larger models require more memory; a mid-size model now fits where 4x refused."""
+        # Small model: 2 GB file -> ~4 GB required; 10 GB available is plenty
+        llm_small = _make_smart_llm_with_mocked_deps(
             mock_vm,
             mock_gguf_backend,
-            available_bytes=10 * 1024**3,
-            total_bytes=16 * 1024**3,
-            gguf_file_size=small_model_size,
+            available_bytes=10 * GIB,
+            total_bytes=16 * GIB,
+            gguf_file_size=2 * GIB,
         )
         assert llm_small.backend is not None
 
-        # Large model should fail with 20GB available (needs 32GB)
+        # Large model: 8 GB file -> ~10 GB required; 20 GB available now loads
+        # (the old 4x formula demanded 32 GB and refused)
+        llm_large = _make_smart_llm_with_mocked_deps(
+            mock_vm,
+            mock_gguf_backend,
+            available_bytes=20 * GIB,
+            total_bytes=48 * GIB,
+            gguf_file_size=8 * GIB,
+        )
+        assert llm_large.backend is not None
+
+        # A truly oversized model (100 GB file) is still refused at 20 GB
         with pytest.raises(RuntimeError) as exc_info:
-            self._make_smart_llm_with_mocked_deps(
+            _make_smart_llm_with_mocked_deps(
                 mock_vm,
                 mock_gguf_backend,
-                available_bytes=20 * 1024**3,
-                total_bytes=48 * 1024**3,
-                gguf_file_size=large_model_size,
+                available_bytes=20 * GIB,
+                total_bytes=128 * GIB,
+                gguf_file_size=100 * GIB,
             )
         assert "Insufficient RAM" in str(exc_info.value)

--- a/tests/test_llm_interface_simplified.py
+++ b/tests/test_llm_interface_simplified.py
@@ -8,11 +8,10 @@ These tests verify:
 4. SmartLLM delegates to backend correctly
 """
 
-import pytest
 import inspect
-import sys
-from pathlib import Path
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 
 class TestRemovedClasses:
@@ -21,29 +20,37 @@ class TestRemovedClasses:
     def test_openvinollm_not_in_module(self):
         """OpenVINOLLM class must NOT exist in llm_interface module."""
         import llm_interface as mod
-        assert not hasattr(mod, "OpenVINOLLM"), \
-            "OpenVINOLLM still exists in llm_interface — it must be removed"
+
+        assert not hasattr(
+            mod, "OpenVINOLLM"
+        ), "OpenVINOLLM still exists in llm_interface — it must be removed"
 
     def test_ollamallm_not_in_module(self):
         """OllamaLLM class must NOT exist in llm_interface module."""
         import llm_interface as mod
-        assert not hasattr(mod, "OllamaLLM"), \
-            "OllamaLLM still exists in llm_interface — it must be removed"
+
+        assert not hasattr(
+            mod, "OllamaLLM"
+        ), "OllamaLLM still exists in llm_interface — it must be removed"
 
     def test_openaicompatibllm_not_in_module(self):
         """OpenAICompatibleLLM class must NOT exist in llm_interface module."""
         import llm_interface as mod
-        assert not hasattr(mod, "OpenAICompatibleLLM"), \
-            "OpenAICompatibleLLM still exists in llm_interface — it must be removed"
+
+        assert not hasattr(
+            mod, "OpenAICompatibleLLM"
+        ), "OpenAICompatibleLLM still exists in llm_interface — it must be removed"
 
     def test_import_raises_no_nameerror_for_smartllm(self):
         """SmartLLM must still be importable after removals."""
         from llm_interface import SmartLLM
+
         assert callable(SmartLLM)
 
     def test_import_raises_no_nameerror_for_ggufbackend(self):
         """GGUFBackend must still be importable after removals."""
         from llm_interface import GGUFBackend
+
         assert callable(GGUFBackend)
 
 
@@ -53,72 +60,88 @@ class TestSmartLLMSignature:
     def test_no_ollama_model_param(self):
         """SmartLLM.__init__ must NOT have ollama_model parameter."""
         from llm_interface import SmartLLM
+
         sig = inspect.signature(SmartLLM.__init__)
-        assert "ollama_model" not in sig.parameters, \
-            "SmartLLM still has ollama_model parameter — remove it"
+        assert (
+            "ollama_model" not in sig.parameters
+        ), "SmartLLM still has ollama_model parameter — remove it"
 
     def test_no_ollama_url_param(self):
         """SmartLLM.__init__ must NOT have ollama_url parameter."""
         from llm_interface import SmartLLM
+
         sig = inspect.signature(SmartLLM.__init__)
-        assert "ollama_url" not in sig.parameters, \
-            "SmartLLM still has ollama_url parameter — remove it"
+        assert (
+            "ollama_url" not in sig.parameters
+        ), "SmartLLM still has ollama_url parameter — remove it"
 
     def test_no_api_url_param(self):
         """SmartLLM.__init__ must NOT have api_url parameter."""
         from llm_interface import SmartLLM
+
         sig = inspect.signature(SmartLLM.__init__)
-        assert "api_url" not in sig.parameters, \
-            "SmartLLM still has api_url parameter — remove it"
+        assert (
+            "api_url" not in sig.parameters
+        ), "SmartLLM still has api_url parameter — remove it"
 
     def test_no_api_model_param(self):
         """SmartLLM.__init__ must NOT have api_model parameter."""
         from llm_interface import SmartLLM
+
         sig = inspect.signature(SmartLLM.__init__)
-        assert "api_model" not in sig.parameters, \
-            "SmartLLM still has api_model parameter — remove it"
+        assert (
+            "api_model" not in sig.parameters
+        ), "SmartLLM still has api_model parameter — remove it"
 
     def test_no_device_param(self):
         """SmartLLM.__init__ must NOT have device parameter."""
         from llm_interface import SmartLLM
+
         sig = inspect.signature(SmartLLM.__init__)
-        assert "device" not in sig.parameters, \
-            "SmartLLM still has device parameter — remove it"
+        assert (
+            "device" not in sig.parameters
+        ), "SmartLLM still has device parameter — remove it"
 
     def test_no_model_path_param(self):
         """SmartLLM.__init__ must NOT have model_path parameter (old OpenVINO path)."""
         from llm_interface import SmartLLM
+
         sig = inspect.signature(SmartLLM.__init__)
-        assert "model_path" not in sig.parameters, \
-            "SmartLLM still has model_path parameter — remove it"
+        assert (
+            "model_path" not in sig.parameters
+        ), "SmartLLM still has model_path parameter — remove it"
 
     def test_has_gguf_path_param(self):
         """SmartLLM.__init__ must have gguf_path parameter."""
         from llm_interface import SmartLLM
+
         sig = inspect.signature(SmartLLM.__init__)
-        assert "gguf_path" in sig.parameters, \
-            "SmartLLM missing gguf_path parameter"
+        assert "gguf_path" in sig.parameters, "SmartLLM missing gguf_path parameter"
 
     def test_has_gguf_n_ctx_param(self):
         """SmartLLM.__init__ must have gguf_n_ctx parameter."""
         from llm_interface import SmartLLM
+
         sig = inspect.signature(SmartLLM.__init__)
-        assert "gguf_n_ctx" in sig.parameters, \
-            "SmartLLM missing gguf_n_ctx parameter"
+        assert "gguf_n_ctx" in sig.parameters, "SmartLLM missing gguf_n_ctx parameter"
 
     def test_has_gguf_n_threads_param(self):
         """SmartLLM.__init__ must have gguf_n_threads parameter."""
         from llm_interface import SmartLLM
+
         sig = inspect.signature(SmartLLM.__init__)
-        assert "gguf_n_threads" in sig.parameters, \
-            "SmartLLM missing gguf_n_threads parameter"
+        assert (
+            "gguf_n_threads" in sig.parameters
+        ), "SmartLLM missing gguf_n_threads parameter"
 
     def test_has_gguf_verbose_param(self):
         """SmartLLM.__init__ must have gguf_verbose parameter."""
         from llm_interface import SmartLLM
+
         sig = inspect.signature(SmartLLM.__init__)
-        assert "gguf_verbose" in sig.parameters, \
-            "SmartLLM missing gguf_verbose parameter"
+        assert (
+            "gguf_verbose" in sig.parameters
+        ), "SmartLLM missing gguf_verbose parameter"
 
 
 class TestSmartLLMInit:
@@ -132,6 +155,7 @@ class TestSmartLLMInit:
         with patch("llm_interface.GGUFBackend") as mock_backend_cls:
             mock_backend_cls.return_value = MagicMock()
             from llm_interface import SmartLLM
+
             llm = SmartLLM(gguf_path=str(gguf_path))
 
             mock_backend_cls.assert_called_once_with(
@@ -150,6 +174,7 @@ class TestSmartLLMInit:
 
         with patch("llm_interface.GGUFBackend"):
             from llm_interface import SmartLLM
+
             with pytest.raises(RuntimeError, match="No GGUF backend available"):
                 SmartLLM(gguf_path=str(bad_path))
 
@@ -157,6 +182,7 @@ class TestSmartLLMInit:
         """SmartLLM init with None gguf_path raises RuntimeError."""
         with patch("llm_interface.GGUFBackend"):
             from llm_interface import SmartLLM
+
             with pytest.raises(RuntimeError, match="No GGUF backend available"):
                 SmartLLM(gguf_path=None)
 
@@ -164,6 +190,7 @@ class TestSmartLLMInit:
         """SmartLLM init with empty string gguf_path raises RuntimeError."""
         with patch("llm_interface.GGUFBackend"):
             from llm_interface import SmartLLM
+
             with pytest.raises(RuntimeError, match="No GGUF backend available"):
                 SmartLLM(gguf_path="")
 
@@ -175,6 +202,7 @@ class TestSmartLLMInit:
         with patch("llm_interface.GGUFBackend") as mock_backend_cls:
             mock_backend_cls.side_effect = RuntimeError("GGUF init failed")
             from llm_interface import SmartLLM
+
             with pytest.raises(RuntimeError, match="No GGUF backend available"):
                 SmartLLM(gguf_path=str(gguf_path))
 
@@ -186,12 +214,14 @@ class TestSmartLLMInit:
         with patch("llm_interface.GGUFBackend") as mock_backend_cls:
             mock_backend_cls.return_value = MagicMock()
             from llm_interface import SmartLLM
+
             llm = SmartLLM(
                 gguf_path=str(gguf_path),
                 gguf_n_ctx=4096,
                 gguf_n_threads=4,
                 gguf_verbose=True,
             )
+            assert llm.backend is not None
 
             mock_backend_cls.assert_called_once_with(
                 gguf_path=str(gguf_path),
@@ -214,6 +244,7 @@ class TestSmartLLMGenerate:
 
         with patch("llm_interface.GGUFBackend", return_value=mock_backend):
             from llm_interface import SmartLLM
+
             llm = SmartLLM(gguf_path=str(gguf_path))
 
             result = llm.generate("Hello, model!")
@@ -233,6 +264,7 @@ class TestSmartLLMGenerate:
 
         with patch("llm_interface.GGUFBackend", return_value=mock_backend):
             from llm_interface import SmartLLM
+
             llm = SmartLLM(gguf_path=str(gguf_path))
             config = InferenceConfig(max_tokens=512, temperature=0.3)
 
@@ -250,6 +282,7 @@ class TestSmartLLMGenerate:
         mock_backend = MagicMock()
         with patch("llm_interface.GGUFBackend", return_value=mock_backend):
             from llm_interface import SmartLLM
+
             llm = SmartLLM(gguf_path=str(gguf_path))
 
             oversized = "x" * 200000  # Exceeds MAX_PROMPT_LENGTH (100000)
@@ -270,6 +303,7 @@ class TestSmartLLMAnswerQuestion:
 
         with patch("llm_interface.GGUFBackend", return_value=mock_backend):
             from llm_interface import SmartLLM
+
             llm = SmartLLM(gguf_path=str(gguf_path))
 
             result = llm.answer_question(
@@ -295,6 +329,7 @@ class TestSmartLLMAnswerQuestion:
 
         with patch("llm_interface.GGUFBackend", return_value=mock_backend):
             from llm_interface import SmartLLM
+
             llm = SmartLLM(gguf_path=str(gguf_path))
 
             result = llm.answer_question(
@@ -317,6 +352,7 @@ class TestSmartLLMAnswerQuestion:
 
         with patch("llm_interface.GGUFBackend", return_value=mock_backend):
             from llm_interface import SmartLLM
+
             llm = SmartLLM(gguf_path=str(gguf_path))
 
             history = [
@@ -359,6 +395,7 @@ class TestSmartLLMGetInfo:
 
         with patch("llm_interface.GGUFBackend", return_value=mock_backend):
             from llm_interface import SmartLLM
+
             llm = SmartLLM(gguf_path=str(gguf_path))
 
             info = llm.get_info()
@@ -378,15 +415,25 @@ class TestNoMultiBackendFallbackChain:
         with patch("llm_interface.GGUFBackend") as mock_backend_cls:
             mock_backend_cls.return_value = MagicMock()
             from llm_interface import SmartLLM
+
             llm = SmartLLM(gguf_path=str(gguf_path))
 
             assert hasattr(llm, "backend")
-            assert not hasattr(llm, "backends") or llm.backends is None, \
-                "SmartLLM should not have self.backends — fallback chain is removed"
+            assert (
+                not hasattr(llm, "backends") or llm.backends is None
+            ), "SmartLLM should not have self.backends — fallback chain is removed"
 
     def test_no_fallback_loop_in_init_source(self):
-        """Source code of SmartLLM.__init__ must not contain a loop over backends."""
+        """Source code of SmartLLM.__init__ must not contain a loop over backends.
+
+        Issue #53 mandates a SINGLE fast-profile retry when the primary model
+        fails the RAM gate (fast_profile_path), so a bare 'fallback' word is no
+        longer forbidden by itself; what stays forbidden is any multi-backend
+        fallback CHAIN (looping over backends, plural backend stores, generic
+        while-loops in the initializer).
+        """
         from llm_interface import SmartLLM
+
         source = inspect.getsource(SmartLLM.__init__)
 
         # These patterns would indicate a fallback chain
@@ -394,21 +441,27 @@ class TestNoMultiBackendFallbackChain:
             "for backend in",
             "while ",
             "self.backends",
-            "fallback",
         ]
         for pattern in forbidden:
-            assert pattern not in source, \
-                f"SmartLLM.__init__ contains forbidden pattern '{pattern}' — fallback chain detected"
+            assert (
+                pattern not in source
+            ), f"SmartLLM.__init__ contains forbidden pattern '{pattern}' — fallback chain detected"
+
+        # The fast-profile retry must be a single named attempt, not a loop.
+        assert "fast_profile_path" in source
+        assert "_load_backend" in source
 
     def test_no_openvino_openvinollm_in_smartllm_source(self):
         """SmartLLM source must not reference removed classes."""
         from llm_interface import SmartLLM
+
         source = inspect.getsource(SmartLLM)
 
         forbidden = ["OpenVINOLLM", "OllamaLLM", "OpenAICompatibleLLM"]
         for cls_name in forbidden:
-            assert cls_name not in source, \
-                f"SmartLLM source contains '{cls_name}' — class must be removed"
+            assert (
+                cls_name not in source
+            ), f"SmartLLM source contains '{cls_name}' — class must be removed"
 
 
 if __name__ == "__main__":

--- a/tests/test_llm_load_api_diagnostic.py
+++ b/tests/test_llm_load_api_diagnostic.py
@@ -1,0 +1,107 @@
+"""
+Acceptance checks for issue #53 (AC6): the API's 503 responses for /ask and
+/ask/stream must include the engine's llm_init_error diagnostic (RAM numbers)
+when no LLM could be loaded, instead of the bare "No LLM backend available".
+
+DISCRIMINATING check: at base both endpoints return
+detail == "No LLM backend available" and ignore engine.llm_init_error, so
+the RAM-number assertions fail with that string visible in the log.
+
+Harness mirrors tests/test_api.py: module-level TestClient, per-test patch of
+api_server.engine. All engine interaction is mocked; nothing loads a model.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+import api_server
+from api_server import app
+
+# Mark all tests in this module as unit tests
+pytestmark = pytest.mark.unit
+
+# Create a test client
+client = TestClient(app)
+
+
+def _patch_engine(mock_engine):
+    """Patch engine on the EXACT module object that owns this file's app.
+
+    Other test modules (test_auth) evict api_server from sys.modules and
+    re-import it; a string target like patch("api_server.engine", ...) would
+    then patch the NEW module while this file's app endpoints still read the
+    ORIGINAL module's global. patch.object pins the module identity.
+    """
+    return patch.object(api_server, "engine", mock_engine)
+
+
+RAM_DIAGNOSTIC = (
+    "Insufficient RAM to load GGUF model: need ~5.2GB, but only 4.0GB available"
+)
+
+
+def _engine_without_llm() -> MagicMock:
+    mock_engine = MagicMock()
+    mock_engine.llm = None
+    mock_engine.llm_init_error = RAM_DIAGNOSTIC
+    return mock_engine
+
+
+@pytest.fixture
+def bypass_auth():
+    """Bypass authentication so this check is order-independent.
+
+    Pre-existing auth tests elsewhere in the suite can leave auth enabled;
+    without this override the 503 assertions would observe a 401 instead.
+    """
+    from auth import authenticate
+
+    app.dependency_overrides[authenticate] = lambda: {
+        "authenticated": True,
+        "method": "test",
+    }
+    yield
+    if authenticate in app.dependency_overrides:
+        del app.dependency_overrides[authenticate]
+
+
+class TestAskNoLlmDiagnostic:
+    """503 detail for /ask and /ask/stream must carry the RAM diagnostic."""
+
+    def test_ask_503_detail_includes_ram_diagnostic(self, bypass_auth):
+        """POST /ask with engine.llm None -> 503 detail includes RAM numbers."""
+        with _patch_engine(_engine_without_llm()):
+            response = client.post("/ask", json={"question": "q"})
+
+        assert response.status_code == 503
+        detail = response.json()["detail"]
+        assert "5.2GB" in detail, (
+            f"/ask 503 detail must include the required-RAM figure from "
+            f"engine.llm_init_error; got detail: {detail!r}"
+        )
+        assert "4.0GB" in detail, (
+            f"/ask 503 detail must include the available-RAM figure from "
+            f"engine.llm_init_error; got detail: {detail!r}"
+        )
+
+    def test_ask_stream_503_detail_includes_ram_diagnostic(self, bypass_auth):
+        """POST /ask/stream with engine.llm None -> 503 detail includes RAM numbers."""
+        if not any(
+            getattr(route, "path", None) == "/ask/stream" for route in app.routes
+        ):
+            pytest.skip("/ask/stream route not registered (no sse-starlette)")
+        with _patch_engine(_engine_without_llm()):
+            response = client.post("/ask/stream", json={"question": "q"})
+
+        assert response.status_code == 503
+        detail = response.json()["detail"]
+        assert "5.2GB" in detail, (
+            f"/ask/stream 503 detail must include the required-RAM figure "
+            f"from engine.llm_init_error; got detail: {detail!r}"
+        )
+        assert "4.0GB" in detail, (
+            f"/ask/stream 503 detail must include the available-RAM figure "
+            f"from engine.llm_init_error; got detail: {detail!r}"
+        )

--- a/tests/test_llm_load_gui_diagnostic.py
+++ b/tests/test_llm_load_gui_diagnostic.py
@@ -1,0 +1,100 @@
+"""
+Acceptance checks for issue #53 (AC5 + diagnostic propagation): the GUI and
+RAGEngine must surface the real RAM diagnostic instead of misdirecting the
+user to "configure an LLM backend".
+
+DISCRIMINATING checks (base is RED):
+- Part 1: app_gui._classify_error maps any unrecognized query error to
+  "Make sure at least one LLM backend is configured in Settings" even when
+  the error text is an "Insufficient RAM" diagnostic, so the
+  '"configured in Settings" not in result' assertion fails at base.
+- Part 2: rag_engine._init_llm swallows the SmartLLM failure and query()
+  raises a bare "LLM not initialized. Cannot answer questions.", so the
+  query-message assertion fails at base. The llm_init_error attribute read
+  uses getattr(..., None) so the base failure comes from the query-message
+  assertion (clean RED), and the recorded-diagnostic assertions apply once
+  the attribute exists.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+RAM_DIAGNOSTIC = (
+    "Insufficient RAM to load GGUF model: need ~5.2GB, "
+    "but only 4.0GB available. Close other applications or use a smaller model."
+)
+
+
+def _load_app_gui():
+    try:
+        import app_gui
+
+        return app_gui
+    except ImportError:
+        pytest.skip("customtkinter not installed")
+
+
+class TestClassifyErrorSurfacesRamDiagnostic:
+    """Part 1: _classify_error must relay RAM numbers, not Settings advice."""
+
+    def test_ram_error_classified_with_numbers_and_no_settings_misdirection(self):
+        app_gui = _load_app_gui()
+        result = app_gui._classify_error(RuntimeError(RAM_DIAGNOSTIC), "query")
+
+        assert (
+            "5.2GB" in result
+        ), f"classified message must keep the required-RAM number; got: {result!r}"
+        assert (
+            "4.0GB" in result
+        ), f"classified message must keep the available-RAM number; got: {result!r}"
+        assert (
+            "Insufficient RAM" in result
+        ), f"classified message must keep the RAM-failure marker; got: {result!r}"
+        assert "configured in Settings" not in result, (
+            "RAM-gate refusal must not be misdirected to "
+            f"'configured in Settings' (a backend IS configured); got: {result!r}"
+        )
+
+
+class TestEngineDiagnosticPropagation:
+    """Part 2: RAGEngine must record and re-raise the load diagnostic."""
+
+    def test_llm_init_error_recorded_and_survives_into_query_message(self):
+        import rag_engine
+        from rag_engine import RAGConfig, RAGEngine
+
+        engine = RAGEngine.__new__(RAGEngine)  # bypass heavy __init__
+        engine.config = RAGConfig()
+        engine.gguf_path = "models/x.gguf"
+        engine.llm = None
+
+        with patch.object(
+            rag_engine,
+            "SmartLLM",
+            side_effect=RuntimeError(
+                "Insufficient RAM to load GGUF model: need ~5.2GB, "
+                "but only 4.0GB available"
+            ),
+        ):
+            engine._init_llm("models/x.gguf")
+
+            assert engine.llm is None, "failed load must leave llm as None"
+            # Tolerant at base (attribute does not exist yet); pinned RED is
+            # the query-message assertion below.
+            diagnostic = getattr(engine, "llm_init_error", None)
+
+            with pytest.raises(RuntimeError) as exc_info:
+                engine.query("q")
+
+        msg = str(exc_info.value)
+        assert "Insufficient RAM" in msg, (
+            "RAGEngine.query() must raise the recorded llm_init_error "
+            f"diagnostic instead of a bare 'LLM not initialized' message; "
+            f"llm_init_error={diagnostic!r}, raised: {msg!r}"
+        )
+        if diagnostic is not None:
+            assert "Insufficient RAM" in diagnostic, (
+                f"llm_init_error must carry the SmartLLM failure text; "
+                f"got: {diagnostic!r}"
+            )

--- a/tests/test_llm_memory_fast_fallback.py
+++ b/tests/test_llm_memory_fast_fallback.py
@@ -1,0 +1,140 @@
+"""
+Acceptance checks for issue #53 (AC3/AC4): SmartLLM must support an optional
+fast_profile_path so that, when the primary GGUF model fails the RAM gate,
+a smaller fast-profile model loads instead of dropping the LLM entirely.
+
+NEW-SURFACE check: the `fast_profile_path` kwarg does not exist at base, so
+scenarios A and B fail at base with TypeError ("unexpected keyword argument
+'fast_profile_path'") — the expected RED. Scenario C (no fast profile →
+direct refusal, today's behavior) is expected to pass at base and after the
+fix.
+
+Contract pinned here:
+
+    SmartLLM(gguf_path=..., fast_profile_path=...)  # new optional kwarg
+
+- primary fails gate + fast profile passes its own gate -> fast model loads;
+- primary fails + fast also fails -> RuntimeError mentioning the PRIMARY
+  model's shortfall (required/available GB and the primary model file name);
+- primary fails + no fast_profile_path -> RuntimeError "Insufficient RAM"
+  exactly as today.
+
+All heavy deps are mocked (psutil, llm_interface.Path, GGUFBackend). The
+Path mock is per-path so the primary and the fast profile can have
+different file sizes in the same construction call.
+"""
+
+from pathlib import PurePath
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+GIB = 1024**3
+MIB = 1024**2
+PRIMARY_PATH = "models/gemma-4-E2B-it-Q5_K_M.gguf"
+PRIMARY_SIZE = int(3.1 * 1e9)  # ~3.1 GB (decimal GB)
+FAST_PATH = "models/fast.gguf"
+FAST_SIZE = 800 * MIB  # 800 MiB fast-profile model
+
+
+class MockVirtualMemory:
+    """Mock psutil.virtual_memory() return value."""
+
+    def __init__(self, available: int, total: int):
+        self.available = available
+        self.total = total
+
+
+def _path_side_effect_for(sizes: dict):
+    """Build a Path-class side effect mapping each path string to a mock
+    whose exists()/stat() reflect the given size table."""
+
+    def _factory(path_str, *args, **kwargs):
+        instance = MagicMock()
+        instance.exists.return_value = str(path_str) in sizes
+        instance.stat.return_value = MagicMock(st_size=sizes.get(str(path_str), 0))
+        instance.name = PurePath(str(path_str)).name
+        return instance
+
+    return _factory
+
+
+class TestFastProfileFallback:
+    """SmartLLM fast_profile_path behavior on RAM-gate refusal."""
+
+    @patch("llm_interface.GGUFBackend")
+    @patch("psutil.virtual_memory")
+    def test_primary_refused_fast_profile_loads(self, mock_vm, mock_backend):
+        """Scenario A: primary (3.1 GB) refuses at 4 GiB free; fast profile loads."""
+        mock_vm.return_value = MockVirtualMemory(available=4 * GIB, total=16 * GIB)
+        path_sizes = {PRIMARY_PATH: PRIMARY_SIZE, FAST_PATH: FAST_SIZE}
+
+        with patch("llm_interface.Path", side_effect=_path_side_effect_for(path_sizes)):
+            from llm_interface import SmartLLM
+
+            llm = SmartLLM(
+                gguf_path=PRIMARY_PATH,
+                fast_profile_path=FAST_PATH,
+                gguf_n_ctx=4096,
+            )
+
+        assert llm.backend is not None, (
+            "SmartLLM must construct via the fast profile when the primary "
+            "model fails the RAM gate"
+        )
+        mock_backend.assert_called_once()
+        call_kwargs = mock_backend.call_args.kwargs
+        assert call_kwargs.get("gguf_path") == FAST_PATH, (
+            f"GGUFBackend must be constructed with the fast profile "
+            f"({FAST_PATH}); got call: {mock_backend.call_args}"
+        )
+
+    @patch("llm_interface.GGUFBackend")
+    @patch("psutil.virtual_memory")
+    def test_primary_and_fast_both_refuse_mentions_primary_shortfall(
+        self, mock_vm, mock_backend
+    ):
+        """Scenario B: both models refuse (500 MiB free); the error must name
+        the PRIMARY model's requirement, not just the fast profile's."""
+        mock_vm.return_value = MockVirtualMemory(available=500 * MIB, total=16 * GIB)
+        path_sizes = {PRIMARY_PATH: PRIMARY_SIZE, FAST_PATH: FAST_SIZE}
+
+        with patch("llm_interface.Path", side_effect=_path_side_effect_for(path_sizes)):
+            from llm_interface import SmartLLM
+
+            with pytest.raises(RuntimeError) as exc_info:
+                SmartLLM(
+                    gguf_path=PRIMARY_PATH,
+                    fast_profile_path=FAST_PATH,
+                    gguf_n_ctx=4096,
+                )
+
+        msg = str(exc_info.value)
+        assert (
+            "Insufficient RAM" in msg
+        ), f"double refusal must raise the RAM diagnostic; got: {msg!r}"
+        assert "GB" in msg, (
+            f"double refusal error must include the primary model's required "
+            f"GB figure; got: {msg!r}"
+        )
+        assert PRIMARY_PATH.split("/")[-1] in msg, (
+            f"double refusal error must name the PRIMARY model "
+            f"({PRIMARY_PATH}); got: {msg!r}"
+        )
+        mock_backend.assert_not_called()
+
+    @patch("llm_interface.GGUFBackend")
+    @patch("psutil.virtual_memory")
+    def test_primary_refused_no_fast_profile_raises(self, mock_vm, mock_backend):
+        """Scenario C: no fast_profile_path configured -> direct refusal, as today."""
+        mock_vm.return_value = MockVirtualMemory(available=4 * GIB, total=16 * GIB)
+        path_sizes = {PRIMARY_PATH: PRIMARY_SIZE}
+
+        with patch("llm_interface.Path", side_effect=_path_side_effect_for(path_sizes)):
+            from llm_interface import SmartLLM
+
+            with pytest.raises(RuntimeError) as exc_info:
+                SmartLLM(gguf_path=PRIMARY_PATH, gguf_n_ctx=4096)
+
+        assert "Insufficient RAM" in str(exc_info.value)
+        mock_backend.assert_not_called()

--- a/tests/test_llm_memory_gate_diagnostic.py
+++ b/tests/test_llm_memory_gate_diagnostic.py
@@ -1,0 +1,67 @@
+"""
+Acceptance checks for issue #53 (AC4 diagnostic content): the RAM-gate
+refusal error must let the user identify WHICH model failed and by how much.
+
+DISCRIMINATING check: at base the gate message includes the required GB and
+the available GB but NOT the model file name (llm_interface.py builds the
+message from numbers only), so this file fails at base with
+"model file name missing from RAM diagnostic". After the fix, all three
+elements must be present in the refusal text.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+GIB = 1024**3
+MODEL_PATH = "models/gemma-4-E2B-it-Q5_K_M.gguf"
+MODEL_NAME = "gemma-4-E2B-it-Q5_K_M.gguf"
+MODEL_SIZE = int(3.1 * 1e9)  # ~3.1 GB (decimal GB)
+
+
+class MockVirtualMemory:
+    """Mock psutil.virtual_memory() return value."""
+
+    def __init__(self, available: int, total: int):
+        self.available = available
+        self.total = total
+
+
+class TestGateDiagnosticNamesTheModel:
+    """The refusal error must include required GB, available GB, model name."""
+
+    @patch("llm_interface.GGUFBackend")
+    @patch("psutil.virtual_memory")
+    def test_refusal_message_includes_numbers_and_model_name(
+        self, mock_vm, mock_backend
+    ):
+        """Gate refusal (3.1 GB model, 4 GiB free) must carry all three elements."""
+        mock_vm.return_value = MockVirtualMemory(available=4 * GIB, total=16 * GIB)
+        with patch("llm_interface.Path") as mock_path_cls:
+            mock_path_instance = MagicMock()
+            mock_path_instance.exists.return_value = True
+            mock_path_instance.stat.return_value = MagicMock(st_size=MODEL_SIZE)
+            mock_path_cls.return_value = mock_path_instance
+
+            from llm_interface import SmartLLM
+
+            with pytest.raises(RuntimeError) as exc_info:
+                SmartLLM(gguf_path=MODEL_PATH, gguf_n_ctx=4096)
+
+        msg = str(exc_info.value)
+
+        # Element 1: "Insufficient RAM" marker
+        assert "Insufficient RAM" in msg, f"missing RAM marker; got: {msg!r}"
+
+        # Element 2: a required-memory GB figure (format-agnostic)
+        assert "GB" in msg, f"required GB figure missing; got: {msg!r}"
+
+        # Element 3: the available GB figure (accept GiB/decimal/no-decimal formats:
+        # 4 GiB formats as 4.0GB in GiB units or 4.3GB in decimal GB units)
+        assert any(
+            variant in msg for variant in ("4.0GB", "4.3GB", "4GB", "4 GiB")
+        ), f"available GB figure missing; got: {msg!r}"
+
+        # Element 4: the model file name (MISSING at base — the pinned defect)
+        if MODEL_NAME not in msg:
+            pytest.fail("model file name missing from RAM diagnostic: " + msg)

--- a/tests/test_llm_memory_gate_estimator.py
+++ b/tests/test_llm_memory_gate_estimator.py
@@ -1,0 +1,73 @@
+"""
+Acceptance checks for issue #53 (AC1): the GGUF load RAM requirement must be a
+realistic estimate, not the old flat "4x file size" multiplier.
+
+NEW-SURFACE check: `llm_interface.estimate_required_memory` does not exist at
+base, so running this file at base fails at collection with ImportError. That
+ImportError is the expected RED for this file; it turns green once the fix
+introduces the function.
+
+Contract pinned here:
+
+    estimate_required_memory(file_size: int, n_ctx: int) -> int
+
+returns file_size + KV-cache estimate (conservatively a 1 GiB constant) +
+1 GiB overhead. For the bundled ~3.1 GB model that is ~5.1 GB — well under
+the old 12.4 GB claim — so the model fits the issue's 8-11 GB free-RAM
+target hardware.
+"""
+
+import pytest
+
+from llm_interface import estimate_required_memory
+
+GIB = 1024**3
+# Documented size of the bundled gemma-4-E2B-it-Q5_K_M.gguf (~3.1 GB, decimal GB)
+BUNDLED_MODEL_SIZE = int(3.1 * 1e9)
+
+
+class TestEstimateRequiredMemory:
+    """Checks for the module-level memory requirement estimator."""
+
+    def test_3_1gb_model_requirement_is_well_under_old_4x_claim(self):
+        """The 3.1 GB model must no longer claim 4x file size (~12.4 GB)."""
+        estimate = estimate_required_memory(BUNDLED_MODEL_SIZE, 4096)
+
+        assert estimate < int(BUNDLED_MODEL_SIZE * 4), (
+            f"estimate_required_memory({BUNDLED_MODEL_SIZE}, 4096) = {estimate}, "
+            f"which is not below the old 4x claim of {int(BUNDLED_MODEL_SIZE * 4)}"
+        )
+
+    def test_3_1gb_model_requirement_within_sane_band(self):
+        """Estimate must cover at least file + 1 GiB overhead, but stay under file + 4 GiB."""
+        estimate = estimate_required_memory(BUNDLED_MODEL_SIZE, 4096)
+
+        lower = BUNDLED_MODEL_SIZE + GIB
+        upper = BUNDLED_MODEL_SIZE + 4 * GIB
+        assert lower <= estimate <= upper, (
+            f"estimate_required_memory({BUNDLED_MODEL_SIZE}, 4096) = {estimate}, "
+            f"expected within sane band [{lower}, {upper}] "
+            f"(file + KV cache + overhead)"
+        )
+
+    @pytest.mark.parametrize("free_gib", [8, 16, 32])
+    def test_3_1gb_model_fits_free_ram_scenarios(self, free_gib):
+        """AC2 by construction: the 3.1 GB model's estimate fits 8 GiB free (and up)."""
+        estimate = estimate_required_memory(BUNDLED_MODEL_SIZE, 4096)
+        available = free_gib * GIB
+
+        assert estimate <= available, (
+            f"estimate_required_memory({BUNDLED_MODEL_SIZE}, 4096) = {estimate} "
+            f"exceeds the {free_gib} GiB free-RAM scenario ({available}); "
+            f"the gate would refuse the bundled model on the issue's target hardware"
+        )
+
+    def test_larger_model_requires_more_memory(self):
+        """Monotonicity: a 16 GiB-file model must require more than a 2 GiB-file model."""
+        small = estimate_required_memory(2 * GIB, 4096)
+        large = estimate_required_memory(16 * GIB, 4096)
+
+        assert large > small, (
+            f"estimate must grow with file size: "
+            f"2 GiB file -> {small}, 16 GiB file -> {large}"
+        )

--- a/tests/test_llm_memory_gate_load.py
+++ b/tests/test_llm_memory_gate_load.py
@@ -1,0 +1,118 @@
+"""
+Acceptance checks for issue #53 (AC2): the RAM gate must let the bundled
+~3.1 GB GGUF model load on machines with 8-11 GB of free RAM.
+
+DISCRIMINATING check: at base the gate computes required = file_size * 4
+(~12.4 GB for the 3.1 GB model) and refuses both the 8 GiB and 11 GiB
+free-RAM scenarios, so both mocked tests below fail with "Insufficient RAM".
+After the fix (file size + KV cache + overhead, ~5.1 GB) both load.
+
+The third test is artifact-gated on the REAL bundled model file being staged
+at models/gemma-4-E2B-it-Q5_K_M.gguf; it skips inline when the file is
+absent (operator-acquired artifact, not in CI working trees).
+
+All heavy deps are mocked: psutil.virtual_memory, llm_interface.Path, and
+llm_interface.GGUFBackend — no real model is ever loaded.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+GIB = 1024**3
+BUNDLED_RELATIVE_PATH = "models/gemma-4-E2B-it-Q5_K_M.gguf"
+# Documented size of the bundled model (~3.1 GB, decimal GB)
+BUNDLED_MODEL_SIZE = int(3.1 * 1e9)
+
+
+class MockVirtualMemory:
+    """Mock psutil.virtual_memory() return value."""
+
+    def __init__(self, available: int, total: int):
+        self.available = available
+        self.total = total
+
+
+class TestBundledModelLoadsOnTargetHardware:
+    """The gate must accept the 3.1 GB bundled model with 8-11 GiB free."""
+
+    @patch("llm_interface.GGUFBackend")
+    @patch("psutil.virtual_memory")
+    def test_bundled_model_loads_with_8gib_free(self, mock_vm, mock_gguf_backend):
+        """8 GiB free RAM must be enough for the ~3.1 GB model at n_ctx=4096."""
+        mock_vm.return_value = MockVirtualMemory(available=8 * GIB, total=16 * GIB)
+        with patch("llm_interface.Path") as mock_path_cls:
+            mock_path_instance = MagicMock()
+            mock_path_instance.exists.return_value = True
+            mock_path_instance.stat.return_value = MagicMock(st_size=BUNDLED_MODEL_SIZE)
+            mock_path_cls.return_value = mock_path_instance
+
+            from llm_interface import SmartLLM
+
+            llm = SmartLLM(
+                gguf_path=BUNDLED_RELATIVE_PATH,
+                gguf_n_ctx=4096,
+            )
+
+        assert llm.backend is not None, (
+            "SmartLLM must construct (RAM gate passes) for a 3.1 GB model "
+            "with 8 GiB available"
+        )
+
+    @patch("llm_interface.GGUFBackend")
+    @patch("psutil.virtual_memory")
+    def test_bundled_model_loads_with_11gib_free(self, mock_vm, mock_gguf_backend):
+        """11 GiB free RAM (the issue's upper target band) must also load the model."""
+        mock_vm.return_value = MockVirtualMemory(available=11 * GIB, total=16 * GIB)
+        with patch("llm_interface.Path") as mock_path_cls:
+            mock_path_instance = MagicMock()
+            mock_path_instance.exists.return_value = True
+            mock_path_instance.stat.return_value = MagicMock(st_size=BUNDLED_MODEL_SIZE)
+            mock_path_cls.return_value = mock_path_instance
+
+            from llm_interface import SmartLLM
+
+            llm = SmartLLM(
+                gguf_path=BUNDLED_RELATIVE_PATH,
+                gguf_n_ctx=4096,
+            )
+
+        assert llm.backend is not None, (
+            "SmartLLM must construct (RAM gate passes) for a 3.1 GB model "
+            "with 11 GiB available"
+        )
+
+    @patch("llm_interface.GGUFBackend")
+    @patch("psutil.virtual_memory")
+    def test_real_bundled_model_loads_with_mocked_free_ram(
+        self, mock_vm, mock_gguf_backend
+    ):
+        """Artifact-gated: use the REAL bundled file's actual size if it is staged.
+
+        The free RAM is mocked to min(8 GiB, actual requirement) where the
+        requirement follows the AC1 contract (file + 1 GiB KV + 1 GiB
+        overhead), so the gate passes by construction. Only llm_interface.Path
+        is NOT mocked here — the real file's st_size is what is under test.
+        """
+        bundled = Path(BUNDLED_RELATIVE_PATH)
+        if not bundled.exists():
+            pytest.skip("bundled GGUF not staged: " + BUNDLED_RELATIVE_PATH)
+        actual_size = bundled.stat().st_size
+        actual_requirement = actual_size + 2 * GIB  # + 1 GiB KV + 1 GiB overhead
+        mock_vm.return_value = MockVirtualMemory(
+            available=min(8 * GIB, actual_requirement),
+            total=max(16 * GIB, actual_requirement),
+        )
+
+        from llm_interface import SmartLLM
+
+        llm = SmartLLM(
+            gguf_path=BUNDLED_RELATIVE_PATH,
+            gguf_n_ctx=4096,
+        )
+
+        assert llm.backend is not None, (
+            "SmartLLM must construct for the real bundled model with free RAM "
+            "mocked at min(8 GiB, actual requirement)"
+        )

--- a/tests/test_llm_memory_gate_order.py
+++ b/tests/test_llm_memory_gate_order.py
@@ -1,0 +1,47 @@
+"""
+Preserving check for issue #53: the RAM gate must be evaluated BEFORE the
+GGUFBackend constructor is attempted, both at base and after the fix.
+
+PRESERVING (expected GREEN at base and after the fix): a 100 GiB file with
+8 GiB free is refused under the old 4x rule (400 GiB required) and under the
+new estimate (file + KV + overhead, ~102 GiB), and the backend constructor
+must never run for a refused model. All heavy deps are mocked.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+GIB = 1024**3
+
+
+class MockVirtualMemory:
+    """Mock psutil.virtual_memory() return value."""
+
+    def __init__(self, available: int, total: int):
+        self.available = available
+        self.total = total
+
+
+class TestGateOrderBeforeBackendConstruction:
+    """Gate refusal must happen before GGUFBackend construction."""
+
+    @patch("llm_interface.GGUFBackend")
+    @patch("psutil.virtual_memory")
+    def test_refusal_skips_backend_constructor(self, mock_vm, mock_backend):
+        """100 GiB model with 8 GiB free: refuse AND never construct backend."""
+        mock_vm.return_value = MockVirtualMemory(available=8 * GIB, total=32 * GIB)
+
+        with patch("llm_interface.Path") as mock_path_cls:
+            mock_path_instance = MagicMock()
+            mock_path_instance.exists.return_value = True
+            mock_path_instance.stat.return_value = MagicMock(st_size=100 * GIB)
+            mock_path_cls.return_value = mock_path_instance
+
+            from llm_interface import SmartLLM
+
+            with pytest.raises(RuntimeError) as exc_info:
+                SmartLLM(gguf_path="huge.gguf", gguf_n_ctx=4096)
+
+        assert "Insufficient RAM" in str(exc_info.value)
+        mock_backend.assert_not_called()

--- a/tests/test_llm_missing_path_message.py
+++ b/tests/test_llm_missing_path_message.py
@@ -1,0 +1,42 @@
+"""
+Preserving checks for issue #53: SmartLLM's no-backend error message for a
+missing model path must keep saying "No GGUF backend available".
+
+PRESERVING (expected GREEN at base and after the fix):
+- gguf_path=None skips the load block entirely and raises the no-backend
+  message;
+- a path that genuinely does not exist on disk (real Path, no mocking)
+  raises the same message.
+
+Only these two genuinely-preserved cases are pinned. The
+constructor-failure message for an EXISTING file is intentionally improving
+in this issue and is deliberately not asserted here.
+"""
+
+import pytest
+
+
+class TestMissingPathMessage:
+    """SmartLLM must keep raising "No GGUF backend available" for missing paths."""
+
+    def test_none_path_raises_no_gguf_backend_message(self):
+        from llm_interface import SmartLLM
+
+        with pytest.raises(RuntimeError) as exc_info:
+            SmartLLM(gguf_path=None)
+
+        assert "No GGUF backend available" in str(exc_info.value), (
+            f"gguf_path=None must raise the no-backend message; "
+            f"got: {str(exc_info.value)!r}"
+        )
+
+    def test_absent_file_raises_no_gguf_backend_message(self):
+        from llm_interface import SmartLLM
+
+        with pytest.raises(RuntimeError) as exc_info:
+            SmartLLM(gguf_path="definitely/not/here.gguf")
+
+        assert "No GGUF backend available" in str(exc_info.value), (
+            f"a nonexistent gguf_path must raise the no-backend message; "
+            f"got: {str(exc_info.value)!r}"
+        )

--- a/tests/test_no_blanket_perf_skips.py
+++ b/tests/test_no_blanket_perf_skips.py
@@ -277,6 +277,9 @@ INLINE_ALLOWLIST = {
     "test_full_council_adversarial.py": _inline_entry(
         "Source code inspection test — bare CTkButton found in _create_widgets", 1
     ),
+    "test_llm_load_api_diagnostic.py": _inline_entry(
+        "/ask/stream route not registered (no sse-starlette)", 1
+    ),
     "test_gguf_path_wiring_final.py": _inline_entry("ChromaDB KeyError ", 2),
     "test_phase1_adversarial.py": _inline_entry(
         "Windows 8.3 short name path mismatch on CI — temp path case differs", 2

--- a/tests/test_no_hardcoded_thread_defaults.py
+++ b/tests/test_no_hardcoded_thread_defaults.py
@@ -52,6 +52,11 @@ PATTERNS = [
         r"gguf_n_threads_entry\.get\(\)\s*or\s*4\b",
         "hardcoded blank-field fallback",
     ),
+    (
+        "app_gui.py",
+        r'\(\s*"gguf_n_threads",\s*4\b',
+        "hardcoded settings-dialog tuple-literal default",
+    ),
 ]
 
 

--- a/tests/test_no_hardcoded_thread_defaults.py
+++ b/tests/test_no_hardcoded_thread_defaults.py
@@ -1,0 +1,81 @@
+"""
+Guardrail for issue #53 (defect-class eradication): the GGUF thread default
+must never regress to a hardcoded literal in any consumer module.
+
+The original defect was a `4` literal duplicated across config.py,
+rag_engine.py, engine_factory.py and app_gui.py; the fix routes every site
+through config.default_gguf_threads(). This guardrail greps the four
+production files for the defective literal patterns so a future edit cannot
+silently reintroduce the drift (repo precedent: test_no_blanket_perf_skips).
+"""
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# (file, defective pattern, description)
+PATTERNS = [
+    (
+        "config.py",
+        r"rag_gguf_n_threads:\s*int\s*=\s*Field\(\s*default\s*=\s*4\b",
+        "hardcoded pydantic default 4",
+    ),
+    (
+        "rag_engine.py",
+        r"gguf_n_threads:\s*int\s*=\s*4\b",
+        "hardcoded RAGConfig __init__ default",
+    ),
+    (
+        "rag_engine.py",
+        r'data\.get\("gguf_n_threads",\s*4\)',
+        "hardcoded from_dict default",
+    ),
+    (
+        "engine_factory.py",
+        r'_get\("gguf_n_threads",\s*4\)',
+        "hardcoded settings-dict fallback",
+    ),
+    (
+        "engine_factory.py",
+        r'"rag_gguf_n_threads",\s*4\)',
+        "hardcoded settings-attr fallback",
+    ),
+    ("app_gui.py", r'"gguf_n_threads":\s*4\b', "hardcoded preset value"),
+    (
+        "app_gui.py",
+        r's\.get\("gguf_n_threads",\s*4\)',
+        "hardcoded settings-display default",
+    ),
+    (
+        "app_gui.py",
+        r"gguf_n_threads_entry\.get\(\)\s*or\s*4\b",
+        "hardcoded blank-field fallback",
+    ),
+]
+
+
+def test_no_hardcoded_gguf_thread_defaults():
+    """No production module may hardcode the GGUF thread default to 4."""
+    offenders = []
+    for filename, pattern, description in PATTERNS:
+        source = (REPO_ROOT / filename).read_text(encoding="utf-8")
+        for lineno, line in enumerate(source.splitlines(), start=1):
+            if re.search(pattern, line):
+                offenders.append(
+                    f"{filename}:{lineno}: {description} -> {line.strip()}"
+                )
+
+    assert not offenders, (
+        "Hardcoded GGUF thread defaults reintroduced; route every site "
+        "through config.default_gguf_threads() instead:\n" + "\n".join(offenders)
+    )
+
+
+def test_thread_default_helper_is_single_source_of_truth():
+    """config.default_gguf_threads must exist and behave as min(cpu, 8)."""
+    import os
+
+    from config import default_gguf_threads
+
+    assert default_gguf_threads() == min(os.cpu_count() or 4, 8)

--- a/tests/test_thread_defaults.py
+++ b/tests/test_thread_defaults.py
@@ -1,0 +1,114 @@
+"""
+Acceptance checks for issue #53 (AC7): GGUF thread defaults must be
+min(os.cpu_count() or 4, 8) everywhere the default is duplicated:
+config.RAGSettings, app_gui Fast/Balanced presets (Quality stays 8),
+rag_engine.RAGConfig, and the engine_factory fallbacks.
+
+DISCRIMINATING on every machine: a test comparing the literal default to
+min(cpu, 8) is vacuous on <=8-core machines (both sides are 4 at base), so
+os.cpu_count is monkeypatched to 32 and the modules are RELOADED so their
+defaults re-evaluate; the expected value is then 8 regardless of the host.
+
+Everything is accessed via module attributes (import config; config.X), not
+from-imports, so reload semantics are observed. Every reload cycle is
+wrapped in try/finally-style fixture teardown with a final restoring reload
+after the monkeypatch is undone. No engine is built: engine_factory's
+create_engine is patched so only its RAGConfig fallback defaults are read.
+"""
+
+import importlib
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import app_gui
+import config
+import engine_factory
+import rag_engine
+
+
+def _reload_modules():
+    """Reload, in dependency order, every module holding thread defaults."""
+    importlib.reload(config)
+    importlib.reload(app_gui)
+    importlib.reload(rag_engine)
+    importlib.reload(engine_factory)
+
+
+@pytest.fixture
+def cpu32_defaults(monkeypatch):
+    """Patch os.cpu_count to 32 and reload the modules so defaults re-evaluate.
+
+    Restores the unpatched modules afterwards with a second reload.
+    """
+    monkeypatch.delenv("RAG_GGUF_N_THREADS", raising=False)
+    monkeypatch.setattr(os, "cpu_count", lambda: 32)
+    _reload_modules()
+    yield
+    monkeypatch.undo()
+    _reload_modules()
+
+
+class TestThreadDefaultsCappedAtCpuCount:
+    """With os.cpu_count() patched to 32, every default must be 8 (min(32, 8))."""
+
+    def test_config_ragsettings_default(self, cpu32_defaults):
+        got = config.RAGSettings().rag_gguf_n_threads
+        assert got == 8, (
+            f"config.RAGSettings rag_gguf_n_threads default: "
+            f"expected 8 (min(32, 8) with os.cpu_count patched to 32), got {got}"
+        )
+
+    def test_gui_fast_preset(self, cpu32_defaults):
+        got = app_gui._PRESET_FAST["gguf_n_threads"]
+        assert got == 8, (
+            f"app_gui._PRESET_FAST gguf_n_threads: "
+            f"expected 8 (min(32, 8) with os.cpu_count patched to 32), got {got}"
+        )
+
+    def test_gui_balanced_preset(self, cpu32_defaults):
+        got = app_gui._PRESET_BALANCED["gguf_n_threads"]
+        assert got == 8, (
+            f"app_gui._PRESET_BALANCED gguf_n_threads: "
+            f"expected 8 (min(32, 8) with os.cpu_count patched to 32), got {got}"
+        )
+
+    def test_gui_quality_preset_stays_8(self, cpu32_defaults):
+        got = app_gui._PRESET_QUALITY["gguf_n_threads"]
+        assert got == 8, (
+            f"app_gui._PRESET_QUALITY gguf_n_threads: expected 8 (unchanged "
+            f"by this issue), got {got}"
+        )
+
+    def test_ragconfig_default_constructed_after_reload(self, cpu32_defaults):
+        got = rag_engine.RAGConfig().gguf_n_threads
+        assert got == 8, (
+            f"rag_engine.RAGConfig gguf_n_threads default: "
+            f"expected 8 (min(32, 8) with os.cpu_count patched to 32), got {got}"
+        )
+
+    def test_engine_factory_settings_fallback(self, cpu32_defaults):
+        """create_engine_from_settings({}) must fall back to 8 threads."""
+        with patch.object(
+            engine_factory, "create_engine", return_value=MagicMock()
+        ) as mock_create:
+            engine_factory.create_engine_from_settings({})
+        got = mock_create.call_args.kwargs["config"].gguf_n_threads
+        assert got == 8, (
+            f"engine_factory.create_engine_from_settings gguf_n_threads "
+            f"fallback: expected 8 (min(32, 8) with os.cpu_count patched "
+            f"to 32), got {got}"
+        )
+
+    def test_engine_factory_env_fallback(self, cpu32_defaults):
+        """create_engine_from_env must default to 8 threads via config.settings."""
+        with patch.object(
+            engine_factory, "create_engine", return_value=MagicMock()
+        ) as mock_create:
+            engine_factory.create_engine_from_env()
+        got = mock_create.call_args.kwargs["config"].gguf_n_threads
+        assert got == 8, (
+            f"engine_factory.create_engine_from_env gguf_n_threads default: "
+            f"expected 8 (min(32, 8) with os.cpu_count patched to 32), got {got}"
+        )

--- a/tests/test_ui_modernization_features.py
+++ b/tests/test_ui_modernization_features.py
@@ -11,8 +11,10 @@ Verifies:
 - Retrieved chunks expandable preview
 """
 
-import pytest
 import inspect
+import re
+
+import pytest
 
 
 class TestNavigationRail:
@@ -26,7 +28,7 @@ class TestNavigationRail:
             pytest.skip("customtkinter not installed")
 
         source = inspect.getsource(app_gui.DocumentQAApp._create_widgets)
-        assert 'nav_rail' in source, "Navigation rail variable not found"
+        assert "nav_rail" in source, "Navigation rail variable not found"
 
     def test_four_nav_buttons_exist(self):
         """Must have buttons for Chat, Documents, Settings, Help."""
@@ -37,10 +39,10 @@ class TestNavigationRail:
 
         source = inspect.getsource(app_gui.DocumentQAApp._create_widgets)
         # Check for icon buttons with text labels
-        assert '💬' in source or 'Chat' in source, "Chat button not found"
-        assert '📄' in source or 'Documents' in source, "Documents button not found"
-        assert '⚙' in source or 'Settings' in source, "Settings button not found"
-        assert '?' in source or 'Help' in source, "Help button not found"
+        assert "💬" in source or "Chat" in source, "Chat button not found"
+        assert "📄" in source or "Documents" in source, "Documents button not found"
+        assert "⚙" in source or "Settings" in source, "Settings button not found"
+        assert "?" in source or "Help" in source, "Help button not found"
 
 
 class TestDocumentsPage:
@@ -54,8 +56,10 @@ class TestDocumentsPage:
             pytest.skip("customtkinter not installed")
 
         source = inspect.getsource(app_gui.DocumentQAApp._create_widgets)
-        assert '_create_documents_page' in source, "Documents page creation method not called"
-        assert hasattr(app_gui.DocumentQAApp, '_create_documents_page')
+        assert (
+            "_create_documents_page" in source
+        ), "Documents page creation method not called"
+        assert hasattr(app_gui.DocumentQAApp, "_create_documents_page")
 
     def test_delete_document_method_exists(self):
         """_delete_document method must exist."""
@@ -64,8 +68,9 @@ class TestDocumentsPage:
         except ImportError:
             pytest.skip("customtkinter not installed")
 
-        assert hasattr(app_gui.DocumentQAApp, '_delete_document'), \
-            "_delete_document method must exist"
+        assert hasattr(
+            app_gui.DocumentQAApp, "_delete_document"
+        ), "_delete_document method must exist"
 
     def test_delete_requires_confirmation(self):
         """Document deletion must require user confirmation."""
@@ -75,8 +80,9 @@ class TestDocumentsPage:
             pytest.skip("customtkinter not installed")
 
         source = inspect.getsource(app_gui.DocumentQAApp._delete_document)
-        assert 'askyesno' in source or 'confirm' in source.lower(), \
-            "Delete must require confirmation"
+        assert (
+            "askyesno" in source or "confirm" in source.lower()
+        ), "Delete must require confirmation"
 
     def test_documents_frame_created(self):
         """Documents list frame must be created in documents page."""
@@ -86,7 +92,7 @@ class TestDocumentsPage:
             pytest.skip("customtkinter not installed")
 
         source = inspect.getsource(app_gui.DocumentQAApp._create_documents_page)
-        assert 'self.documents_frame' in source, "documents_frame not created"
+        assert "self.documents_frame" in source, "documents_frame not created"
 
 
 class TestSettingsPage:
@@ -100,8 +106,8 @@ class TestSettingsPage:
             pytest.skip("customtkinter not installed")
 
         source = inspect.getsource(app_gui.DocumentQAApp._create_widgets)
-        assert '_create_settings_page' in source, "Settings page creation not called"
-        assert hasattr(app_gui.DocumentQAApp, '_create_settings_page')
+        assert "_create_settings_page" in source, "Settings page creation not called"
+        assert hasattr(app_gui.DocumentQAApp, "_create_settings_page")
 
     def test_advanced_settings_present(self):
         """Advanced Settings section must be present in settings page."""
@@ -111,9 +117,9 @@ class TestSettingsPage:
             pytest.skip("customtkinter not installed")
 
         source = inspect.getsource(app_gui.DocumentQAApp._create_settings_page)
-        assert 'advanced' in source.lower() or 'retrieval' in source.lower(), (
-            "Advanced/retrieval settings must be in _create_settings_page"
-        )
+        assert (
+            "advanced" in source.lower() or "retrieval" in source.lower()
+        ), "Advanced/retrieval settings must be in _create_settings_page"
 
     def test_settings_fields_present(self):
         """All canonical settings fields must be present."""
@@ -123,8 +129,14 @@ class TestSettingsPage:
             pytest.skip("customtkinter not installed")
 
         source = inspect.getsource(app_gui.DocumentQAApp._create_settings_page)
-        required_fields = ['chunk_size', 'n_results', 'max_tokens', 'temperature',
-                           'reranking_enabled', 'retrieval_window']
+        required_fields = [
+            "chunk_size",
+            "n_results",
+            "max_tokens",
+            "temperature",
+            "reranking_enabled",
+            "retrieval_window",
+        ]
         for field in required_fields:
             assert field in source.lower(), f"Settings field '{field}' not found"
 
@@ -140,8 +152,8 @@ class TestHelpPage:
             pytest.skip("customtkinter not installed")
 
         source = inspect.getsource(app_gui.DocumentQAApp._create_widgets)
-        assert '_create_help_page' in source, "Help page creation not called"
-        assert hasattr(app_gui.DocumentQAApp, '_create_help_page')
+        assert "_create_help_page" in source, "Help page creation not called"
+        assert hasattr(app_gui.DocumentQAApp, "_create_help_page")
 
     def test_help_page_method_exists(self):
         """_create_help_page method must exist."""
@@ -150,8 +162,9 @@ class TestHelpPage:
         except ImportError:
             pytest.skip("customtkinter not installed")
 
-        assert hasattr(app_gui.DocumentQAApp, '_create_help_page'), \
-            "_create_help_page method must exist"
+        assert hasattr(
+            app_gui.DocumentQAApp, "_create_help_page"
+        ), "_create_help_page method must exist"
 
     def test_help_contains_keyboard_shortcuts(self):
         """Help page must document keyboard shortcuts."""
@@ -161,9 +174,10 @@ class TestHelpPage:
             pytest.skip("customtkinter not installed")
 
         source = inspect.getsource(app_gui.DocumentQAApp._create_help_page)
-        assert 'Keyboard Shortcuts' in source or 'Ctrl+' in source, \
-            "Help page must include keyboard shortcuts"
-        assert 'Ctrl+Enter' in source, "Ctrl+Enter shortcut must be documented"
+        assert (
+            "Keyboard Shortcuts" in source or "Ctrl+" in source
+        ), "Help page must include keyboard shortcuts"
+        assert "Ctrl+Enter" in source, "Ctrl+Enter shortcut must be documented"
 
 
 class TestCopyButton:
@@ -177,7 +191,7 @@ class TestCopyButton:
             pytest.skip("customtkinter not installed")
 
         source = inspect.getsource(app_gui.DocumentQAApp._add_message)
-        assert 'copy' in source.lower(), "Copy button implementation not found"
+        assert "copy" in source.lower(), "Copy button implementation not found"
 
     def test_add_message_has_copy_button_logic(self):
         """_add_message must have logic for copy button."""
@@ -187,7 +201,7 @@ class TestCopyButton:
             pytest.skip("customtkinter not installed")
 
         source = inspect.getsource(app_gui.DocumentQAApp._add_message)
-        assert '_make_button' in source, "Copy button must be created with _make_button"
+        assert "_make_button" in source, "Copy button must be created with _make_button"
 
 
 class TestRetrievedChunksExpander:
@@ -200,8 +214,9 @@ class TestRetrievedChunksExpander:
         except ImportError:
             pytest.skip("customtkinter not installed")
 
-        assert hasattr(app_gui.DocumentQAApp, '_create_retrieved_chunks_expander'), \
-            "_create_retrieved_chunks_expander method must exist"
+        assert hasattr(
+            app_gui.DocumentQAApp, "_create_retrieved_chunks_expander"
+        ), "_create_retrieved_chunks_expander method must exist"
 
     def test_add_message_creates_chunks_expander(self):
         """_add_message must call _create_retrieved_chunks_expander when chunks present."""
@@ -211,9 +226,10 @@ class TestRetrievedChunksExpander:
             pytest.skip("customtkinter not installed")
 
         source = inspect.getsource(app_gui.DocumentQAApp._add_message)
-        assert 'retrieved_chunks' in source, "retrieved_chunks parameter not used"
-        assert '_create_retrieved_chunks_expander' in source, \
-            "Must call _create_retrieved_chunks_expander for chunks"
+        assert "retrieved_chunks" in source, "retrieved_chunks parameter not used"
+        assert (
+            "_create_retrieved_chunks_expander" in source
+        ), "Must call _create_retrieved_chunks_expander for chunks"
 
 
 class TestPageSwitching:
@@ -226,10 +242,12 @@ class TestPageSwitching:
         except ImportError:
             pytest.skip("customtkinter not installed")
 
-        assert hasattr(app_gui.DocumentQAApp, '_switch_page'), \
-            "_switch_page method must exist"
-        assert hasattr(app_gui.DocumentQAApp, '_show_page'), \
-            "_show_page method must exist"
+        assert hasattr(
+            app_gui.DocumentQAApp, "_switch_page"
+        ), "_switch_page method must exist"
+        assert hasattr(
+            app_gui.DocumentQAApp, "_show_page"
+        ), "_show_page method must exist"
 
     def test_current_page_tracking(self):
         """App must track current page."""
@@ -239,7 +257,7 @@ class TestPageSwitching:
             pytest.skip("customtkinter not installed")
 
         source = inspect.getsource(app_gui.DocumentQAApp._switch_page)
-        assert '_current_page' in source, "Must track current page with _current_page"
+        assert "_current_page" in source, "Must track current page with _current_page"
 
 
 class TestMultilineComposer:
@@ -253,9 +271,10 @@ class TestMultilineComposer:
             pytest.skip("customtkinter not installed")
 
         source = inspect.getsource(app_gui.DocumentQAApp._create_chat_page)
-        assert 'CTkTextbox' in source, "Must use CTkTextbox for multiline input"
-        assert 'self.question_entry = CTkTextbox' in source, \
-            "question_entry must be a CTkTextbox"
+        assert "CTkTextbox" in source, "Must use CTkTextbox for multiline input"
+        assert (
+            "self.question_entry = CTkTextbox" in source
+        ), "question_entry must be a CTkTextbox"
 
     def test_ctrl_enter_submits_in_multiline(self):
         """Ctrl+Enter must submit in multiline mode."""
@@ -265,8 +284,12 @@ class TestMultilineComposer:
             pytest.skip("customtkinter not installed")
 
         source = inspect.getsource(app_gui.DocumentQAApp._create_chat_page)
-        assert 'bind("<Control-Return>"' in source, "Ctrl+Return binding required"
-        assert '_ask_question' in source, "Ctrl+Return must call _ask_question"
+        # black may wrap bind(...) across lines; match the call open plus the
+        # sequence with any whitespace between them.
+        assert re.search(
+            r'bind\(\s*"<Control-Return>"', source
+        ), "Ctrl+Return binding required"
+        assert "_ask_question" in source, "Ctrl+Return must call _ask_question"
 
     def test_enter_allows_newline(self):
         """Regular Enter must allow newlines (not submit)."""
@@ -276,6 +299,6 @@ class TestMultilineComposer:
             pytest.skip("customtkinter not installed")
 
         source = inspect.getsource(app_gui.DocumentQAApp._create_chat_page)
-        assert 'bind("<Return>"' in source, "Return key binding required"
+        assert re.search(r'bind\(\s*"<Return>"', source), "Return key binding required"
         # Should NOT call _ask_question for regular Return
-        assert 'lambda e: None' in source, "Return should not submit"
+        assert "lambda e: None" in source, "Return should not submit"


### PR DESCRIPTION
Closes #53

## Root Cause

Three stacked defects produced one user experience: (1) `llm_interface.SmartLLM.__init__` estimated the load-time RAM requirement as a flat `int(file_size * 4)` (`llm_interface.py:404`), so the bundled ~3.1 GB Gemma 4 E2B Q5_K_M GGUF was quoted at ~12.4 GB and deterministically refused on the issue's target hardware (16 GB laptop, 8-11 GB free) despite a real requirement of ~5-6 GB; (2) when loading failed, the diagnostic was destroyed at three layers — `RAGEngine._init_llm` (rag_engine.py:206-209) caught everything into `self.llm = None`, `query()` re-raised the bare "LLM not initialized. Cannot answer questions." (rag_engine.py:339-340), and the consumers translated that into misdirection: `app_gui._classify_error` ("Make sure at least one LLM backend is configured in Settings", app_gui.py:277) and `api_server` 503s with the bare `detail="No LLM backend available"` (:549, :722); (3) `rag_gguf_n_threads` was hardcoded to 4 across five duplication sites (config.py:57, rag_engine.py:80/148, engine_factory.py:141/204, GUI presets app_gui.py:52/61), forfeiting throughput on 8+-core CPUs.

## Fix

- `llm_interface.py`: new `estimate_required_memory(file_size, n_ctx)` = file_size + `kv_estimate(n_ctx)` (conservative 1 GiB constant pending #52's measured per-architecture numbers) + 1 GiB overhead; the gate message now names the model file (`os.path.basename`) plus required/available GB; new optional `fast_profile_path` kwarg retries through the same gate when the primary is refused (re-raising the primary shortfall when the fallback also fails); backend-constructor failures surface their cause under the preserved `No GGUF backend available` prefix instead of being swallowed.
- `rag_engine.py`: `RAGEngine.llm_init_error` retains the lazy-init failure text (cleared on success); `query()` raises `LLM not initialized: <diagnostic>`; `RAGConfig` gains `fast_profile_path` (plumbed to/from dict) and all thread defaults derive from the new `config.default_gguf_threads()` = `min(os.cpu_count() or 4, 8)`.
- `app_gui.py`: `_classify_error` gained an Insufficient-RAM branch that relays the numbers instead of the "configure a backend" misdirection; Fast/Balanced presets, display defaults, and blank-field fallbacks use the dynamic default; the chat worker's pre-query guard routes through `_classify_error` with `engine.llm_init_error`; `_load_settings` honors `RAG_FAST_PROFILE_PATH` so the desktop advice is actionable; bundled-model autodetect filename typo fixed (`Q5_K-M` -> `Q5_K_M` to match `app_paths.DEFAULT_BUNDLED_GGUF`).
- `api_server.py`: `/ask` and `/ask/stream` 503 details carry `engine.llm_init_error` (generic string retained as fallback); lifespan wires `fast_profile_path` into `RAGConfig`.
- `engine_factory.py`: both creation paths use the shared thread default and plumb `fast_profile_path`.
- `contracts/api.openapi.yaml`: the two 503 descriptions now note the diagnostic in the detail (status codes and routes unchanged; #51 freeze intact).
- `CONFIGURATION.md`: gate formula, `RAG_FAST_PROFILE_PATH`, and the new thread default documented.

## Recurrence Prevention (defect class)

- Defect class: hardcoded numeric defaults and swallow-and-replace error handlers duplicated across consumer modules instead of derived from the single owning helper.
- Sweep result: 12 in-class hits, all FIX (llm_interface formula + constructor swallow; rag_engine swallow + generic raise + 2 duplicated defaults; config/engine_factory/app_gui thread-default literals; GUI misdirection; API generic 503; bundled-filename typo); 4 OUT_OF_CLASS dispositions (optional-feature handlers, config persistence logging) — full table in `08a-recurrence-sweep.md`.
- Guardrail: `tests/test_no_hardcoded_thread_defaults.py` (repo precedent: `test_no_blanket_perf_skips.py`) greps the four production files for the eight defective literal patterns and pins `default_gguf_threads()` semantics; demonstrated to FAIL on base 2e8374f3 (2 failed) and PASS on the fix (2 passed).

## Tests

- Acceptance checks: nine typed checks frozen at a red checkpoint before any fix code, replayed base-vs-head via `repro-check.sh` — C1-C7 RED/ERROR->GREEN (DISCRIMINATING/NEW-SURFACE), C8-C9 GREEN->GREEN (PRESERVING); all nine PASS on final HEAD. Logs: `.agents/issue-traces/53-desktop-ram-gate-threads-diagnostics/repro/C*.{base,head}.log`.
- NEW-SURFACE mutation probes: reverting the estimator to 4x flips C1 RED (3 failed); removing the `fast_profile_path` kwarg flips C3 RED (3 failed); control 9 passed.
- Impacted suites: touched-subsystem files (api, rag_engine init/lazy/adversarial/resilience, gui corrective, engine factory wiring) all green; broad local suite `pytest tests/ -m "not slow"` -> 2071 passed with only pre-existing environmental failures, each verified failing at BASE in clean worktrees (auth/doc-processor/BM25/root-health web-archive mount; details in `08-test-results.md`).
- Lint: `flake8 --max-line-length=100 --extend-ignore=E203,W503` clean on every touched production module and test file.
- Deferred-work scan: `scan-deferred.sh` -> clean.
- Authoritative full backend matrix (Windows 3.10/3.11/3.12) runs on this PR.

## Regression Protection

- Nine frozen acceptance checks added as permanent regression tests (estimator band + 8/16/32 GB scenarios; 8/11 GiB loads incl. artifact-gated real-GGUF test; fast-fallback triple; diagnostic content; GUI classifier + engine propagation; API 503 detail; machine-independent thread-default reload test; gate-before-constructor order; missing-path message).
- `tests/test_llm_interface_memory_budget.py` was rewritten to the new contract — this is the issue-required behavior change (the old suite pinned the 4x formula), acknowledged here explicitly; the file is not part of the frozen checkpoint manifest.
- Existing tests that pinned superseded contracts or bare-MagicMock engines were reconciled: test_api/test_api_endpoints (`llm_init_error = None`), test_api_server_ragconfig_wiring (new field on spec'd mocks), test_llm_interface_simplified (fallback-chain guard narrowed to true chain indicators — the single named fast-profile retry is issue-mandated), tests/regression/test_remediation_fixes (thread default superseded by #53), tests/test_no_blanket_perf_skips (new allowlist entry).

## Acceptance Criteria -> Evidence

| Acceptance criterion | Evidence |
|---|---|
| AC1 realistic estimate, not 4x (~5-6 GB for 3.1 GB) | C1 `tests/test_llm_memory_gate_estimator.py` PASS (band [file+1GiB, file+4GiB], < 4x, monotonic) |
| AC2 loads on simulated 8-11 GB free | C2 `tests/test_llm_memory_gate_load.py` PASS (8/11 GiB load; artifact-gated real GGUF test included) |
| AC3 Fast-profile fallback triggers | C3 `tests/test_llm_memory_fast_fallback.py` PASS (fallback loads; both-fail names primary; no-fallback preserves refusal) |
| AC4 no-fallback error carries required/available + model name | C4 `tests/test_llm_memory_gate_diagnostic.py` PASS |
| AC5 GUI surfaces the real diagnostic | C5 `tests/test_llm_load_gui_diagnostic.py` PASS (classifier + worker guard via `llm_init_error`) |
| AC6 API 503 detail carries RAM numbers | C6 `tests/test_llm_load_api_diagnostic.py` PASS (/ask + /ask/stream) |
| AC7 thread default `min(os.cpu_count() or 4, 8)` everywhere | C7 `tests/test_thread_defaults.py` PASS (config, presets, RAGConfig, both factory paths; reload-based, machine-independent) |

## Invariant Audit

Repository has no invariant/architecture-contract doc; audited against the contracts that exist:

- Frozen API contract (`contracts/api.openapi.yaml`, #51): not broken — 503 status codes and routes unchanged; description text updated; `contracts/tests/run_conformance.py` checks status codes only.
- `scan-deferred.sh`: clean on added lines.
- No persistence/schema/migration surface touched.

## Risk and Rollback

- Risk level: low/medium — behavior change is the issue's intent (more successful loads; larger, more accurate error messages); thread default rises only on >4-core machines, capped at 8 and aligned with the existing Quality preset.
- Rollback: single-commit revert of the branch; no migrations or data involved.
- Residual risk: `kv_estimate` is a conservative constant pending #52's measured per-architecture numbers — per the issue, the formula (not test thresholds) gets revised if A2's measurements demand it.

## Waivers (or none)

none

## Merge status

Awaiting explicit user approval; not merged.
PR head: de864b01643307e9a6abf639f3417d455f0662af

## Feedback round (post-review)

Review feedback (internal F1-F6, external council C1-C7, Copilot inline) closed in 785d223 + 1666aa7; ledger, gates, and exit-gate evidence in [the feedback-round comment](https://github.com/ZaxbyHub/trainingapp/pull/92#issuecomment-5565770801). Reviewer APPROVE; final critic NEEDS_REVISION -> remediation -> APPROVE at 1666aa7.

