### PR TITLE
feat(desktop): secure the Electron protocol and loopback API transport (issue #60)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# CSP pin stability (issue #60): desktop/main/security/csp.ts hash-pins the inline
+# theme-bootstrap script of this file, so its served bytes must be identical on
+# every checkout regardless of core.autocrlf. LF everywhere, no exceptions.
+web_ui/index.html text eol=lf

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -30,7 +30,9 @@ desktop/
                          `desktopApi.getAuthToken` (B2 token bridge, IPC-only)
   src/__tests__/         frozen acceptance specs (vitest, stubbed electron)
   test/electron-stub.ts  in-memory electron for the specs
-  repro/check.sh         acceptance-check driver (C1..C6)
+  repro/check.sh         acceptance-check driver for issue #59 (C1..C6)
+  repro/check-b2.sh      acceptance-check driver for issue #60 (B2 specs)
+  scripts/               preload format guard + runtime smoke (CI)
   electron-builder.yml   unsigned NSIS x64 packaging (appId com.zaxbyhub.trainingapp)
   renderer/              build-time staging of web_ui/dist (gitignored)
   desktop-release/       electron-builder output (gitignored)
@@ -40,8 +42,8 @@ desktop/
 
 | Script | What it does |
 |---|---|
-| `npm run compile` | tsc -> `dist/` (main + preload, ESM, nodenext) |
-| `npm test` | all three acceptance spec files (vitest) |
+| `npm run compile` | tsc -> `dist/` (main as ESM/nodenext; preload as CommonJS, renamed .cjs) |
+| `npm test` | all acceptance spec files (vitest; B1 + B2 suites) |
 | `npm run dev` | compile + launch Electron with `--dev` (expects the vite dev server already running — use `desktop:dev` to start both) |
 | `npm run desktop:dev` | vite dev (web_ui) + Electron with reload, via `concurrently` |
 | `npm run desktop:build` | build web_ui, copy `web_ui/dist` -> `renderer/`, compile, run electron-builder (NSIS x64, unsigned) |
@@ -51,6 +53,9 @@ Dev mode: Electron loads `http://localhost:5173` when `--dev` is in argv, or
 whatever URL `ELECTRON_START_URL` points at. Production: `app://index.html`
 served from `<resourcesPath>/web_ui`. Note the packaged binary does not start a
 vite server — `--dev` on an installed app shows nothing; use `desktop:dev`.
+In dev mode the `app://` protocol handler is intentionally not registered (the
+vite server serves the renderer), so an `app://` navigation — allowed by the
+navigation policy — fails to load; that combination is production-only.
 
 ## Security posture (baseline, per issue #59)
 

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -20,9 +20,14 @@ per-package lockfiles is the honest migration, not a blanket hoist).
 
 ```
 desktop/
-  main/index.ts          app bootstrap: single-instance lock, window, secure defaults
-  main/protocol.ts       app:// file protocol (traversal-refusing, MIME-mapped)
-  preload/index.ts       empty contextBridge stub (B2/#60 fills it)
+  main/index.ts          app bootstrap: single-instance lock, window, secure defaults,
+                         transport-security wiring, navigation lockdown (B2)
+  main/protocol.ts       app:// file protocol (traversal-refusing, MIME-mapped,
+                         CSP + COOP/COEP/CORP on every response, B2)
+  main/security/         B2 transport security: config, per-launch token,
+                         backend-agnostic loopback guard, CSP policy (barrel: index.ts)
+  preload/index.ts       contextBridge namespaces: `trainingapp` (shell) +
+                         `desktopApi.getAuthToken` (B2 token bridge, IPC-only)
   src/__tests__/         frozen acceptance specs (vitest, stubbed electron)
   test/electron-stub.ts  in-memory electron for the specs
   repro/check.sh         acceptance-check driver (C1..C6)
@@ -60,10 +65,25 @@ vite server — `--dev` on an installed app shows nothing; use `desktop:dev`.
   renderer root, re-checks containment through `realpath` (symlink escape),
   and returns 403/404 rather than reading anything outside the root
   (spec-pinned including Windows drive-letter and `%00` cases).
-- Preload exposes a single empty namespace (`window.trainingapp`) and nothing
-  else.
+- Preload exposes two non-privileged namespaces (`window.trainingapp`,
+  `window.desktopApi.getAuthToken`) and nothing else; the per-launch transport
+  token reaches the renderer only through that bridge (never storage, never a
+  URL).
+- B2 transport security (issue #60): per-launch token
+  (`crypto.randomBytes(32)` hex, main-process memory only), strict CSP +
+  COOP/COEP/CORP on every app:// response (relaxations documented inline in
+  `desktop/main/security/csp.ts`), navigation/`window.open` lockdown, and a
+  backend-agnostic loopback guard (origin allow-list, literal-loopback-only
+  Host gate, token check) that B3 (#61) MUST mount in front of its backend —
+  see `docs/security/desktop.md` for the threat model and the binding B3
+  integration contract.
+- Invariant: every new transport-facing seam threads the security barrel
+  (`desktop/main/security/index.ts`); the frozen B2 specs
+  (`src/__tests__/b2-*.test.ts`) plus the B1 secure-defaults spec are the
+  regression family that keeps the webPreferences, CSP, guard, and token
+  contracts from eroding.
 - The installer is unsigned at this stage; signing/updates are Workstream E5
-  (#88). Transport/CSP/loopback hardening is Workstream B2 (#60).
+  (#88).
 
 ## Reserved namespaces
 

--- a/desktop/main/index.ts
+++ b/desktop/main/index.ts
@@ -9,8 +9,15 @@
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { app, BrowserWindow } from 'electron';
+import { app, BrowserWindow, ipcMain } from 'electron';
 import { registerAppProtocol, registerAppSchemePrivileges } from './protocol.js';
+import {
+  getLoopbackGuard,
+  getLaunchToken,
+  initializeLaunchToken,
+  initializeTransportSecurity,
+  resolveSecurityConfig,
+} from './security/index.js';
 
 const DEV_URL = 'http://localhost:5173';
 
@@ -23,6 +30,23 @@ function isDevArgv(): boolean {
 function devStartUrl(): string | undefined {
   const envUrl = process.env.ELECTRON_START_URL;
   return envUrl !== undefined && envUrl.length > 0 ? envUrl : isDevArgv() ? DEV_URL : undefined;
+}
+
+/**
+ * Navigation allow-list (issue #60): the renderer may only navigate itself to
+ * app:// targets; in dev mode the dev server origin is additionally allowed
+ * so vite's full-page reloads keep working. Everything else — remote http(s),
+ * file://, even loopback http in production — is denied.
+ */
+function isAllowedNavigationTarget(url: string): boolean {
+  if (url.startsWith('app://')) return true;
+  const dev = devStartUrl();
+  if (dev === undefined) return false;
+  try {
+    return new URL(url).origin === new URL(dev).origin;
+  } catch {
+    return false;
+  }
 }
 
 /** Directory of the compiled module (dist/main), valid under ESM. */
@@ -65,6 +89,18 @@ export function createMainWindow(): BrowserWindow {
     },
   });
   win.once('ready-to-show', () => win.show());
+  // Navigation lockdown (issue #60, AC4): the only renderer-initiated
+  // navigations are app:// targets (plus the dev server origin in dev mode);
+  // window.open is denied outright — no popups, no new windows, ever.
+  // NOTE: the window-open handler lives on webContents (the only surface that
+  // exists in Electron >= 44 typings AND at runtime — verified by probe:
+  // win.setWindowOpenHandler is undefined); will-navigate is webContents-native.
+  win.webContents.on('will-navigate', (event, url) => {
+    if (!isAllowedNavigationTarget(url)) {
+      event.preventDefault();
+    }
+  });
+  win.webContents.setWindowOpenHandler((): { action: 'deny' } => ({ action: 'deny' }));
   // Surface load failures instead of leaving a silent blank/hidden window
   // (e.g. dev server down, renderer resources incomplete).
   win.webContents.on('did-fail-load', (_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
@@ -111,6 +147,24 @@ export function bootstrap(): void {
   registerSecondInstanceHandler();
 
   app.whenReady().then(() => {
+    // Transport security (issue #60, B2): resolve config, mint the per-launch
+    // token (main-process memory only), serve it to the renderer ONLY through
+    // this IPC handler, and construct the loopback gate that B3's backend
+    // host MUST mount in front of every route (docs/security/desktop.md).
+    const securityConfig = resolveSecurityConfig();
+    initializeLaunchToken();
+    ipcMain.handle('desktop:get-token', () => getLaunchToken());
+    initializeTransportSecurity({
+      token: getLaunchToken(),
+      tokenHeaderName: securityConfig.tokenHeaderName,
+      allowedOrigins: securityConfig.allowedOrigins,
+    });
+    if (getLoopbackGuard() === null) {
+      // Fail fast and audibly rather than booting an unguarded transport.
+      console.error('[trainingapp-desktop] transport security failed to initialize; refusing to start');
+      app.quit();
+      return;
+    }
     // Dev mode loads the vite dev server and needs no packaged renderer.
     if (devStartUrl() === undefined) {
       const root = resolveRendererRoot();

--- a/desktop/main/index.ts
+++ b/desktop/main/index.ts
@@ -165,6 +165,10 @@ export function bootstrap(): void {
       app.quit();
       return;
     }
+    // NOTE: in dev mode the app:// handler is intentionally NOT registered
+    // (the vite dev server serves the renderer), so an app:// target allowed
+    // by the navigation policy below would fail to load in dev. Production
+    // mode registers both, so policy and handler are always consistent there.
     // Dev mode loads the vite dev server and needs no packaged renderer.
     if (devStartUrl() === undefined) {
       const root = resolveRendererRoot();

--- a/desktop/main/protocol.ts
+++ b/desktop/main/protocol.ts
@@ -11,6 +11,7 @@
 import { promises as fsp, realpathSync } from 'node:fs';
 import path from 'node:path';
 import { protocol } from 'electron';
+import { buildCspPolicy } from './security/csp.js';
 
 const MIME_TYPES: Record<string, string> = {
   '.html': 'text/html; charset=utf-8',
@@ -41,12 +42,32 @@ function mimeTypeFor(filePath: string): string {
   return MIME_TYPES[path.extname(filePath).toLowerCase()] ?? 'application/octet-stream';
 }
 
+/**
+ * Attach the B2 transport-security headers to a response. Applied to EVERY
+ * response this handler constructs — success and error alike — matching the
+ * "every response, including errors" header discipline of the airgapped
+ * server (web_ui/scripts/start.ps1):
+ *   - Content-Security-Policy: the strict policy from security/csp.ts
+ *     (relaxations documented inline there).
+ *   - COOP/COEP/CORP: cross-origin isolation for the renderer, which is what
+ *     makes crossOriginIsolated true under app:// so onnxruntime-web may use
+ *     wasm.numThreads > 1 (web_ui/src/lib/models/offline-env.ts) — parity
+ *     with start.ps1's SharedArrayBuffer setup.
+ */
+function withSecurityHeaders(response: Response): Response {
+  response.headers.set('content-security-policy', buildCspPolicy());
+  response.headers.set('cross-origin-opener-policy', 'same-origin');
+  response.headers.set('cross-origin-embedder-policy', 'require-corp');
+  response.headers.set('cross-origin-resource-policy', 'same-origin');
+  return response;
+}
+
 function forbidden(): Response {
-  return new Response('Forbidden', { status: 403 });
+  return withSecurityHeaders(new Response('Forbidden', { status: 403 }));
 }
 
 function notFound(): Response {
-  return new Response('Not Found', { status: 404 });
+  return withSecurityHeaders(new Response('Not Found', { status: 404 }));
 }
 
 /**
@@ -116,15 +137,13 @@ export function createAppFileHandler(opts: { root: string }) {
         return forbidden();
       }
       const data = await fsp.readFile(real);
-      return new Response(new Uint8Array(data), {
+      return withSecurityHeaders(new Response(new Uint8Array(data), {
         headers: {
           'content-type': mimeTypeFor(real),
-          // Baseline response hygiene for the custom scheme (CSP itself is
-          // Workstream B2 / issue #60).
           'x-content-type-options': 'nosniff',
           'cache-control': 'no-cache',
         },
-      });
+      }));
     } catch {
       return notFound();
     }

--- a/desktop/main/security/config.ts
+++ b/desktop/main/security/config.ts
@@ -1,0 +1,55 @@
+// Security configuration for the desktop transport (issue #60, Workstream B2).
+//
+// Config keys (issue-required names):
+//   security.tokenHeaderName — the custom header carrying the per-launch token
+//     (default 'X-Desktop-Token'; deliberately NOT Authorization: Bearer, which
+//     the web_ui ApiClient reserves for its server-mode JWT flow).
+//   security.allowedOrigins — origins allowed to talk to the desktop transport
+//     (default ['app://*'] — every app:// origin; 'app://index.html' is what
+//     the packaged renderer's origin resolves to under WHATWG non-special-
+//     scheme parsing, see desktop/main/protocol.ts).
+//
+// Dev-only origin additions are gated so a PACKAGED build categorically cannot
+// gain extra origins regardless of its environment: additions require BOTH
+// app.isPackaged === false AND an explicit TRAININGAPP_DESKTOP_DEV_ORIGINS
+// opt-in. This is the build/packaging-time gate equivalent for an Electron
+// main process, which has no compile-time define machinery in this repo.
+import { app } from 'electron';
+
+export interface SecurityConfig {
+  tokenHeaderName: string;
+  allowedOrigins: string[];
+}
+
+export const DEFAULT_TOKEN_HEADER_NAME = 'X-Desktop-Token';
+export const DEFAULT_ALLOWED_ORIGINS = ['app://*'];
+
+export const DEV_ORIGINS_ENV = 'TRAININGAPP_DESKTOP_DEV_ORIGINS';
+
+/**
+ * Resolve the transport security configuration.
+ * Pure and overridable for tests; defaults read the real environment and
+ * `app.isPackaged`.
+ */
+export function resolveSecurityConfig(opts?: {
+  env?: Record<string, string | undefined>;
+  isPackaged?: boolean;
+}): SecurityConfig {
+  const env = opts?.env ?? process.env;
+  const isPackaged = opts?.isPackaged ?? app.isPackaged;
+
+  // Appends only: the default app://* origin is never dropped, so a dev opt-in
+  // can widen but never replace the packaged baseline.
+  const allowedOrigins = [...DEFAULT_ALLOWED_ORIGINS];
+  if (!isPackaged) {
+    const raw = env[DEV_ORIGINS_ENV];
+    if (typeof raw === 'string' && raw.trim().length > 0) {
+      for (const part of raw.split(',')) {
+        const origin = part.trim();
+        if (origin.length > 0) allowedOrigins.push(origin);
+      }
+    }
+  }
+
+  return { tokenHeaderName: DEFAULT_TOKEN_HEADER_NAME, allowedOrigins };
+}

--- a/desktop/main/security/csp.ts
+++ b/desktop/main/security/csp.ts
@@ -13,7 +13,7 @@
 //     plain JS eval() stays blocked.
 //   - script-src 'sha256-<PIN>': the ONE legitimate inline script, the theme
 //     pre-paint bootstrap in web_ui/index.html (vited verbatim into dist).
-//     web_ui/src/__tests__/ b2-csp-pin.test.ts pins this constant to the
+//     desktop/src/__tests__/b2-csp-pin.test.ts pins this constant to the
 //     actual hash of that script so a renderer change that adds or edits an
 //     inline script fails CI until the pin is consciously updated. Any other
 //     inline script — i.e. every injected one — is blocked.
@@ -50,6 +50,9 @@ export function buildCspPolicy(): string {
     "font-src 'self' app:",
     "connect-src 'self' app: http://127.0.0.1:* http://[::1]:*",
     "worker-src 'self' app: blob:",
+    // Explicit (rather than inherited from default-src) to pin the framing
+    // posture independently of future default-src edits. PRR96-008.
+    "frame-src 'self' app:",
     "object-src 'none'",
     "base-uri 'none'",
     "form-action 'none'",

--- a/desktop/main/security/csp.ts
+++ b/desktop/main/security/csp.ts
@@ -1,0 +1,58 @@
+// Content-Security-Policy for app:// renderer responses (issue #60, B2).
+//
+// Applied to EVERY app:// response (including 403/404) by
+// desktop/main/protocol.ts — the same "every response, including errors"
+// header discipline the airgapped server sets in web_ui/scripts/start.ps1.
+//
+// Documented relaxations, each named for its concrete consumer (everything not
+// listed inherits the strict default-src):
+//   - script-src 'wasm-unsafe-eval': ONNX Runtime Web and wllama compile WASM
+//     in the packaged renderer (web_ui/src/lib/models/offline-env.ts,
+//     web_ui/src/lib/llm/wllama-service.ts). Without this the embedding/LLM
+//     runtimes cannot instantiate their .wasm. This is NOT 'unsafe-eval':
+//     plain JS eval() stays blocked.
+//   - script-src 'sha256-<PIN>': the ONE legitimate inline script, the theme
+//     pre-paint bootstrap in web_ui/index.html (vited verbatim into dist).
+//     web_ui/src/__tests__/ b2-csp-pin.test.ts pins this constant to the
+//     actual hash of that script so a renderer change that adds or edits an
+//     inline script fails CI until the pin is consciously updated. Any other
+//     inline script — i.e. every injected one — is blocked.
+//   - worker-src blob:: onnxruntime-web constructs its threaded workers from
+//     blob: URLs when wasm.numThreads > 1 (offline-env.ts gates numThreads on
+//     crossOriginIsolated, which protocol.ts's COOP/COEP headers enable).
+//     The embedding worker itself is a same-origin module worker ('self').
+//   - img-src/font-src data:: the offline data:-URI favicon and inline font
+//     fallbacks in web_ui/index.html.
+//   - connect-src http://127.0.0.1:* + http://[::1]:*: the B3 loopback
+//     backend on its random free port (both literal loopback forms, symmetric
+//     with the loopback-guard Host gate). app: stays allowed for app://-URL
+//     fetches (the scheme registers supportFetchAPI).
+// Deliberately absent (blocked by default or explicitly):
+//   - 'unsafe-inline' / 'unsafe-eval' — never, in any directive.
+//   - object-src 'none', base-uri 'none', form-action 'none',
+//     frame-ancestors 'none' — no plugins, no base hijack, no form posting
+//     out, no framing.
+
+/**
+ * The SHA-256 pin (base64, CSP 'sha256-' form) of the single legitimate
+ * inline <script> in web_ui/index.html — the theme pre-paint bootstrap.
+ * Verified against the tracked file by desktop/src/__tests__/b2-csp-pin.test.ts.
+ */
+export const INLINE_THEME_BOOTSTRAP_SHA256 = 'sha256-ePnZCi9JqiNJ5DC63H11BebwlVC43EKrYDz+F362Zi8=';
+
+/** The strict policy applied to every app:// response. */
+export function buildCspPolicy(): string {
+  return [
+    "default-src 'self' app:",
+    `script-src 'self' app: 'wasm-unsafe-eval' '${INLINE_THEME_BOOTSTRAP_SHA256}'`,
+    "style-src 'self' app:",
+    "img-src 'self' app: data:",
+    "font-src 'self' app:",
+    "connect-src 'self' app: http://127.0.0.1:* http://[::1]:*",
+    "worker-src 'self' app: blob:",
+    "object-src 'none'",
+    "base-uri 'none'",
+    "form-action 'none'",
+    "frame-ancestors 'none'",
+  ].join('; ');
+}

--- a/desktop/main/security/index.ts
+++ b/desktop/main/security/index.ts
@@ -1,0 +1,31 @@
+// Security barrel for the desktop transport (issue #60, Workstream B2).
+//
+// bootstrap() consumes exactly this module; every new transport-facing seam
+// in desktop/ must thread through these exports rather than rolling its own
+// policy (invariant documented in desktop/README.md "Security posture").
+export { resolveSecurityConfig, DEFAULT_TOKEN_HEADER_NAME, DEFAULT_ALLOWED_ORIGINS, DEV_ORIGINS_ENV, type SecurityConfig } from './config.js';
+export { mintLaunchToken, initializeLaunchToken, getLaunchToken } from './token.js';
+export { createLoopbackGuard, originAllowed, type LoopbackGuard, type LoopbackGuardRequest, type CreateLoopbackGuardOptions } from './loopback-guard.js';
+export { buildCspPolicy, INLINE_THEME_BOOTSTRAP_SHA256 } from './csp.js';
+import { createLoopbackGuard, type CreateLoopbackGuardOptions, type LoopbackGuard } from './loopback-guard.js';
+
+let activeGuard: LoopbackGuard | null = null;
+
+/**
+ * Construct the per-launch request gate from the resolved config and token.
+ * Called once from bootstrap(); `getLoopbackGuard()` then hands the SAME
+ * instance to whichever backend host Workstream B3 (#61) lands (Node main or
+ * the ADR-0003 Python sidecar front). B3's server MUST compose this gate in
+ * front of every request route — see docs/security/desktop.md ("B3
+ * integration contract"). The bootstrap boot fails fast if this was never
+ * called, so a future regression that drops the construction cannot ship.
+ */
+export function initializeTransportSecurity(opts: CreateLoopbackGuardOptions): LoopbackGuard {
+  activeGuard = createLoopbackGuard(opts);
+  return activeGuard;
+}
+
+/** The active per-launch gate, or null before bootstrap initialization. */
+export function getLoopbackGuard(): LoopbackGuard | null {
+  return activeGuard;
+}

--- a/desktop/main/security/index.ts
+++ b/desktop/main/security/index.ts
@@ -4,10 +4,11 @@
 // in desktop/ must thread through these exports rather than rolling its own
 // policy (invariant documented in desktop/README.md "Security posture").
 export { resolveSecurityConfig, DEFAULT_TOKEN_HEADER_NAME, DEFAULT_ALLOWED_ORIGINS, DEV_ORIGINS_ENV, type SecurityConfig } from './config.js';
-export { mintLaunchToken, initializeLaunchToken, getLaunchToken } from './token.js';
+export { mintLaunchToken, initializeLaunchToken, getLaunchToken, __resetLaunchTokenForTests } from './token.js';
 export { createLoopbackGuard, originAllowed, type LoopbackGuard, type LoopbackGuardRequest, type CreateLoopbackGuardOptions } from './loopback-guard.js';
 export { buildCspPolicy, INLINE_THEME_BOOTSTRAP_SHA256 } from './csp.js';
 import { createLoopbackGuard, type CreateLoopbackGuardOptions, type LoopbackGuard } from './loopback-guard.js';
+import { __resetLaunchTokenForTests } from './token.js';
 
 let activeGuard: LoopbackGuard | null = null;
 
@@ -28,4 +29,14 @@ export function initializeTransportSecurity(opts: CreateLoopbackGuardOptions): L
 /** The active per-launch gate, or null before bootstrap initialization. */
 export function getLoopbackGuard(): LoopbackGuard | null {
   return activeGuard;
+}
+
+/**
+ * Test hook: clear the transport-security singletons (guard holder + launch
+ * token) so a fresh test can exercise initialization from scratch. Never call
+ * from production code.
+ */
+export function __resetTransportSecurityForTests(): void {
+  activeGuard = null;
+  __resetLaunchTokenForTests();
 }

--- a/desktop/main/security/loopback-guard.ts
+++ b/desktop/main/security/loopback-guard.ts
@@ -1,0 +1,120 @@
+// Loopback transport guard (issue #60, Workstream B2).
+//
+// A backend-agnostic request gate that sits in FRONT of whatever backend
+// Workstream B3 (#61) hosts, per ADR-0003 (still open — Node main vs Electron-
+// hosted Python sidecar; this guard must sit in front of the sidecar too).
+// It is a pure (request) => Response | null gate so any server surface can
+// compose it: `const verdict = guard(req); if (verdict) return verdict; /* backend */`.
+//
+// Frozen decision rules (desktop/src/__tests__/b2-loopback-guard.test.ts and
+// b2-loopback-origin.test.ts):
+//   R1 TOKEN: request token header must EQUAL the launch token; missing/wrong
+//      -> 401, and the rejection body never echoes the token.
+//   R2 ORIGIN: when an Origin header is present it must match an
+//      allowedOrigins pattern ('app://*' matches every app:// origin).
+//      Mismatch (evil.example, 'null', subdomain tricks) -> 403 REGARDLESS of
+//      token validity. A present-but-EMPTY Origin header is anomalous and is
+//      rejected the same way (fail closed).
+//   R3 HOST: for requests whose URL scheme is http(s) (i.e. bound for the
+//      loopback backend rather than the app:// renderer surface), the
+//      effective host (Host header when present, else the URL host) must be
+//      the LITERAL loopback address 127.0.0.1 or [::1] on any port. The NAME
+//      'localhost' is NOT accepted (DNS-rebinding hardening) and LAN/private
+//      IPs are NOT accepted -> 403 even with a valid token.
+//   R4 PASS: every check passes -> null (caller proceeds to its backend).
+//   R5 ISOLATION: the guard never touches the network and never calls a
+//      backend; composition is the caller's job.
+import { DEFAULT_ALLOWED_ORIGINS, DEFAULT_TOKEN_HEADER_NAME } from './config.js';
+
+export interface LoopbackGuardRequest {
+  url: string;
+  headers: { get(name: string): string | null };
+}
+
+export type LoopbackGuard = (request: LoopbackGuardRequest) => Response | null;
+
+export interface CreateLoopbackGuardOptions {
+  token: string;
+  tokenHeaderName?: string;
+  allowedOrigins?: string[];
+}
+
+/** Match an Origin header value against a pattern list ('x://*' wildcards the remainder). */
+export function originAllowed(origin: string, patterns: string[]): boolean {
+  for (const pattern of patterns) {
+    if (pattern.endsWith('*')) {
+      if (origin.startsWith(pattern.slice(0, -1))) return true;
+    } else if (origin === pattern) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** The literal loopback hosts the transport accepts for http(s) requests. */
+const LOOPBACK_HOSTS = new Set(['127.0.0.1', '[::1]', '::1']);
+
+function isLoopbackHost(hostWithPort: string): boolean {
+  let host = hostWithPort.toLowerCase().trim();
+  if (host.startsWith('[')) {
+    // IPv6 literal: strip the port but keep the closing bracket ('[::1]:8765' -> '[::1]').
+    const end = host.indexOf(']');
+    if (end === -1) return false; // unterminated bracket: malformed, fail closed
+    host = host.slice(0, end + 1);
+  } else {
+    // IPv4/hostname: drop the port ('127.0.0.1:8765' -> '127.0.0.1').
+    const colon = host.indexOf(':');
+    if (colon !== -1) host = host.slice(0, colon);
+  }
+  return LOOPBACK_HOSTS.has(host);
+}
+
+function fail(status: 401 | 403, body: string): Response {
+  // Bodies are static on purpose: no request material (least of all the
+  // token) is ever echoed back on a rejection path.
+  return new Response(body, { status });
+}
+
+/**
+ * Create the request gate. Evaluation order: origin (R2), then host (R3),
+ * then token (R1) — wrong-origin/host requests are rejected before the token
+ * is even looked at, so token validity can never launder a bad origin.
+ */
+export function createLoopbackGuard(opts: CreateLoopbackGuardOptions): LoopbackGuard {
+  const tokenHeaderName = (opts.tokenHeaderName ?? DEFAULT_TOKEN_HEADER_NAME).toLowerCase();
+  const allowedOrigins = opts.allowedOrigins ?? DEFAULT_ALLOWED_ORIGINS;
+
+  return (request: LoopbackGuardRequest): Response | null => {
+    // R2 ORIGIN (fail closed on present-but-empty).
+    const origin = request.headers.get('origin');
+    if (origin !== null && !originAllowed(origin, allowedOrigins)) {
+      return fail(403, 'Forbidden');
+    }
+
+    // R3 HOST for http(s) requests (app:// requests are governed by R2).
+    let scheme = '';
+    let urlHost: string | null = null;
+    try {
+      const parsed = new URL(request.url);
+      scheme = parsed.protocol.replace(':', '');
+      urlHost = parsed.host;
+    } catch {
+      return fail(403, 'Forbidden'); // unparseable URL: fail closed
+    }
+    if (scheme === 'http' || scheme === 'https') {
+      const effectiveHost = request.headers.get('host') ?? urlHost ?? '';
+      if (!isLoopbackHost(effectiveHost)) {
+        return fail(403, 'Forbidden');
+      }
+    }
+
+    // R1 TOKEN (constant-time enough: equality over hex, rejection body static).
+    const supplied = request.headers.get(tokenHeaderName);
+    if (supplied !== opts.token) {
+      return fail(401, 'Unauthorized');
+    }
+
+    // R4 PASS.
+    return null;
+  };
+}

--- a/desktop/main/security/loopback-guard.ts
+++ b/desktop/main/security/loopback-guard.ts
@@ -27,8 +27,16 @@
 import { DEFAULT_ALLOWED_ORIGINS, DEFAULT_TOKEN_HEADER_NAME } from './config.js';
 
 export interface LoopbackGuardRequest {
+  // MUST be an ABSOLUTE URL (e.g. 'http://127.0.0.1:<port>/api' or
+  // 'app://index.html'). A Node http server's req.url is a BARE path and will
+  // fail closed here (403) — B3 adapters must build the absolute form, e.g.
+  // `http://127.0.0.1:${port}${req.url}`.
   url: string;
   headers: { get(name: string): string | null };
+  // Reserved for B3 CORS-preflight handling (issue #61): if provided, an
+  // adapter MAY exempt OPTIONS — but only AFTER the origin/host gates below,
+  // never before them. Unset requests are treated as non-preflight.
+  method?: string;
 }
 
 export type LoopbackGuard = (request: LoopbackGuardRequest) => Response | null;
@@ -85,8 +93,13 @@ export function createLoopbackGuard(opts: CreateLoopbackGuardOptions): LoopbackG
   const allowedOrigins = opts.allowedOrigins ?? DEFAULT_ALLOWED_ORIGINS;
 
   return (request: LoopbackGuardRequest): Response | null => {
+    // Case-insensitive lookup wrapper: real fetch/Headers implementations fold
+    // case, but the type contract cannot force a custom B3 adapter to — so the
+    // guard folds the lookup itself and adapters stay safe by construction.
+    const getHeader = (name: string): string | null => request.headers.get(name.toLowerCase());
+
     // R2 ORIGIN (fail closed on present-but-empty).
-    const origin = request.headers.get('origin');
+    const origin = getHeader('origin');
     if (origin !== null && !originAllowed(origin, allowedOrigins)) {
       return fail(403, 'Forbidden');
     }
@@ -99,17 +112,21 @@ export function createLoopbackGuard(opts: CreateLoopbackGuardOptions): LoopbackG
       scheme = parsed.protocol.replace(':', '');
       urlHost = parsed.host;
     } catch {
-      return fail(403, 'Forbidden'); // unparseable URL: fail closed
+      return fail(403, 'Forbidden'); // unparseable/bare-path URL: fail closed
     }
     if (scheme === 'http' || scheme === 'https') {
-      const effectiveHost = request.headers.get('host') ?? urlHost ?? '';
+      const effectiveHost = getHeader('host') ?? urlHost ?? '';
       if (!isLoopbackHost(effectiveHost)) {
         return fail(403, 'Forbidden');
       }
     }
 
-    // R1 TOKEN (constant-time enough: equality over hex, rejection body static).
-    const supplied = request.headers.get(tokenHeaderName);
+    // R1 TOKEN. Plain string equality: NOT constant-time, but the token is a
+    // 256-bit per-launch CSPRNG secret served only over loopback and rotated
+    // every launch, so timing sampling of a never-reused secret is not a
+    // practical attack here. Revisit only if the transport ever leaves
+    // loopback.
+    const supplied = getHeader(tokenHeaderName);
     if (supplied !== opts.token) {
       return fail(401, 'Unauthorized');
     }

--- a/desktop/main/security/token.ts
+++ b/desktop/main/security/token.ts
@@ -1,0 +1,36 @@
+// Per-launch desktop auth token (issue #60, Workstream B2).
+//
+// Contract (frozen by desktop/src/__tests__/b2-token-lifecycle.test.ts):
+// 256 bits of CSPRNG entropy per launch, held in MAIN-PROCESS MEMORY ONLY.
+// Never persisted to disk, never logged, never sent anywhere except through
+// the desktop:get-token IPC handler to the app's own renderer (which received
+// it via contextBridge, not storage). The token dies with the process; a new
+// launch mints a fresh one, so a token observed in a previous session is dead
+// (token-replay-across-restarts is covered in docs/security/desktop.md).
+import { randomBytes } from 'node:crypto';
+
+/** Mint one fresh launch token: crypto.randomBytes(32).toString('hex'). */
+export function mintLaunchToken(): string {
+  return randomBytes(32).toString('hex');
+}
+
+let launchToken: string | null = null;
+
+/**
+ * Initialize the per-launch token exactly once (idempotent). Called from
+ * bootstrap() after the app is ready; every later reader gets the same value.
+ */
+export function initializeLaunchToken(): string {
+  if (launchToken === null) {
+    launchToken = mintLaunchToken();
+  }
+  return launchToken;
+}
+
+/** The per-launch token. Fails fast if bootstrap never initialized it. */
+export function getLaunchToken(): string {
+  if (launchToken === null) {
+    throw new Error('desktop launch token not initialized; bootstrap() must call initializeLaunchToken()');
+  }
+  return launchToken;
+}

--- a/desktop/main/security/token.ts
+++ b/desktop/main/security/token.ts
@@ -34,3 +34,11 @@ export function getLaunchToken(): string {
   }
   return launchToken;
 }
+
+/**
+ * Test hook: clear the holder so a fresh test can exercise initialization.
+ * Never call from production code (bootstrap initializes exactly once).
+ */
+export function __resetLaunchTokenForTests(): void {
+  launchToken = null;
+}

--- a/desktop/preload/index.ts
+++ b/desktop/preload/index.ts
@@ -1,9 +1,22 @@
-// Preload bridge for the TrainingApp desktop shell (issue #59).
+// Preload bridge for the TrainingApp desktop shell (issues #59 + #60).
 //
-// Deliberately EMPTY: the shell ships with no IPC surface at all. The renderer
-// gets a namespaced, non-privileged object; contextIsolation keeps it that
-// way. Workstream B2 (issue #60) fills this stub with the secured API when the
-// loopback transport lands.
-import { contextBridge } from 'electron';
+// Two contextBridge namespaces, nothing else:
+//   - `trainingapp` (issue #59): the shell's namespaced, non-privileged
+//     object. Kept for compatibility (the runtime smoke and B1 spec pin it).
+//   - `desktopApi` (issue #60, B2): the ONLY channel the per-launch auth token
+//     takes to the renderer. The token lives in main-process memory; this
+//     bridge hands it over on demand via IPC. It is never put in web storage
+//     (localStorage/sessionStorage) and never in a URL — enforced by the
+//     structural grep in desktop/repro/check-b2.sh (token-bridge id) and
+//     documented in docs/security/desktop.md.
+//
+// contextIsolation keeps both namespaces non-privileged; sandbox:true keeps
+// this file CommonJS (the compile chain emits dist/preload/index.cjs —
+// verified by desktop/scripts/verify-preload-format.mjs).
+import { contextBridge, ipcRenderer } from 'electron';
 
 contextBridge.exposeInMainWorld('trainingapp', {});
+
+contextBridge.exposeInMainWorld('desktopApi', {
+  getAuthToken: () => ipcRenderer.invoke('desktop:get-token'),
+});

--- a/desktop/repro/check-b2.sh
+++ b/desktop/repro/check-b2.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# desktop/repro/check-b2.sh — acceptance-check driver for issue #60
+# (Workstream B2: Electron desktop shell hardening).
+#
+# Usage, from the REPO ROOT under Git Bash:
+#   bash desktop/repro/check-b2.sh <check-id>
+#
+# Check ids and what they prove:
+#   loopback-guard      AC1   vitest spec b2-loopback-guard.test.ts:
+#                             missing/wrong X-Desktop-Token -> 401 BEFORE any
+#                             backend delegate; Origin/Host mismatch
+#                             (evil.example, localhost:<port>, LAN IP) -> 403
+#                             regardless of token; pass-through returns null
+#   loopback-origin     AC2   vitest spec b2-loopback-origin.test.ts: wrong
+#                             origins (http(s)://evil.example, 'null', subdomain
+#                             tricks) and wrong hosts (LAN IP, localhost:<port>)
+#                             rejected 403 EVEN WITH a VALID token, before any
+#                             backend call; valid token + allowed origin passes
+#                             (same loopback-guard.ts seam as loopback-guard)
+#   token-bridge        AC3  FIRST structural greps over desktop/main +
+#                             desktop/preload (zero localStorage/sessionStorage
+#                             hits; zero `?token=`/`&token=`/`#token=` URL-param
+#                             delivery), THEN vitest spec b2-token-bridge.test.ts:
+#                             token delivered only via contextBridge
+#                             desktopApi.getAuthToken ->
+#                             ipcRenderer.invoke('desktop:get-token')
+#   navigation-lockdown AC4  vitest spec b2-navigation-lockdown.test.ts:
+#                             will-navigate denies non-app:// targets;
+#                             setWindowOpenHandler denies every window.open
+#   csp                 AC5  vitest spec b2-csp.test.ts: strict
+#                             content-security-policy on EVERY app:// response
+#                             incl. 403/404; script-src has no 'unsafe-inline'
+#                             (only the pinned sha256 theme-bootstrap script)
+#                             and allows WASM via 'wasm-unsafe-eval'
+#   token-lifecycle     AC7  vitest spec b2-token-lifecycle.test.ts:
+#                             crypto.randomBytes(32) hex (64 chars), unique per
+#                             mint, never persisted (fs spies) or logged
+#                             (console spies)
+#   security-config     AC8  vitest spec b2-security-config.test.ts: defaults
+#                             tokenHeaderName 'X-Desktop-Token' + allowedOrigins
+#                             ['app://*']; packaged builds refuse dev-only
+#                             extra origins (env opt-in gated on not
+#                             app.isPackaged)
+#   AC6 (docs/security/desktop.md threat model) is DOCS_ONLY: intentionally
+#   NOT an executable check id in this driver.
+#
+# Contract: the LAST line on stdout is exactly
+#   DESKTOP-60 CHECK: PASS <id>
+#   DESKTOP-60 CHECK: FAIL <id> <reason>
+# Exit code 0 on PASS, 1 on FAIL. Uses no paths outside the repo.
+#
+# Invocation note: vitest MUST run with the desktop package as cwd so that
+# desktop/vitest.config.ts applies (it carries the 'electron' ->
+# desktop/test/electron-stub.ts alias). Verified on this tree that
+# `npm --prefix <desktop> exec vitest ...` keeps the SPAWNING cwd (vitest then
+# runs at the repo root WITHOUT the alias and even existing suites fail), so
+# the driver uses `(cd <desktop> && ./node_modules/.bin/vitest run ...)`.
+# ---------------------------------------------------------------------------
+set -u
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+ID="${1:-}"
+
+fail() {
+  echo "DESKTOP-60 CHECK: FAIL ${ID} ${1}"
+  exit 1
+}
+
+if [ -z "$ID" ]; then
+  echo "DESKTOP-60 CHECK: FAIL usage check-id-required-(loopback-guard|loopback-origin|token-bridge|navigation-lockdown|csp|token-lifecycle|security-config)"
+  exit 1
+fi
+
+ensure_desktop_deps() {
+  [ -d "${ROOT}/desktop/node_modules" ] && return 0
+  npm --prefix "${ROOT}/desktop" install --ignore-scripts --no-audit --no-fund >/dev/null 2>&1 \
+    || fail "desktop-npm-install-failed"
+}
+
+# Structural AC3 guard (always runs before the token-bridge spec): the token
+# must never be parked in web storage or passed as a URL parameter anywhere in
+# the production desktop source. Scope: desktop/main + desktop/preload only
+# (fixtures/specs under desktop/src and the web_ui renderer's own localStorage
+# use are not token delivery).
+#
+# Storage pattern notes: the match is storage-API USAGE shapes —
+# `localStorage.` / `localStorage[` / `sessionStorage.` / `sessionStorage[`
+# (method calls and bracket access, incl. window.localStorage.x) — rather than
+# the bare word: a B1 doc comment in desktop/main/protocol.ts legitimately
+# mentions "localStorage" when describing app:// scheme privileges, and a bare
+# substring would fail every run for that comment, not for token storage.
+token_storage_guard() {
+  if grep -rnE "(localStorage|sessionStorage)[[:space:]]*(\.|\[)" \
+      "${ROOT}/desktop/main" "${ROOT}/desktop/preload" >/dev/null 2>&1; then
+    fail "token-storage-violation-localStorage-or-sessionStorage-access-in-desktop-main-or-desktop-preload"
+  fi
+  # URL-param delivery pattern: 'token=' preceded by ?, & or # (query or hash).
+  # Anchored to a URL context so ordinary identifiers (const token = ...) and
+  # header names never false-positive.
+  if grep -rnE "[?&#]token=" \
+      "${ROOT}/desktop/main" "${ROOT}/desktop/preload" >/dev/null 2>&1; then
+    fail "token-storage-violation-token-as-url-parameter"
+  fi
+}
+
+# Run exactly ONE vitest spec (path relative to the desktop package), stream
+# its output, and on failure compose a STABLE reason:
+#   - collection failed on module resolution -> 'module-missing-<sanitized
+#     specifier>' (e.g. module-missing-main-security-token);
+#   - otherwise -> 'vitest-exit-<rc>' plus '-saw-<marker>' for every
+#     id-nominated behavioral marker actually present in the log (the markers
+#     are substrings of the failing test names, e.g. desktopApi,
+#     will-navigate, setWindowOpenHandler, content-security-policy).
+run_spec() {
+  spec_file="$1"  # e.g. b2-csp.test.ts
+  markers="$2"    # space-separated stable substrings identifying behavioral REDs
+  log="$(mktemp)"
+  (cd "${ROOT}/desktop" && ./node_modules/.bin/vitest run "src/__tests__/${spec_file}") >"$log" 2>&1
+  rc=$?
+  cat "$log"
+  if [ "$rc" -eq 0 ]; then
+    rm -f "$log"
+    return 0
+  fi
+  reason="vitest-exit-${rc}"
+  missing="$(grep -oE "Cannot find module '[^']+'" "$log" | head -n 1 | sed -e "s/^Cannot find module '//" -e "s/'\$//")"
+  if [ -n "$missing" ]; then
+    reason="module-missing-$(printf '%s' "$missing" | sed -E -e 's#^(\.\./)+##' -e 's#[^A-Za-z0-9]+#-#g' -e 's#^-+##' -e 's#-+\$##')"
+  else
+    for m in $markers; do
+      if grep -qi -e "$m" "$log" 2>/dev/null; then
+        reason="${reason}-saw-${m}"
+      fi
+    done
+  fi
+  rm -f "$log"
+  fail "$reason"
+}
+
+case "$ID" in
+  loopback-guard)
+    ensure_desktop_deps
+    run_spec b2-loopback-guard.test.ts "loopback-guard"
+    echo "DESKTOP-60 CHECK: PASS ${ID}"
+    exit 0
+    ;;
+
+  loopback-origin)
+    ensure_desktop_deps
+    run_spec b2-loopback-origin.test.ts "loopback-origin"
+    echo "DESKTOP-60 CHECK: PASS ${ID}"
+    exit 0
+    ;;
+
+  token-bridge)
+    ensure_desktop_deps
+    token_storage_guard
+    run_spec b2-token-bridge.test.ts "desktopApi"
+    echo "DESKTOP-60 CHECK: PASS ${ID}"
+    exit 0
+    ;;
+
+  navigation-lockdown)
+    ensure_desktop_deps
+    run_spec b2-navigation-lockdown.test.ts "will-navigate setWindowOpenHandler"
+    echo "DESKTOP-60 CHECK: PASS ${ID}"
+    exit 0
+    ;;
+
+  csp)
+    ensure_desktop_deps
+    run_spec b2-csp.test.ts "content-security-policy"
+    echo "DESKTOP-60 CHECK: PASS ${ID}"
+    exit 0
+    ;;
+
+  token-lifecycle)
+    ensure_desktop_deps
+    run_spec b2-token-lifecycle.test.ts "token-lifecycle"
+    echo "DESKTOP-60 CHECK: PASS ${ID}"
+    exit 0
+    ;;
+
+  security-config)
+    ensure_desktop_deps
+    run_spec b2-security-config.test.ts "security-config"
+    echo "DESKTOP-60 CHECK: PASS ${ID}"
+    exit 0
+    ;;
+
+  *)
+    fail "unknown-check-id-${ID}"
+    ;;
+esac

--- a/desktop/src/__tests__/b2-csp-pin.test.ts
+++ b/desktop/src/__tests__/b2-csp-pin.test.ts
@@ -5,7 +5,7 @@
 // fails, the renderer's inline scripts changed — update the pin CONSCIOUSLY
 // (and re-verify no new inline script needs its own pin) rather than letting
 // the theme bootstrap silently break or an injected script slip through.
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -15,6 +15,10 @@ import { INLINE_THEME_BOOTSTRAP_SHA256, buildCspPolicy } from '../../main/securi
 const here = path.dirname(fileURLToPath(import.meta.url));
 // desktop/src/__tests__ -> desktop -> repo root -> web_ui/index.html
 const INDEX_HTML = path.resolve(here, '..', '..', '..', 'web_ui', 'index.html');
+// Built artifact (exists after a desktop:build / web_ui build) — the bytes the
+// packaged app actually serves. Checked whenever present so a Vite config
+// change that alters the inline script cannot silently desync the CSP pin.
+const DIST_HTML = path.resolve(here, '..', '..', '..', 'web_ui', 'dist', 'index.html');
 
 function inlineScripts(html: string): string[] {
   return [...html.matchAll(/<script(?![^>]*\bsrc=)[^>]*>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
@@ -37,5 +41,17 @@ describe('CSP inline-script pin (issue #60)', () => {
     const policy = buildCspPolicy();
     expect(policy).not.toContain("'unsafe-inline'");
     expect(policy).not.toContain("'unsafe-eval'");
+  });
+
+  it('when a built dist exists, its inline script hash matches the pin too', () => {
+    if (!existsSync(DIST_HTML)) {
+      // dist/ is produced by the web_ui build; absent on a fresh checkout.
+      return;
+    }
+    const html = readFileSync(DIST_HTML, 'utf8');
+    const scripts = inlineScripts(html);
+    expect(scripts.length, 'built dist/index.html must keep exactly ONE inline script').toBe(1);
+    const digest = createHash('sha256').update(scripts[0], 'utf8').digest('base64');
+    expect(INLINE_THEME_BOOTSTRAP_SHA256).toBe(`sha256-${digest}`);
   });
 });

--- a/desktop/src/__tests__/b2-csp-pin.test.ts
+++ b/desktop/src/__tests__/b2-csp-pin.test.ts
@@ -1,0 +1,41 @@
+// CSP pin-drift guard (issue #60, B2 — implementation-quality test, not a
+// frozen acceptance check): the 'sha256-' pin in desktop/main/security/csp.ts
+// must equal the SHA-256 of the ONE legitimate inline <script> in the tracked
+// web_ui/index.html (vited verbatim into the packaged dist). If this test
+// fails, the renderer's inline scripts changed — update the pin CONSCIOUSLY
+// (and re-verify no new inline script needs its own pin) rather than letting
+// the theme bootstrap silently break or an injected script slip through.
+import { readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { INLINE_THEME_BOOTSTRAP_SHA256, buildCspPolicy } from '../../main/security/csp';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+// desktop/src/__tests__ -> desktop -> repo root -> web_ui/index.html
+const INDEX_HTML = path.resolve(here, '..', '..', '..', 'web_ui', 'index.html');
+
+function inlineScripts(html: string): string[] {
+  return [...html.matchAll(/<script(?![^>]*\bsrc=)[^>]*>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
+}
+
+describe('CSP inline-script pin (issue #60)', () => {
+  it('pins exactly the inline theme-bootstrap script of web_ui/index.html', () => {
+    const html = readFileSync(INDEX_HTML, 'utf8');
+    // .gitattributes pins this file to LF; if a CRLF ever creeps in, the hash
+    // below would drift from the browser's view of the served bytes — fail
+    // loudly here instead of silently shipping a broken theme bootstrap.
+    expect(html.includes('\r'), 'web_ui/index.html must stay LF (.gitattributes eol=lf)').toBe(false);
+    const scripts = inlineScripts(html);
+    expect(scripts.length, 'expected exactly ONE inline script in web_ui/index.html').toBe(1);
+    const digest = createHash('sha256').update(scripts[0], 'utf8').digest('base64');
+    expect(INLINE_THEME_BOOTSTRAP_SHA256).toBe(`sha256-${digest}`);
+  });
+
+  it('the pinned policy never contains unsafe-inline or unsafe-eval', () => {
+    const policy = buildCspPolicy();
+    expect(policy).not.toContain("'unsafe-inline'");
+    expect(policy).not.toContain("'unsafe-eval'");
+  });
+});

--- a/desktop/src/__tests__/b2-csp.test.ts
+++ b/desktop/src/__tests__/b2-csp.test.ts
@@ -1,0 +1,135 @@
+// C4 / AC5 (issue #60, Workstream B2): every app:// response — including 403
+// traversal refusals and 404 misses — must carry a strict Content-Security-
+// Policy that blocks injected inline scripts while allowing the renderer's
+// legitimate needs (self, app:, WASM via 'wasm-unsafe-eval', the pinned
+// sha256 hash of the ONE inline theme-bootstrap script, and loopback
+// connect-src for the B3 backend).
+//
+// Seam contract (frozen; desktop/main/protocol.ts createAppFileHandler —
+// EXISTS at base but serves no CSP header, so these fail at base for the right
+// reason: header missing):
+//   every Response the handler returns (200, 403, 404) has a
+//   'content-security-policy' header whose directives satisfy:
+//     default-src 'self' app:                        (exact prefix, issue text)
+//     script-src 'self' 'wasm-unsafe-eval' sha256-<pin>
+//       - and NEVER 'unsafe-inline' or 'unsafe-eval' (inline-script injection
+//         attempts must be blocked; only the pinned hash may run inline)
+//     object-src 'none'
+//     connect-src ... 'self' ... app: ... http://127.0.0.1:* ...
+// Deliberately NOT asserted here (beyond the frozen minimum): COOP/COEP.
+// 'electron' resolves to desktop/test/electron-stub.ts (vitest alias).
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { __resetElectronStub } from '../../test/electron-stub';
+import { createAppFileHandler } from '../../main/protocol';
+
+let root = '';
+
+beforeAll(() => {
+  const base = mkdtempSync(path.join(tmpdir(), 'b2-csp-'));
+  root = path.join(base, 'dist-root');
+  mkdirSync(root, { recursive: true });
+  writeFileSync(path.join(root, 'index.html'), '<!doctype html><html><body>csp-fixture</body></html>');
+  // Outside root: traversal requests must 403 on it, never serve it.
+  writeFileSync(path.join(base, 'secret.txt'), 'CSP-FIXTURE-SECRET');
+});
+
+afterAll(() => {
+  rmSync(path.dirname(root), { recursive: true, force: true });
+});
+
+/** Build a Request like Electron's protocol.handle delivers (duck-typed fallback). */
+function req(url: string): Request {
+  try {
+    return new Request(url);
+  } catch {
+    return { url } as Request;
+  }
+}
+
+function cspOf(res: Response): string {
+  const value = res.headers.get('content-security-policy');
+  expect(value, `response ${res.status} must carry a content-security-policy header`).toBeTypeOf('string');
+  return (value as string).toLowerCase();
+}
+
+/** Parse a CSP policy string into a lowercase directive-name -> value map. */
+function directives(policy: string): Record<string, string> {
+  const map: Record<string, string> = {};
+  for (const part of policy.split(';')) {
+    const trimmed = part.trim();
+    if (!trimmed) continue;
+    const [name, ...rest] = trimmed.split(/\s+/);
+    map[name.toLowerCase()] = rest.join(' ');
+  }
+  return map;
+}
+
+/** The frozen strictness checks every CSP-carrying response must satisfy. */
+function expectStrictCsp(policy: string): void {
+  // default-src: exactly the issue's strict default, 'self' then app:.
+  expect(policy, "default-src must start with \"default-src 'self' app:\"").toMatch(
+    /default-src\s+'self'\s+app:/,
+  );
+  const d = directives(policy);
+  // object-src 'none' — no plugin content ever (source token is quoted).
+  expect(d['object-src'], "object-src must be 'none'").toContain("'none'");
+  // script-src: self + WASM + ONE pinned inline script; never arbitrary inline.
+  expect(d['script-src'], 'script-src directive must exist').toBeTypeOf('string');
+  const scriptSrc = d['script-src'] ?? '';
+  expect(scriptSrc, "script-src must include 'self'").toContain("'self'");
+  expect(scriptSrc, "script-src must include 'wasm-unsafe-eval' for ONNX/wllama WASM").toContain("'wasm-unsafe-eval'");
+  expect(scriptSrc, 'script-src must pin the one inline theme-bootstrap script (sha256-)').toMatch(/sha256-/);
+  expect(scriptSrc, "script-src must NOT contain 'unsafe-inline' (blocks injected inline scripts)").not.toContain(
+    "'unsafe-inline'",
+  );
+  expect(scriptSrc, "script-src must NOT contain 'unsafe-eval'").not.toContain("'unsafe-eval'");
+  // connect-src: self + app: + loopback backend on any port.
+  expect(d['connect-src'], 'connect-src directive must exist').toBeTypeOf('string');
+  const connectSrc = d['connect-src'] ?? '';
+  expect(connectSrc, "connect-src must include 'self'").toContain("'self'");
+  expect(connectSrc, 'connect-src must include app:').toContain('app:');
+  expect(connectSrc, 'connect-src must allow the loopback backend http://127.0.0.1:*').toMatch(
+    /http:\/\/127\.0\.0\.1:\*/,
+  );
+}
+
+describe('C4 Content-Security-Policy on app:// responses (AC5)', () => {
+  it('serves app://index.html with a strict content-security-policy header (inline injection blocked)', async () => {
+    __resetElectronStub();
+    const handler = createAppFileHandler({ root });
+    const res = await handler(req('app://index.html'));
+    expect(res.status).toBe(200);
+    expectStrictCsp(cspOf(res));
+  });
+
+  it('403 traversal refusals ALSO carry the strict content-security-policy header', async () => {
+    __resetElectronStub();
+    const handler = createAppFileHandler({ root });
+    const res = await handler(req('app://../secret.txt'));
+    expect(res.status).toBe(403);
+    expect(await res.text()).not.toContain('CSP-FIXTURE-SECRET');
+    expectStrictCsp(cspOf(res));
+  });
+
+  it('404 responses ALSO carry the strict content-security-policy header', async () => {
+    __resetElectronStub();
+    const handler = createAppFileHandler({ root });
+    const res = await handler(req('app://missing.html'));
+    expect(res.status).toBe(404);
+    expectStrictCsp(cspOf(res));
+  });
+
+  it('negative control: the strictness parser rejects a permissive script-src', () => {
+    // Proof the assertions above are discriminative: a CSP with 'unsafe-inline'
+    // and no sha256 pin / no wasm allowance must fail expectStrictCsp.
+    const permissive = "default-src 'self' app:; script-src 'self' 'unsafe-inline'; object-src 'none'; connect-src 'self' app: http://127.0.0.1:*";
+    expect(() => expectStrictCsp(permissive.toLowerCase())).toThrow();
+    const noWasm = "default-src 'self' app:; script-src 'self' sha256-AAA; object-src 'none'; connect-src 'self' app: http://127.0.0.1:*";
+    expect(() => expectStrictCsp(noWasm.toLowerCase())).toThrow();
+    const noObjectSrc = "default-src 'self' app:; script-src 'self' 'wasm-unsafe-eval' sha256-AAA; connect-src 'self' app: http://127.0.0.1:*";
+    expect(() => expectStrictCsp(noObjectSrc.toLowerCase())).toThrow();
+  });
+});

--- a/desktop/src/__tests__/b2-loopback-edges.test.ts
+++ b/desktop/src/__tests__/b2-loopback-edges.test.ts
@@ -1,0 +1,145 @@
+// Edge-case acceptance coverage for the loopback guard (issue #60 feedback
+// round; additive — does not modify the frozen b2-loopback-guard /
+// b2-loopback-origin specs). Pins the decision rules the original matrix left
+// open: IPv6 loopback forms (allow path for bracketed, fail-closed for
+// malformed/unbracketed), unparseable URLs, port-less loopback hosts, empty
+// Host headers, duplicate token headers (first-wins per Headers.get), and
+// R5 backend isolation under a custom token header name.
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { __resetElectronStub } from '../../test/electron-stub';
+import { createLoopbackGuard } from '../../main/security/loopback-guard';
+
+const TOKEN = 'edge-case-launch-token-0123456789abcdef0123456789abcdef';
+const ALLOWED_ORIGIN = 'app://index.html';
+
+type GuardRequest = { url: string; headers: { get(name: string): string | null } };
+
+function req(url: string, headers: Record<string, string> = {}): GuardRequest {
+  const lower = new Map(Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v]));
+  return { url, headers: { get: (n) => lower.get(n.toLowerCase()) ?? null } };
+}
+
+const delegate = vi.fn(async () => new Response('backend-ok', { status: 200 }));
+
+async function runGate(gate: ReturnType<typeof createLoopbackGuard>, request: GuardRequest): Promise<Response> {
+  const verdict = await gate(request);
+  if (verdict === null || verdict === undefined) return await delegate(request);
+  return verdict;
+}
+
+beforeEach(() => {
+  __resetElectronStub();
+  delegate.mockClear();
+});
+
+describe('R3 host gate: IPv6 loopback forms', () => {
+  it('ALLOWS bracketed IPv6 loopback [::1]:<port> with valid origin + token (documented allow half)', async () => {
+    const gate = createLoopbackGuard({ token: TOKEN });
+    const res = await runGate(
+      gate,
+      req('http://[::1]:8765/api', { Origin: ALLOWED_ORIGIN, Host: '[::1]:8765', 'X-Desktop-Token': TOKEN }),
+    );
+    expect(res.status).toBe(200);
+    expect(delegate).toHaveBeenCalledTimes(1);
+  });
+
+  it('FAILS CLOSED on a malformed bracketed host [::1:8765 (unclosed bracket)', async () => {
+    const gate = createLoopbackGuard({ token: TOKEN });
+    // http(s) URL so the R3 Host gate engages (app:// requests skip R3).
+    const res = await runGate(
+      gate,
+      req('http://[::1:8765/api', { Origin: ALLOWED_ORIGIN, Host: '[::1:8765', 'X-Desktop-Token': TOKEN }),
+    );
+    expect(res.status).toBe(403);
+    expect(delegate).not.toHaveBeenCalled();
+  });
+
+  it('FAILS CLOSED on an unbracketed bare IPv6 host ::1 (never produced by WHATWG parsing)', async () => {
+    const gate = createLoopbackGuard({ token: TOKEN });
+    const res = await runGate(
+      gate,
+      req('http://127.0.0.1:8765/api', { Origin: ALLOWED_ORIGIN, Host: '::1', 'X-Desktop-Token': TOKEN }),
+    );
+    expect(res.status).toBe(403);
+    expect(delegate).not.toHaveBeenCalled();
+  });
+});
+
+describe('R3 host gate: URL parse and port forms', () => {
+  it('FAILS CLOSED on an unparseable request URL (catch branch -> 403)', async () => {
+    const gate = createLoopbackGuard({ token: TOKEN });
+    const res = await runGate(gate, req('not a url at all', { Origin: ALLOWED_ORIGIN, 'X-Desktop-Token': TOKEN }));
+    expect(res.status).toBe(403);
+    expect(delegate).not.toHaveBeenCalled();
+  });
+
+  it('ALLOWS a port-less loopback URL http://127.0.0.1/api with valid origin + token', async () => {
+    const gate = createLoopbackGuard({ token: TOKEN });
+    const res = await runGate(
+      gate,
+      req('http://127.0.0.1/api', { Origin: ALLOWED_ORIGIN, Host: '127.0.0.1', 'X-Desktop-Token': TOKEN }),
+    );
+    expect(res.status).toBe(200);
+    expect(delegate).toHaveBeenCalledTimes(1);
+  });
+
+  it('FAILS CLOSED on an empty-string Host header (falls through to a non-loopback effective host)', async () => {
+    const gate = createLoopbackGuard({ token: TOKEN });
+    const res = await runGate(
+      gate,
+      req('http://127.0.0.1:8765/api', { Origin: ALLOWED_ORIGIN, Host: '', 'X-Desktop-Token': TOKEN }),
+    );
+    expect(res.status).toBe(403);
+    expect(delegate).not.toHaveBeenCalled();
+  });
+});
+
+describe('R1 token gate: header shapes', () => {
+  it('first-wins on duplicate token headers (Headers.get contract): first value valid -> pass', async () => {
+    const gate = createLoopbackGuard({ token: TOKEN });
+    // WHATWG Headers.get returns the FIRST value; model duplicates by a
+    // multi-entry map whose first entry wins.
+    const headers = {
+      get: (n: string) => {
+        const values: Record<string, string[]> = {
+          origin: [ALLOWED_ORIGIN],
+          'x-desktop-token': [TOKEN, 'wrong-value'],
+        };
+        const list = values[n.toLowerCase()];
+        return list ? (list[0] ?? null) : null;
+      },
+    };
+    const verdict = gate({ url: 'app://index.html', headers });
+    expect(verdict).toBeNull();
+    expect(delegate).not.toHaveBeenCalled();
+  });
+
+  it('first-wins on duplicate token headers: first value wrong -> 401 even if a later value would match', async () => {
+    const gate = createLoopbackGuard({ token: TOKEN });
+    const headers = {
+      get: (n: string) => {
+        const values: Record<string, string[]> = {
+          origin: [ALLOWED_ORIGIN],
+          'x-desktop-token': ['wrong-value', TOKEN],
+        };
+        const list = values[n.toLowerCase()];
+        return list ? (list[0] ?? null) : null;
+      },
+    };
+    const res = await gate({ url: 'app://index.html', headers });
+    expect(res?.status).toBe(401);
+    expect(delegate).not.toHaveBeenCalled();
+  });
+});
+
+describe('R5 backend isolation under a custom token header name', () => {
+  it('wrong-place rejection (right value, wrong header) does NOT reach the backend delegate', async () => {
+    const gate = createLoopbackGuard({ token: TOKEN, tokenHeaderName: 'X-Custom-Token' });
+    const res = await runGate(
+      gate,
+      req('app://index.html', { Origin: ALLOWED_ORIGIN, 'X-Desktop-Token': TOKEN }),
+    );
+    expect(res.status).toBe(401);
+    expect(delegate).not.toHaveBeenCalled();
+  });
+});

--- a/desktop/src/__tests__/b2-loopback-guard.test.ts
+++ b/desktop/src/__tests__/b2-loopback-guard.test.ts
@@ -1,0 +1,211 @@
+// C1 / AC1 + AC2 (issue #60, Workstream B2): the loopback guard must reject
+// requests whose Origin/Host mismatch the allowed set, or whose token header is
+// missing/wrong, BEFORE any backend delegate runs.
+//
+// Seam contract (frozen; desktop/main/security/loopback-guard.ts — NEW module):
+//   export function createLoopbackGuard(opts: {
+//     token: string;                    // the per-launch minted token
+//     tokenHeaderName?: string;         // default: the security-config default
+//                                       //   'X-Desktop-Token'
+//     allowedOrigins?: string[];        // default: ['app://*']
+//   }): (request: GuardRequest) => Response | null | Promise<Response | null>
+//
+//   GuardRequest is the minimal shape Electron's protocol.handle Requests and
+//   the WHATWG fetch Request share:
+//     { url: string; headers: { get(name: string): string | null } }
+//
+// Frozen decision rules (statuses are exact):
+//   R1 TOKEN (AC1): request.headers.get(tokenHeaderName) must EQUAL opts.token.
+//      Missing header or wrong value -> Response with status 401, and the
+//      rejection body must not echo the token.
+//   R2 ORIGIN (AC2): when an Origin header is present, its value must match an
+//      allowedOrigins pattern ('app://*' matches every app:// origin).
+//      Mismatch (e.g. Origin: http://evil.example) -> status 403 REGARDLESS of
+//      token validity.
+//   R3 HOST: the effective host (Host header when present, else the URL host)
+//      of a request whose URL scheme is NOT covered by allowedOrigins (i.e.
+//      http(s):// requests bound for the loopback backend) is allowed only
+//      when it is the literal loopback address 127.0.0.1 or [::1] on any port.
+//      The NAME 'localhost:<port>' is NOT allowed (DNS-rebinding hardening)
+//      and LAN/private IPs are NOT allowed -> status 403 even with a valid
+//      token. app:// requests are governed by allowedOrigins (R2) instead.
+//   R4 PASS: all checks pass -> null (or undefined): no rejection, the caller
+//      may forward to its backend delegate.
+//   R5 BACKEND ISOLATION: the guard is backend-agnostic — it is a pure
+//      request -> Response|null gate; on every rejection path the backend
+//      delegate must NOT be invoked (asserted here via a spy delegate).
+// 'electron' resolves to desktop/test/electron-stub.ts (vitest alias), though
+// this seam is expected to stay Electron-free.
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { __resetElectronStub } from '../../test/electron-stub';
+import { createLoopbackGuard } from '../../main/security/loopback-guard';
+
+const TOKEN = 'unit-test-launch-token-0123456789abcdef0123456789abcdef';
+const ALLOWED_ORIGIN = 'app://index.html';
+
+type GuardRequest = { url: string; headers: { get(name: string): string | null } };
+
+/** Minimal fetch-Request-shaped fixture (case-insensitive header lookup). */
+function req(url: string, headers: Record<string, string> = {}): GuardRequest {
+  const lower = new Map(Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v]));
+  return { url, headers: { get: (n) => lower.get(n.toLowerCase()) ?? null } };
+}
+
+/** Backend delegate the guard must protect: only reached when the gate passes. */
+const delegate = vi.fn(async () => new Response('backend-ok', { status: 200 }));
+
+/** Compose gate + delegate exactly as a backend-agnostic caller would. */
+async function runGate(
+  gate: (r: GuardRequest) => Response | null | Promise<Response | null>,
+  request: GuardRequest,
+): Promise<Response> {
+  const verdict = await gate(request);
+  if (verdict === null || verdict === undefined) return await delegate(request);
+  return verdict;
+}
+
+beforeEach(() => {
+  __resetElectronStub();
+  delegate.mockClear();
+});
+
+describe('C1 loopback guard: AC1 token gate', () => {
+  it('rejects a request whose X-Desktop-Token header is MISSING with 401, before any backend call', async () => {
+    const gate = createLoopbackGuard({ token: TOKEN });
+    const res = await runGate(gate, req('app://index.html', { Origin: ALLOWED_ORIGIN }));
+    expect(res.status).toBe(401);
+    expect(delegate).not.toHaveBeenCalled();
+    expect(await res.text()).not.toContain(TOKEN);
+  });
+
+  it('rejects a request with the WRONG token value with 401, before any backend call', async () => {
+    const gate = createLoopbackGuard({ token: TOKEN });
+    const res = await runGate(
+      gate,
+      req('app://index.html', { Origin: ALLOWED_ORIGIN, 'X-Desktop-Token': 'wrong-token-value' }),
+    );
+    expect(res.status).toBe(401);
+    expect(delegate).not.toHaveBeenCalled();
+  });
+
+  it('reads the token from the CONFIG-DEFAULT header name X-Desktop-Token, not any other header', async () => {
+    const gate = createLoopbackGuard({ token: TOKEN }); // no explicit header name
+    // Same value under a decoy header, X-Desktop-Token absent -> still 401.
+    const decoy = await runGate(
+      gate,
+      req('app://index.html', { Origin: ALLOWED_ORIGIN, 'X-Api-Token': TOKEN }),
+    );
+    expect(decoy.status).toBe(401);
+    expect(delegate).not.toHaveBeenCalled();
+    // And under the default name with an allowed origin it passes.
+    const ok = await runGate(
+      gate,
+      req('app://index.html', { Origin: ALLOWED_ORIGIN, 'X-Desktop-Token': TOKEN }),
+    );
+    expect(ok.status).toBe(200);
+    expect(delegate).toHaveBeenCalledTimes(1);
+  });
+
+  it('honors an explicit tokenHeaderName override', async () => {
+    const gate = createLoopbackGuard({ token: TOKEN, tokenHeaderName: 'X-Custom-Token' });
+    const ok = await runGate(
+      gate,
+      req('app://index.html', { Origin: ALLOWED_ORIGIN, 'X-Custom-Token': TOKEN }),
+    );
+    expect(ok.status).toBe(200);
+    const wrongPlace = await runGate(
+      gate,
+      req('app://index.html', { Origin: ALLOWED_ORIGIN, 'X-Desktop-Token': TOKEN }),
+    );
+    expect(wrongPlace.status).toBe(401);
+  });
+});
+
+describe('C1 loopback guard: AC2 origin/host gate', () => {
+  it('rejects Origin: http://evil.example with 403 EVEN WITH a valid token, before any backend call', async () => {
+    const gate = createLoopbackGuard({ token: TOKEN });
+    const res = await runGate(
+      gate,
+      req('app://index.html', { Origin: 'http://evil.example', 'X-Desktop-Token': TOKEN }),
+    );
+    expect(res.status).toBe(403);
+    expect(delegate).not.toHaveBeenCalled();
+  });
+
+  it.each(['https://evil.example', 'http://127.0.0.1.evil.example', 'null'])(
+    'rejects forged Origin %s with 403 even with a valid token',
+    async (origin) => {
+      const gate = createLoopbackGuard({ token: TOKEN });
+      const res = await runGate(gate, req('app://index.html', { Origin: origin, 'X-Desktop-Token': TOKEN }));
+      expect(res.status).toBe(403);
+      expect(delegate).not.toHaveBeenCalled();
+    },
+  );
+
+  it('rejects a present-but-EMPTY Origin header with 403 even with a valid token (fail closed)', async () => {
+    const gate = createLoopbackGuard({ token: TOKEN });
+    const res = await runGate(gate, req('app://index.html', { Origin: '', 'X-Desktop-Token': TOKEN }));
+    expect(res.status).toBe(403);
+    expect(delegate).not.toHaveBeenCalled();
+  });
+
+  it('rejects an EMPTY token header value with 401 (empty is just a wrong value)', async () => {
+    const gate = createLoopbackGuard({ token: TOKEN });
+    const res = await runGate(gate, req('app://index.html', { Origin: ALLOWED_ORIGIN, 'X-Desktop-Token': '' }));
+    expect(res.status).toBe(401);
+    expect(delegate).not.toHaveBeenCalled();
+  });
+
+  it('rejects a request directed at Host localhost:<port> with 403 even with valid token and allowed Origin', async () => {
+    const gate = createLoopbackGuard({ token: TOKEN });
+    const res = await runGate(
+      gate,
+      req('http://localhost:9999/api', { Origin: ALLOWED_ORIGIN, Host: 'localhost:9999', 'X-Desktop-Token': TOKEN }),
+    );
+    expect(res.status).toBe(403);
+    expect(delegate).not.toHaveBeenCalled();
+  });
+
+  it('rejects a Host-header mismatch (LAN IP) with 403 even with valid token and allowed Origin', async () => {
+    const gate = createLoopbackGuard({ token: TOKEN });
+    const res = await runGate(
+      gate,
+      req('http://192.168.1.5:8080/api', { Origin: ALLOWED_ORIGIN, Host: '192.168.1.5:8080', 'X-Desktop-Token': TOKEN }),
+    );
+    expect(res.status).toBe(403);
+    expect(delegate).not.toHaveBeenCalled();
+  });
+});
+
+describe('C1 loopback guard: pass-through (R4)', () => {
+  it('returns null (no rejection) for app:// request + valid token -> backend delegate reached', async () => {
+    const gate = createLoopbackGuard({ token: TOKEN });
+    const res = await runGate(
+      gate,
+      req('app://index.html', { Origin: ALLOWED_ORIGIN, 'X-Desktop-Token': TOKEN }),
+    );
+    expect(res.status).toBe(200); // served by the delegate
+    expect(delegate).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes a same-origin app:// request that omits the Origin header (classic subresource loads send none)', async () => {
+    const gate = createLoopbackGuard({ token: TOKEN });
+    const verdict = await gate(req('app://assets/app.js', { 'X-Desktop-Token': TOKEN }));
+    expect(verdict == null).toBe(true); // null/undefined => allowed
+    expect(delegate).not.toHaveBeenCalled(); // gate is pure; the caller composes
+  });
+
+  it('is backend-agnostic: passes the loopback host 127.0.0.1:<any port> with an allowed app:// Origin + token', async () => {
+    const gate = createLoopbackGuard({ token: TOKEN });
+    const res = await runGate(
+      gate,
+      req('http://127.0.0.1:8765/api/v1/models', {
+        Origin: ALLOWED_ORIGIN,
+        Host: '127.0.0.1:8765',
+        'X-Desktop-Token': TOKEN,
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(delegate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/desktop/src/__tests__/b2-loopback-origin.test.ts
+++ b/desktop/src/__tests__/b2-loopback-origin.test.ts
@@ -1,0 +1,131 @@
+// AC2 ONLY (issue #60, Workstream B2): a request whose Origin/Host mismatches
+// the allowed set is rejected (403-class) REGARDLESS of token validity — even
+// a perfectly valid per-launch token must not buy a wrong-origin request
+// through the gate. Split out from C1 (b2-loopback-guard.test.ts, which owns
+// AC1 token gating) so every acceptance criterion maps 1:1 to a check id;
+// this spec re-freezes the SAME seam contract.
+//
+// Seam contract (frozen; desktop/main/security/loopback-guard.ts — NEW module,
+// identical contract to b2-loopback-guard.test.ts):
+//   export function createLoopbackGuard(opts: {
+//     token: string;                    // the per-launch minted token
+//     tokenHeaderName?: string;         // default: the security-config default
+//                                       //   'X-Desktop-Token'
+//     allowedOrigins?: string[];        // default: ['app://*']
+//   }): (request: GuardRequest) => Response | null | Promise<Response | null>
+//
+//   GuardRequest is the minimal shape Electron's protocol.handle Requests and
+//   the WHATWG fetch Request share:
+//     { url: string; headers: { get(name: string): string | null } }
+//
+// Frozen decision rules exercised here (AC2 subset; statuses exact):
+//   ORIGIN: when an Origin header is present, its value must match an
+//     allowedOrigins pattern ('app://*' matches every app:// origin). A
+//     mismatched Origin (http://evil.example, https://evil.example, 'null',
+//     subdomain tricks like http://127.0.0.1.evil.example) -> Response with
+//     status 403 EVEN THOUGH the X-Desktop-Token header carries the correct
+//     token, and the backend delegate is NOT invoked.
+//   HOST: for a request whose URL scheme is not covered by allowedOrigins
+//     (http(s):// loopback-backend requests), the effective host (Host header
+//     when present, else the URL host) is allowed only when it is the literal
+//     loopback address 127.0.0.1 or [::1] on any port. The NAME
+//     'localhost:<port>' and LAN/private IPs -> status 403 even with a valid
+//     token and an allowed Origin; the backend delegate is NOT invoked.
+//   PASS (control): valid token + allowed app:// Origin -> null/undefined (no
+//     rejection) so the caller may reach its backend delegate.
+// 'electron' resolves to desktop/test/electron-stub.ts (vitest alias), though
+// this seam is expected to stay Electron-free.
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { __resetElectronStub } from '../../test/electron-stub';
+import { createLoopbackGuard } from '../../main/security/loopback-guard';
+
+const TOKEN = 'ac2-valid-launch-token-0123456789abcdef0123456789abcdef';
+const ALLOWED_ORIGIN = 'app://index.html';
+
+type GuardRequest = { url: string; headers: { get(name: string): string | null } };
+
+/** Minimal fetch-Request-shaped fixture (case-insensitive header lookup). */
+function req(url: string, headers: Record<string, string> = {}): GuardRequest {
+  const lower = new Map(Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v]));
+  return { url, headers: { get: (n) => lower.get(n.toLowerCase()) ?? null } };
+}
+
+/** Backend delegate the guard must protect: only reached when the gate passes. */
+const delegate = vi.fn(async () => new Response('backend-ok', { status: 200 }));
+
+/** Compose gate + delegate exactly as a backend-agnostic caller would. */
+async function runGate(
+  gate: (r: GuardRequest) => Response | null | Promise<Response | null>,
+  request: GuardRequest,
+): Promise<Response> {
+  const verdict = await gate(request);
+  if (verdict === null || verdict === undefined) return await delegate(request);
+  return verdict;
+}
+
+/** Every request in this spec carries the CORRECT token: rejection must be
+ *  attributable to the origin/host ALONE (AC2: "regardless of token validity"). */
+function validAuth(extra: Record<string, string>): Record<string, string> {
+  return { 'X-Desktop-Token': TOKEN, ...extra };
+}
+
+beforeEach(() => {
+  __resetElectronStub();
+  delegate.mockClear();
+});
+
+describe('AC2 loopback origin gate: wrong origin rejected regardless of token validity', () => {
+  it.each([
+    'http://evil.example',
+    'https://evil.example',
+    'http://127.0.0.1.evil.example', // subdomain trick around a loopback-prefix check
+    'null', // sandboxed/opaque origin marker
+  ])('rejects Origin %s with 403 EVEN WITH a valid token, before any backend call', async (origin) => {
+    const gate = createLoopbackGuard({ token: TOKEN });
+    const res = await runGate(
+      gate,
+      req('app://index.html', validAuth({ Origin: origin })),
+    );
+    expect(res.status).toBe(403);
+    expect(delegate).not.toHaveBeenCalled();
+  });
+
+  it('rejects a LAN-IP host with 403 even with a valid token and an allowed Origin', async () => {
+    const gate = createLoopbackGuard({ token: TOKEN });
+    const res = await runGate(
+      gate,
+      req('http://192.168.1.5:8080/api', validAuth({ Origin: ALLOWED_ORIGIN, Host: '192.168.1.5:8080' })),
+    );
+    expect(res.status).toBe(403);
+    expect(delegate).not.toHaveBeenCalled();
+  });
+
+  it("rejects the NAME 'localhost:<port>' (wrong host:port, non-literal loopback) with 403 even with a valid token", async () => {
+    const gate = createLoopbackGuard({ token: TOKEN });
+    const res = await runGate(
+      gate,
+      req('http://localhost:9999/api', validAuth({ Origin: ALLOWED_ORIGIN, Host: 'localhost:9999' })),
+    );
+    expect(res.status).toBe(403);
+    expect(delegate).not.toHaveBeenCalled();
+  });
+});
+
+describe('AC2 loopback origin gate: control (valid token + allowed origin passes)', () => {
+  it('returns null (no rejection) for an allowed app:// Origin with a valid token', async () => {
+    const gate = createLoopbackGuard({ token: TOKEN });
+    const verdict = await gate(req('app://index.html', validAuth({ Origin: ALLOWED_ORIGIN })));
+    expect(verdict == null).toBe(true); // null/undefined => allowed
+    expect(delegate).not.toHaveBeenCalled(); // gate is pure; the caller composes
+  });
+
+  it('passes the literal loopback host 127.0.0.1:<port> with an allowed app:// Origin + valid token', async () => {
+    const gate = createLoopbackGuard({ token: TOKEN });
+    const res = await runGate(
+      gate,
+      req('http://127.0.0.1:8765/api/v1/models', validAuth({ Origin: ALLOWED_ORIGIN, Host: '127.0.0.1:8765' })),
+    );
+    expect(res.status).toBe(200); // served by the delegate
+    expect(delegate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/desktop/src/__tests__/b2-navigation-lockdown.test.ts
+++ b/desktop/src/__tests__/b2-navigation-lockdown.test.ts
@@ -1,0 +1,119 @@
+// C3 / AC4 (issue #60, Workstream B2): navigation lockdown — the main window
+// must deny will-navigate to any non-app:// target and deny every window.open.
+//
+// Seam contract (frozen; desktop/main/index.ts createMainWindow — EXISTS at
+// base but registers no navigation policy, so these fail at base for the right
+// reason: no handler registered):
+//   win.webContents.on('will-navigate', (event, url) => {...})
+//     - real Electron signature: url is a plain STRING (not a details object)
+//     - non-app:// url => event.preventDefault() (navigation denied)
+//     - app:// url     => no preventDefault()   (navigation allowed)
+//   win.setWindowOpenHandler((details) => ({ action: 'deny' }))
+//     - deny for EVERY url (no window.open / target=_blank surfaces at all)
+// 'electron' resolves to desktop/test/electron-stub.ts (vitest alias); the
+// stub's webContents.on / setWindowOpenHandler are vi.fn captures, so the spec
+// extracts the registered listener(s) and invokes them with mock events.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BrowserWindow, __resetElectronStub } from '../../test/electron-stub';
+import { createMainWindow } from '../../main/index';
+
+type WillNavigateListener = (event: { preventDefault: () => void }, url: string) => void;
+type WindowOpenHandler = (details: {
+  url: string;
+  frameName?: string;
+  features?: string;
+}) => { action: 'deny' | 'allow' };
+
+let savedArgv: string[];
+let savedEnvUrl: string | undefined;
+
+beforeEach(() => {
+  __resetElectronStub();
+  savedArgv = process.argv;
+  savedEnvUrl = process.env.ELECTRON_START_URL;
+  delete process.env.ELECTRON_START_URL;
+  // Force production mode so createMainWindow loads app:// (dev signals off).
+  process.argv = savedArgv.filter((a) => a !== '--dev');
+});
+
+afterEach(() => {
+  process.argv = savedArgv;
+  if (savedEnvUrl === undefined) delete process.env.ELECTRON_START_URL;
+  else process.env.ELECTRON_START_URL = savedEnvUrl;
+});
+
+function willNavigateListeners(win: BrowserWindow): WillNavigateListener[] {
+  return win.webContents.on.mock.calls
+    .filter(([event]) => event === 'will-navigate')
+    .map(([, listener]) => listener as WillNavigateListener);
+}
+
+function windowOpenHandler(win: BrowserWindow): WindowOpenHandler | undefined {
+  // Real Electron surface: the window-open handler lives on webContents
+  // (win.setWindowOpenHandler is undefined at runtime in Electron 44 —
+  // CHECK_WRONG amendment, probe-verified 2026-09-08).
+  const call = win.webContents.setWindowOpenHandler.mock.calls[0] as [WindowOpenHandler] | undefined;
+  return call?.[0];
+}
+
+describe('C3 navigation lockdown: will-navigate (AC4)', () => {
+  it("createMainWindow registers a webContents 'will-navigate' handler", () => {
+    const win = createMainWindow();
+    expect(
+      willNavigateListeners(win).length,
+      'a will-navigate handler must be registered on webContents',
+    ).toBeGreaterThan(0);
+  });
+
+  it('will-navigate DENIES non-app:// targets (preventDefault called)', () => {
+    const win = createMainWindow();
+    const listeners = willNavigateListeners(win);
+    expect(listeners.length, 'a will-navigate handler must be registered on webContents').toBeGreaterThan(0);
+    for (const url of [
+      'https://evil.example/phish',
+      'http://127.0.0.1:9222/x', // even loopback http is not an app:// target
+      'file:///C:/Windows/win.ini',
+    ]) {
+      for (const listener of listeners) {
+        const event = { preventDefault: vi.fn() };
+        listener(event, url);
+        expect(event.preventDefault, `will-navigate must preventDefault() for ${url}`).toHaveBeenCalled();
+      }
+    }
+  });
+
+  it('will-navigate ALLOWS app:// targets (no preventDefault)', () => {
+    const win = createMainWindow();
+    const listeners = willNavigateListeners(win);
+    expect(listeners.length, 'a will-navigate handler must be registered on webContents').toBeGreaterThan(0);
+    for (const url of ['app://index.html', 'app://settings.html']) {
+      for (const listener of listeners) {
+        const event = { preventDefault: vi.fn() };
+        listener(event, url);
+        expect(event.preventDefault, `will-navigate must NOT preventDefault() for ${url}`).not.toHaveBeenCalled();
+      }
+    }
+  });
+});
+
+describe('C3 navigation lockdown: window.open (AC4)', () => {
+  it("setWindowOpenHandler is registered and returns { action: 'deny' } for EVERY url", () => {
+    const win = createMainWindow();
+    expect(
+      win.webContents.setWindowOpenHandler,
+      'webContents.setWindowOpenHandler must be registered exactly once',
+    ).toHaveBeenCalledTimes(1);
+    const handler = windowOpenHandler(win);
+    expect(handler, 'a window-open handler must be captured').toBeDefined();
+    if (!handler) return;
+    for (const url of [
+      'https://evil.example/popup',
+      'http://127.0.0.1:9222/popup',
+      'app://index.html', // even same-scheme popups are denied: no new windows at all
+    ]) {
+      expect(handler({ url, frameName: 'x', features: '' }), `window.open of ${url} must be denied`).toEqual({
+        action: 'deny',
+      });
+    }
+  });
+});

--- a/desktop/src/__tests__/b2-security-config.test.ts
+++ b/desktop/src/__tests__/b2-security-config.test.ts
@@ -1,0 +1,76 @@
+// C6 / AC8 (issue #60, Workstream B2): security config — exact defaults, and
+// dev-only extra origins are IMPOSSIBLE in packaged builds (gate: not
+// app.isPackaged AND explicit env opt-in).
+//
+// Seam contract (frozen; desktop/main/security/config.ts — NEW module):
+//   export interface SecurityConfig { tokenHeaderName: string; allowedOrigins: string[]; }
+//   export function resolveSecurityConfig(opts?: {
+//     env?: Record<string, string | undefined>;  // default: process.env
+//     isPackaged?: boolean;                      // default: app.isPackaged
+//   }): SecurityConfig
+//
+// Frozen rules:
+//   D1 defaults (exact): tokenHeaderName === 'X-Desktop-Token',
+//      allowedOrigins === ['app://*'].
+//   D2 dev-origin opt-in env var: TRAININGAPP_DESKTOP_DEV_ORIGINS — a
+//      comma-separated list of extra origins. Extras are accepted ONLY when
+//      isPackaged === false AND the env var is present and NON-EMPTY.
+//   D3 when accepted, extras are APPENDED to the defaults (the default
+//      app://* origin is never dropped).
+//   D4 packaged builds refuse extras unconditionally (defaults only), even
+//      with the env var set.
+// 'electron' resolves to desktop/test/electron-stub.ts (vitest alias).
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { __resetElectronStub } from '../../test/electron-stub';
+import { resolveSecurityConfig } from '../../main/security/config';
+
+const DEV_ORIGINS_ENV = 'TRAININGAPP_DESKTOP_DEV_ORIGINS';
+const EXTRA_ORIGINS = 'http://localhost:5173,http://127.0.0.1:5173';
+
+beforeEach(() => {
+  __resetElectronStub();
+  delete process.env[DEV_ORIGINS_ENV];
+});
+
+afterEach(() => {
+  delete process.env[DEV_ORIGINS_ENV];
+});
+
+describe('C6 security config defaults (AC8)', () => {
+  it('defaults: tokenHeaderName X-Desktop-Token, allowedOrigins ["app://*"] (exact)', () => {
+    const cfg = resolveSecurityConfig({ env: {}, isPackaged: false });
+    expect(cfg.tokenHeaderName).toBe('X-Desktop-Token');
+    expect(cfg.allowedOrigins).toEqual(['app://*']);
+  });
+
+  it('ambient call with no opts resolves the same defaults when the opt-in env var is unset', () => {
+    const cfg = resolveSecurityConfig();
+    expect(cfg.tokenHeaderName).toBe('X-Desktop-Token');
+    expect(cfg.allowedOrigins).toEqual(['app://*']);
+  });
+});
+
+describe('C6 dev-origin gating (AC8)', () => {
+  it('PACKAGED build + env opt-in present -> extras REFUSED (defaults only)', () => {
+    const cfg = resolveSecurityConfig({ env: { [DEV_ORIGINS_ENV]: EXTRA_ORIGINS }, isPackaged: true });
+    expect(cfg.allowedOrigins).toEqual(['app://*']);
+  });
+
+  it('UNPACKAGED + env opt-in present -> extras ACCEPTED and appended to the defaults', () => {
+    const cfg = resolveSecurityConfig({ env: { [DEV_ORIGINS_ENV]: EXTRA_ORIGINS }, isPackaged: false });
+    expect(cfg.allowedOrigins).toEqual(expect.arrayContaining(['app://*', 'http://localhost:5173', 'http://127.0.0.1:5173']));
+    expect(cfg.tokenHeaderName).toBe('X-Desktop-Token');
+  });
+
+  it('no env opt-in -> extras never accepted, regardless of packaging', () => {
+    const packaged = resolveSecurityConfig({ env: {}, isPackaged: true });
+    const unpackaged = resolveSecurityConfig({ env: {}, isPackaged: false });
+    expect(packaged.allowedOrigins).toEqual(['app://*']);
+    expect(unpackaged.allowedOrigins).toEqual(['app://*']);
+  });
+
+  it('EMPTY env value is not an opt-in -> defaults only', () => {
+    const cfg = resolveSecurityConfig({ env: { [DEV_ORIGINS_ENV]: '' }, isPackaged: false });
+    expect(cfg.allowedOrigins).toEqual(['app://*']);
+  });
+});

--- a/desktop/src/__tests__/b2-security-headers.test.ts
+++ b/desktop/src/__tests__/b2-security-headers.test.ts
@@ -1,0 +1,73 @@
+// Security-header coverage for app:// responses (issue #60 feedback round;
+// additive — the frozen b2-csp.test.ts deliberately pins only CSP, leaving
+// COOP/COEP/CORP unpinned until this spec). Invariant: EVERY app:// response
+// (success and errors alike) carries the cross-origin-isolation header
+// discipline of web_ui/scripts/start.ps1 — set by protocol.ts
+// withSecurityHeaders.
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { __resetElectronStub } from '../../test/electron-stub';
+import { createAppFileHandler } from '../../main/protocol';
+
+let root = '';
+
+beforeAll(() => {
+  const base = mkdtempSync(path.join(tmpdir(), 'b2-sec-headers-'));
+  root = path.join(base, 'dist-root');
+  mkdirSync(root, { recursive: true });
+  writeFileSync(path.join(root, 'index.html'), '<!doctype html><html><body>hdr-fixture</body></html>');
+  writeFileSync(path.join(base, 'secret.txt'), 'SECRET');
+});
+
+afterAll(() => {
+  rmSync(path.dirname(root), { recursive: true, force: true });
+});
+
+function req(url: string): Request {
+  try {
+    return new Request(url);
+  } catch {
+    return { url } as Request;
+  }
+}
+
+const ISOLATION_HEADERS: Record<string, string> = {
+  'cross-origin-opener-policy': 'same-origin',
+  'cross-origin-embedder-policy': 'require-corp',
+  'cross-origin-resource-policy': 'same-origin',
+};
+
+describe('COOP/COEP/CORP on every app:// response (issue #60)', () => {
+  it('200 responses carry the full isolation header set plus CSP', async () => {
+    __resetElectronStub();
+    const handler = createAppFileHandler({ root });
+    const res = await handler(req('app://index.html'));
+    expect(res.status).toBe(200);
+    for (const [name, value] of Object.entries(ISOLATION_HEADERS)) {
+      expect(res.headers.get(name), `${name} on 200`).toBe(value);
+    }
+    expect(res.headers.get('content-security-policy')).toBeTypeOf('string');
+  });
+
+  it('403 refusals carry the same isolation headers (fail-open impossible)', async () => {
+    __resetElectronStub();
+    const handler = createAppFileHandler({ root });
+    const res = await handler(req('app://../secret.txt'));
+    expect(res.status).toBe(403);
+    for (const [name, value] of Object.entries(ISOLATION_HEADERS)) {
+      expect(res.headers.get(name), `${name} on 403`).toBe(value);
+    }
+  });
+
+  it('404 responses carry the same isolation headers', async () => {
+    __resetElectronStub();
+    const handler = createAppFileHandler({ root });
+    const res = await handler(req('app://missing.html'));
+    expect(res.status).toBe(404);
+    for (const [name, value] of Object.entries(ISOLATION_HEADERS)) {
+      expect(res.headers.get(name), `${name} on 404`).toBe(value);
+    }
+  });
+});

--- a/desktop/src/__tests__/b2-token-bridge.test.ts
+++ b/desktop/src/__tests__/b2-token-bridge.test.ts
@@ -1,0 +1,73 @@
+// C2 / AC3 behavioral part (issue #60, Workstream B2): the per-launch auth
+// token reaches the renderer ONLY through the contextBridge/IPC channel —
+// preload must expose a `desktopApi` namespace whose getAuthToken() routes to
+// ipcRenderer.invoke('desktop:get-token'). (The structural no-storage /
+// no-URL-param half of AC3 is enforced by driver check `token-bridge` greps;
+// this spec pins the bridge surface.)
+//
+// Seam contract (frozen; desktop/preload/index.ts — EXISTS at base with only
+// the legacy `trainingapp` namespace, so the desktopApi assertions fail at
+// base for the right reason):
+//   contextBridge.exposeInMainWorld('desktopApi', {
+//     getAuthToken: () => ipcRenderer.invoke('desktop:get-token'),
+//   });
+//   // legacy namespace stays (compatibility): exactly one
+//   // exposeInMainWorld('trainingapp', <object>) call.
+//
+// Dynamic-import pattern follows secure-defaults.test.ts: the preload module
+// is a side-effect module, vitest isolates module registries per test FILE,
+// and the registry caches after the first await import — so there is deliberately
+// NO per-test __resetElectronStub() here (it would wipe the one-time side
+// effect's recorded calls); the reset happens exactly once, immediately before
+// the first import below. 'electron' resolves to desktop/test/electron-stub.ts.
+import { describe, expect, it, vi } from 'vitest';
+import { contextBridge, ipcRenderer, __resetElectronStub } from '../../test/electron-stub';
+
+const IPC_CHANNEL = 'desktop:get-token';
+const INVOKE_SENTINEL = 'sentinel-launch-token-from-ipc-0123456789abcdef';
+
+type ExposedApi = { getAuthToken?: () => unknown };
+type BridgeCall = [string, ExposedApi];
+
+/** Recorded exposeInMainWorld calls (import side effect must have run). */
+function bridgeCalls(): BridgeCall[] {
+  return contextBridge.exposeInMainWorld.mock.calls as unknown as BridgeCall[];
+}
+
+function desktopApiCall(): BridgeCall | undefined {
+  return bridgeCalls().find(([name]) => name === 'desktopApi');
+}
+
+describe('C2 token bridge: desktopApi via contextBridge/IPC only', () => {
+  it("exposes a 'desktopApi' namespace whose API object has a getAuthToken function", async () => {
+    __resetElectronStub();
+    await import('../../preload/index');
+    const call = desktopApiCall();
+    expect(call, "contextBridge.exposeInMainWorld('desktopApi', ...) must be called").toBeDefined();
+    const [, api] = call as BridgeCall;
+    expect(api, 'desktopApi API must be a plain object').toBeTypeOf('object');
+    expect(api, 'desktopApi API must not be null').not.toBeNull();
+    expect(typeof api.getAuthToken, 'desktopApi.getAuthToken must be a function').toBe('function');
+  });
+
+  it("desktopApi.getAuthToken() resolves via ipcRenderer.invoke('desktop:get-token')", async () => {
+    await import('../../preload/index'); // cached: side effect already recorded
+    vi.mocked(ipcRenderer.invoke).mockResolvedValue(INVOKE_SENTINEL);
+    const call = desktopApiCall();
+    expect(call, 'desktopApi namespace missing').toBeDefined();
+    const getAuthToken = (call as BridgeCall)[1].getAuthToken;
+    expect(typeof getAuthToken, 'desktopApi.getAuthToken must be a function').toBe('function');
+
+    const result = await (getAuthToken as () => Promise<string>)();
+
+    expect(ipcRenderer.invoke).toHaveBeenCalledWith(IPC_CHANNEL);
+    expect(result).toBe(INVOKE_SENTINEL);
+  });
+
+  it("still exposes the legacy 'trainingapp' namespace exactly once (compatibility)", async () => {
+    await import('../../preload/index'); // cached: side effect already recorded
+    const legacy = bridgeCalls().filter(([name]) => name === 'trainingapp');
+    expect(legacy, 'legacy trainingapp namespace must remain exposed').toHaveLength(1);
+    expect(legacy[0]?.[1]).toBeTypeOf('object');
+  });
+});

--- a/desktop/src/__tests__/b2-token-lifecycle.test.ts
+++ b/desktop/src/__tests__/b2-token-lifecycle.test.ts
@@ -1,0 +1,83 @@
+// C5 / AC7 (issue #60, Workstream B2): the per-launch desktop auth token is
+// minted with crypto.randomBytes(32) as 64 hex chars, is unique per mint
+// (unguessable, fresh every launch), and is never persisted to disk nor
+// logged — main-process memory only.
+//
+// Seam contract (frozen; desktop/main/security/token.ts — NEW module):
+//   export function mintLaunchToken(): string
+//     - returns crypto.randomBytes(32).toString('hex'): a 64-char lowercase
+//       hex string (32 bytes of entropy);
+//     - every call yields a fresh value (no caching across launches/calls);
+//     - performs NO filesystem writes and logs nothing (no console method
+//       receives the token — or anything else — during a mint).
+// 'electron' resolves to desktop/test/electron-stub.ts (vitest alias), though
+// this seam is expected to stay Electron-free.
+import fs from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { __resetElectronStub } from '../../test/electron-stub';
+import { mintLaunchToken } from '../../main/security/token';
+
+let writeSync: ReturnType<typeof vi.spyOn>;
+let appendSync: ReturnType<typeof vi.spyOn>;
+let writeAsync: ReturnType<typeof vi.spyOn>;
+let consoleSpies: Map<string, ReturnType<typeof vi.spyOn>>;
+
+beforeEach(() => {
+  __resetElectronStub();
+  // Persistence guard: minting must not touch the filesystem through the
+  // usual write surfaces (verified viable on node:fs / fs.promises here).
+  writeSync = vi.spyOn(fs, 'writeFileSync');
+  appendSync = vi.spyOn(fs, 'appendFileSync');
+  writeAsync = vi.spyOn(fs.promises, 'writeFile');
+  // Logging guard: no console method may receive the token.
+  consoleSpies = new Map(
+    (['log', 'info', 'warn', 'error', 'debug'] as const).map((m) => [m, vi.spyOn(console, m).mockImplementation(() => {})]),
+  );
+});
+
+afterEach(() => {
+  writeSync.mockRestore();
+  appendSync.mockRestore();
+  writeAsync.mockRestore();
+  for (const s of consoleSpies.values()) s.mockRestore();
+});
+
+/** Flattened string rendering of every argument every console spy received. */
+function consoleOutput(): string {
+  let all = '';
+  for (const s of consoleSpies.values()) {
+    for (const call of s.mock.calls) all += call.map((a) => String(a)).join(' ') + '\n';
+  }
+  return all;
+}
+
+describe('C5 token lifecycle (AC7)', () => {
+  it('mints a 64-char lowercase hex token (crypto.randomBytes(32).toString("hex"))', () => {
+    const token = mintLaunchToken();
+    expect(token).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('mints a UNIQUE token on every call (fresh per launch, unguessable)', () => {
+    const mints = new Set<string>();
+    for (let i = 0; i < 8; i++) mints.add(mintLaunchToken());
+    expect(mints.size, '8 mints must produce 8 distinct tokens').toBe(8);
+  });
+
+  it('never persists the token: no fs write surface is called during a mint', () => {
+    const token = mintLaunchToken();
+    expect(writeSync).not.toHaveBeenCalled();
+    expect(appendSync).not.toHaveBeenCalled();
+    expect(writeAsync).not.toHaveBeenCalled();
+    // Belt-and-braces: even if some write fired, the token must not be in it.
+    for (const spy of [writeSync, appendSync, writeAsync]) {
+      for (const call of spy.mock.calls) {
+        expect(call.some((a) => String(a).includes(token))).toBe(false);
+      }
+    }
+  });
+
+  it('never logs the token: no console method receives it during a mint', () => {
+    const token = mintLaunchToken();
+    expect(consoleOutput()).not.toContain(token);
+  });
+});

--- a/desktop/src/__tests__/b2-token-storage.test.ts
+++ b/desktop/src/__tests__/b2-token-storage.test.ts
@@ -1,0 +1,44 @@
+// Token-storage structural guard, ported into vitest so it runs in CI's
+// `npm --prefix desktop test` (the driver-side grep in desktop/repro/check-b2.sh
+// runs the same two patterns but only on explicit `check-b2.sh token-bridge`
+// invocations). Invariant (issue #60, AC3): the desktop transport token is
+// never parked in web storage and never delivered via a URL parameter.
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+// desktop/src/__tests__ -> desktop -> repo root
+const ROOT = path.resolve(here, '..', '..', '..');
+const SCAN_DIRS = [path.join(ROOT, 'desktop', 'main'), path.join(ROOT, 'desktop', 'preload')];
+
+/** Recursively list .ts files under a directory (node_modules never appears there). */
+function tsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...tsFiles(full));
+    else if (entry.endsWith('.ts')) out.push(full);
+  }
+  return out;
+}
+
+const STORAGE_USAGE = /(localStorage|sessionStorage)\s*(\.|\[)/;
+const URL_PARAM_TOKEN = /[?&#]token=/;
+
+describe('AC3 structural guard: token never in web storage or URL params', () => {
+  it('desktop/main + desktop/preload contain zero storage-API usage shapes', () => {
+    for (const file of SCAN_DIRS.flatMap((d) => tsFiles(d))) {
+      const source = readFileSync(file, 'utf8');
+      expect(STORAGE_USAGE.test(source), `${file} must not touch localStorage/sessionStorage`).toBe(false);
+    }
+  });
+
+  it('desktop/main + desktop/preload contain zero token-as-URL-parameter patterns', () => {
+    for (const file of SCAN_DIRS.flatMap((d) => tsFiles(d))) {
+      const source = readFileSync(file, 'utf8');
+      expect(URL_PARAM_TOKEN.test(source), `${file} must not deliver a token via URL parameter`).toBe(false);
+    }
+  });
+});

--- a/desktop/src/__tests__/secure-defaults.test.ts
+++ b/desktop/src/__tests__/secure-defaults.test.ts
@@ -71,18 +71,24 @@ describe('AC3 secure defaults', () => {
     expect(win.loadFile).not.toHaveBeenCalled();
   });
 
-  it('preload exposes exactly one namespace, `trainingapp`, with a plain-object API', async () => {
+  it('preload exposes the legacy `trainingapp` namespace and the B2 `desktopApi` token bridge', async () => {
     // Imported dynamically here so the module's contextBridge side effect runs
     // AFTER the beforeEach stub reset (the ESM registry caches it; vitest
     // isolates registries per test file, so it fires exactly once for this spec).
+    // Issue #60 (B2) extended the B1 single-namespace contract: `desktopApi`
+    // carries the per-launch token bridge; `trainingapp` stays for compat.
     await import('../../preload/index');
-    expect(contextBridge.exposeInMainWorld).toHaveBeenCalledTimes(1);
-    const [name, api] = contextBridge.exposeInMainWorld.mock.calls[0] as [
+    const calls = contextBridge.exposeInMainWorld.mock.calls as unknown as [
       string,
-      unknown,
-    ];
-    expect(name).toBe('trainingapp');
-    expect(api).toBeTypeOf('object');
-    expect(api).not.toBeNull();
+      Record<string, unknown>,
+    ][];
+    const trainingapp = calls.find(([name]) => name === 'trainingapp');
+    const desktopApi = calls.find(([name]) => name === 'desktopApi');
+    expect(trainingapp, 'legacy trainingapp namespace must remain exposed').toBeDefined();
+    expect(trainingapp?.[1]).toBeTypeOf('object');
+    expect(trainingapp?.[1]).not.toBeNull();
+    expect(desktopApi, 'desktopApi token-bridge namespace must be exposed').toBeDefined();
+    expect(desktopApi?.[1]).toBeTypeOf('object');
+    expect(typeof desktopApi?.[1].getAuthToken, 'desktopApi.getAuthToken must be a function').toBe('function');
   });
 });

--- a/desktop/test/electron-stub.ts
+++ b/desktop/test/electron-stub.ts
@@ -1,8 +1,9 @@
-// In-memory Electron stub for the issue #59 acceptance checks.
+// In-memory Electron stub for the issue #59/#60 acceptance checks.
 // desktop/vitest.config.ts aliases the bare specifier 'electron' to this file,
 // so neither the specs nor the production seams under test need the real
 // Electron binary. The stub mirrors the small surface the seams are allowed to
-// touch: app, BrowserWindow, protocol, contextBridge, ipcRenderer, shell.
+// touch: app, BrowserWindow, protocol, contextBridge, ipcRenderer, ipcMain,
+// shell.
 //
 // Test-driving notes:
 // - `app.on` both records the call (vi.fn) and really registers on an internal
@@ -11,6 +12,14 @@
 //   live instances via the static `getAllWindows()`.
 // - `BrowserWindow.prototype.isMinimized` returns true so implementations that
 //   restore only when minimized still call `restore()` in the AC4 spec.
+// - `app.isPackaged` is a PLAIN MUTABLE BOOLEAN like the real Electron property
+//   (issue #60 / AC8 specs assign `app.isPackaged = true` directly); a vi.fn
+//   would read truthy-by-default and mislead production `if (app.isPackaged)`
+//   checks.
+// - `ipcMain.handle` is a vi.fn so the token-IPC registration test can assert
+//   what channel got registered and rewire it.
+// - `BrowserWindow.setWindowOpenHandler` is a vi.fn capturing the handler so
+//   navigation-lockdown specs can invoke it and check the deny decision.
 // - Call `__resetElectronStub()` from beforeEach in every spec.
 import { EventEmitter } from 'node:events';
 import { vi } from 'vitest';
@@ -32,6 +41,8 @@ export const app = {
   isReady: vi.fn((): boolean => true),
   getPath: vi.fn((_name: string): string => process.cwd()),
   getAppPath: vi.fn((): string => process.cwd()),
+  // Plain boolean, NOT a vi.fn (see file header). Mutate directly in specs.
+  isPackaged: false as boolean,
 };
 
 export class BrowserWindow {
@@ -55,11 +66,24 @@ export class BrowserWindow {
   show = vi.fn();
   hide = vi.fn();
   close = vi.fn();
+  // Captures the window.open policy handler (issue #60 / AC4): specs invoke
+  // the captured fn with mock details and assert the deny decision. KEPT for
+  // stub-shape compat; the REAL Electron surface is webContents-level (below)
+  // — win.setWindowOpenHandler is undefined at runtime in Electron 44
+  // (probe-verified 2026-09-08; CHECK_WRONG amendment on b2-navigation-lockdown).
+  setWindowOpenHandler = vi.fn();
   destroy = vi.fn(() => {
     const i = BrowserWindow.windows.indexOf(this);
     if (i >= 0) BrowserWindow.windows.splice(i, 1);
   });
-  webContents = { on: vi.fn(), send: vi.fn() };
+  webContents = {
+    on: vi.fn(),
+    send: vi.fn(),
+    // The REAL surface for the window-open policy handler (Electron >= 12,
+    // incl. 44): production code registers it here, and the
+    // b2-navigation-lockdown spec extracts it from this mock.
+    setWindowOpenHandler: vi.fn(),
+  };
   constructor(opts?: { webPreferences?: Record<string, unknown> }) {
     this.webPreferences = opts?.webPreferences;
     BrowserWindow.windows.push(this);
@@ -87,6 +111,13 @@ export const ipcRenderer = {
   removeListener: vi.fn(),
 };
 
+export const ipcMain = {
+  handle: vi.fn(),
+  on: vi.fn(),
+  once: vi.fn(),
+  removeHandler: vi.fn(),
+};
+
 export const shell = {
   openExternal: vi.fn(),
 };
@@ -98,9 +129,19 @@ export function __resetElectronStub(): void {
   app.quit.mockClear();
   app.on.mockClear();
   app.once.mockClear();
+  app.isPackaged = false;
   emitter.removeAllListeners();
   BrowserWindow.windows.length = 0;
   protocol.handle.mockClear();
   protocol.registerSchemesAsPrivileged.mockClear();
   contextBridge.exposeInMainWorld.mockClear();
+  ipcRenderer.on.mockClear();
+  ipcRenderer.once.mockClear();
+  ipcRenderer.send.mockClear();
+  ipcRenderer.invoke.mockClear();
+  ipcRenderer.removeListener.mockClear();
+  ipcMain.handle.mockClear();
+  ipcMain.on.mockClear();
+  ipcMain.once.mockClear();
+  ipcMain.removeHandler.mockClear();
 }

--- a/docs/security/desktop.md
+++ b/docs/security/desktop.md
@@ -88,12 +88,22 @@ When the backend host lands (#61, per ADR-0003), it MUST:
 2. Mount `getLoopbackGuard()` (constructed at bootstrap and surfaced by
    `desktop/main/security/index.ts`) in front of EVERY request route, before
    any backend logic: `const verdict = guard(req); if (verdict) return verdict;`
-3. Read the header name from `resolveSecurityConfig().tokenHeaderName`
+3. **Adapt the request shape correctly.** The guard requires:
+   - `url` as an ABSOLUTE URL — a Node `http.IncomingMessage.url` is a bare
+     path and fails closed (403); build it explicitly, e.g.
+     `url: \`http://127.0.0.1:${port}${req.url}\``.
+   - Case-insensitive header lookup. Real `fetch`/`Headers` fold case; a
+     hand-rolled adapter must too (or lowercase names before lookup) — the
+     guard folds names itself as defense-in-depth, but do not rely on that.
+   - `method` (optional, reserved for #61): a CORS-preflight `OPTIONS` may be
+     answered by the adapter, but ONLY after the guard's origin/host gates
+     pass — never exempt preflight requests before the guard.
+4. Read the token header name from `resolveSecurityConfig().tokenHeaderName`
    (default `X-Desktop-Token`) — do not hard-code it, and do not switch the
    desktop transport to `Authorization: Bearer` (the web_ui ApiClient reserves
    that header for its server-mode JWT flow; B9 renders the desktop token via
    the `desktopApi.getAuthToken()` bridge instead of `auth.ts` storage).
-4. Never log the token, the raw `Authorization`-equivalent header, or full
+5. Never log the token, the raw `Authorization`-equivalent header, or full
    request URLs at info level.
 
 The bootstrap fails fast (`app.quit()`) if the guard was not constructed, so

--- a/docs/security/desktop.md
+++ b/docs/security/desktop.md
@@ -1,0 +1,108 @@
+# Desktop Security: Threat Model and Transport Contract (issue #60)
+
+Scope: the Electron desktop shell under `desktop/` — the `app://` renderer
+surface and the loopback API transport. Python-side server hardening is
+covered by `docs/security_hardening_guide.md`; renderer feature work is B9
+(#67); the backend host itself is B3 (#61).
+
+## Architecture invariants
+
+1. **The renderer is untrusted input to the main process.** It runs
+   third-party-influenced bundles (model runtimes, app code) inside
+   `contextIsolation: true`, `sandbox: true`, `nodeIntegration: false`,
+   `webviewTag: false` (pinned by `desktop/src/__tests__/secure-defaults.test.ts`).
+   Everything below assumes a compromised or malicious renderer must not be
+   able to reach the backend, navigate the shell, or escalate out of its
+   sandbox.
+2. **Every transport seam threads the security barrel.** All security
+   primitives live in `desktop/main/security/` (`config`, `token`,
+   `loopback-guard`, `csp`) and are consumed via the barrel
+   (`desktop/main/security/index.ts`). New seams must reuse them, not roll
+   their own policy. Enforced by the frozen B2 regression family
+   (`desktop/src/__tests__/b2-*.test.ts` + `desktop/repro/check-b2.sh`).
+3. **Loopback-only transport.** The backend that B3 hosts binds
+   `127.0.0.1` on a random free port. The Python server's own default is
+   loopback with explicit `API_HOST=0.0.0.0` opt-in (`api_server.py`),
+   but its auth is off by default (`auth.py` `ENABLE_AUTH=false`) — which is
+   exactly why the desktop transport carries its own token gate: **a loopback
+   port is reachable by every local process**, so origin+token enforcement
+   must not depend on the backend's own auth settings. This guard sits in
+   front of the B3 backend regardless of which side of ADR-0003 (#57) wins
+   (Node main or Electron-hosted Python sidecar).
+
+## Threats and mitigations
+
+### Token theft
+- **Threat:** any renderer script (or anything that can read renderer
+  storage/history) learns the transport token.
+- **Mitigations:**
+  - The token is `crypto.randomBytes(32)` hex, minted once per launch in the
+    main process (`desktop/main/security/token.ts`), held in main-process
+    memory only. It is never written to disk (fs-write spies in
+    `b2-token-lifecycle.test.ts`) and never logged (console spies, and
+    rejection bodies are static strings that never echo it).
+  - The renderer receives it ONLY through
+    `contextBridge.exposeInMainWorld('desktopApi', { getAuthToken })` ->
+    `ipcRenderer.invoke('desktop:get-token')`. It never touches
+    localStorage/sessionStorage and never travels in a URL (structurally
+    enforced by the `token-bridge` greps in `desktop/repro/check-b2.sh`).
+  - Rejection responses are static; no reflection of request material.
+
+### Malicious renderer content
+- **Threat:** injected markup/script in the packaged web_ui bundle escalates
+  beyond the renderer (phishing navigation, exfiltration, arbitrary JS).
+- **Mitigations:**
+  - Strict CSP on every `app://` response (success AND errors, `protocol.ts`):
+    `script-src 'self' app: 'wasm-unsafe-eval' 'sha256-<pin>'` — arbitrary
+    inline scripts and eval are blocked; the single legitimate inline script
+    (theme bootstrap in `web_ui/index.html`) is hash-pinned, and the pin is
+    CI-verified against the tracked file (`b2-csp-pin.test.ts`). Relaxations
+    and their consumers are documented inline in `desktop/main/security/csp.ts`.
+  - Navigation lockdown (`main/index.ts`): `will-navigate` denies everything
+    except `app://` (plus the dev-server origin in dev mode);
+    `setWindowOpenHandler` denies every `window.open` (C3 spec).
+  - COOP/COEP/CORP on every response (same discipline as `start.ps1`), which
+    also enables cross-origin isolation for multithreaded WASM.
+
+### LAN exposure
+- **Threat:** the backend (or the transport) is reachable from other machines.
+- **Mitigations:** the backend binds literal loopback only (B3 contract);
+  the guard's Host gate accepts only `127.0.0.1` / `[::1]` literals — the
+  name `localhost` and LAN/private IPs are rejected even with a valid token
+  (DNS-rebinding hardening, R3 in `loopback-guard.ts`). Wrong origin
+  (`Origin` outside `security.allowedOrigins`, default `["app://*"]`,
+  including `Origin: null` and subdomain tricks) is rejected 403 BEFORE the
+  token is checked.
+
+### Token replay across restarts
+- **Threat:** a token captured in session N is replayed in session N+1.
+- **Mitigations:** the token dies with the process — every launch mints a
+  fresh one (uniqueness pinned by `b2-token-lifecycle.test.ts`), nothing
+  persists it, so a replayed stale token fails the equality check (401).
+
+## B3 integration contract (binding, not advisory)
+
+When the backend host lands (#61, per ADR-0003), it MUST:
+
+1. Bind `127.0.0.1` on a **random free port** (ask the OS, do not hard-code).
+2. Mount `getLoopbackGuard()` (constructed at bootstrap and surfaced by
+   `desktop/main/security/index.ts`) in front of EVERY request route, before
+   any backend logic: `const verdict = guard(req); if (verdict) return verdict;`
+3. Read the header name from `resolveSecurityConfig().tokenHeaderName`
+   (default `X-Desktop-Token`) — do not hard-code it, and do not switch the
+   desktop transport to `Authorization: Bearer` (the web_ui ApiClient reserves
+   that header for its server-mode JWT flow; B9 renders the desktop token via
+   the `desktopApi.getAuthToken()` bridge instead of `auth.ts` storage).
+4. Never log the token, the raw `Authorization`-equivalent header, or full
+   request URLs at info level.
+
+The bootstrap fails fast (`app.quit()`) if the guard was not constructed, so
+a regression that drops the initialization cannot ship silently.
+
+## Known limits (explicit, not silent)
+
+- Rate limiting beyond origin+token and TLS are out of scope for B2 per the
+  issue (loopback-only traffic never leaves the machine).
+- The manual verification transcript for this issue was produced against a
+  local launch of the real guard (see the PR body); the packaged-app run on
+  the reference laptop is an E3 (#86) validation-matrix item.


### PR DESCRIPTION
Closes #60

## Root Cause

The Electron desktop shell shipped by Workstream B1 (PR #95) deliberately deferred all transport hardening to B2 (`desktop/main/index.ts:6-8`, `desktop/main/protocol.ts:9-10`, `desktop/README.md:50-66`): `app://` responses carried no CSP (and no COOP/COEP/CORP), the window had no `will-navigate`/`window.open` lockdown, the preload exposed no token bridge, and no request gate existed in front of the future loopback backend — while `auth.py:25` still defaults `ENABLE_AUTH=false`, meaning an unguarded loopback port would be callable by any local process. This PR builds that missing layer (Workstream B2).

## Fix

Minimal layer at the right trust boundary (the main process; the renderer is untrusted input):

- `desktop/main/security/` (new): `config.ts` (`security.tokenHeaderName` default `X-Desktop-Token`, `security.allowedOrigins` default `["app://*"]`; dev-only origin additions require `!app.isPackaged` AND an explicit `TRAININGAPP_DESKTOP_DEV_ORIGINS` env opt-in, so packaged builds categorically cannot gain origins); `token.ts` (per-launch `crypto.randomBytes(32).toString('hex')`, main-process memory only, never persisted/logged); `loopback-guard.ts` (backend-agnostic request gate: origin allow-list incl. `Origin: null`/empty and subdomain tricks rejected 403 regardless of token, literal-loopback-only Host gate — `localhost` names and LAN IPs rejected as DNS-rebinding hardening — then token equality check with static 401 bodies that never echo the token); `csp.ts` (strict CSP with inline-documented relaxations: `'wasm-unsafe-eval'` for ONNX/wllama, a sha256 pin for the ONE legitimate inline theme-bootstrap script, `worker-src blob:` for ORT threading, loopback `connect-src`); `index.ts` barrel + per-launch guard holder.
- `desktop/main/index.ts`: navigation lockdown (`will-navigate` allows `app://` only — plus the dev-server origin in dev mode; `webContents.setWindowOpenHandler` denies every `window.open`; note this is the only surface that exists at runtime in Electron 44 — probe-verified), and `bootstrap()` wires config → token → `ipcMain.handle('desktop:get-token')` → guard construction with a fail-fast `app.quit()` if the guard was not constructed.
- `desktop/main/protocol.ts`: every `app://` response (success, 403, 404) carries CSP + COOP/COEP/CORP — the "every response, including errors" discipline of `web_ui/scripts/start.ps1`; COOP/COEP also enable `crossOriginIsolated` so ONNX can use `numThreads > 1` under `app://`.
- `desktop/preload/index.ts`: additive `contextBridge.exposeInMainWorld('desktopApi', { getAuthToken: () => ipcRenderer.invoke('desktop:get-token') })`; the legacy `trainingapp` namespace is unchanged; preload stays CommonJS (`.cjs`, sandboxed-renderer requirement, guarded by `verify-preload-format.mjs`).
- `docs/security/desktop.md` (new): threat model (token theft, malicious renderer content, LAN exposure, token replay across restarts) and the **binding B3 integration contract**: #61's backend MUST bind `127.0.0.1` on a random free port, MUST mount `getLoopbackGuard()` in front of every route before backend logic, MUST read the header name from config, MUST NOT log the token. This is the issue's own ownership split, enforced by the fail-fast bootstrap assertion — not silent deferral.
- `.gitattributes`: `web_ui/index.html` pinned to LF so the CSP sha256 pin is identical on every checkout (the pin would otherwise be autocrlf-dependent).
- `web_ui/` itself: byte-zero diff (B9/#67 owns renderer consumption; the `ApiClient('')` constructor is untouched as the issue requires).

Reviewer wiring note (for anyone checking): the new `desktop/main/security/*.ts` files need no tsconfig/CI changes — the existing `tsconfig.json` include `main/**/*.ts` compiles them and `desktop-build.yml`'s existing `npm --prefix desktop test` picks up the new specs.

## Recurrence Prevention (defect class)

- Defect class: a new transport/process seam ships without its trust-boundary enforcement (no origin allow-list, no auth gate, no CSP, no navigation lockdown).
- Sweep result: 11 hits across 7 predicates (window-open surfaces, navigation policy, exposed bridges, response construction, bind addresses, token storage, webPreferences coverage) — every hit dispositioned as the enforcement itself, test infrastructure, or a documented out-of-class surface (browser-mode JWT in `web_ui/src/lib/api/auth.ts` is a different token for a different transport; relationship documented in `docs/security/desktop.md`).
- Guardrail: regression family — 7 frozen acceptance specs + `desktop/repro/check-b2.sh` run in CI via the existing `desktop-build.yml` test step — plus the documented "every seam threads the security barrel" invariant. Demonstrated to bite with three mutation probes (nav allow-list neutered → `FAIL navigation-lockdown`; `wasm-unsafe-eval` dropped → `FAIL csp`; token check neutered → `FAIL loopback-guard`; each restored → PASS) and by the frozen red checkpoint (base logs show every check RED/ERROR at 8af74d4).

## Tests

- Regression test: `npm --prefix desktop test` → 15 files / 94 tests PASS (B1 files unchanged except the intentional two-namespace preload contract update in `secure-defaults.test.ts`; 7 frozen B2 specs + feedback-round additive specs: guard edge cases, CI-enforced token-storage greps, security-header pinning, pin-drift guard).
- Acceptance checks (issue-tracer red checkpoint): all 7 ids `DESKTOP-60 CHECK: PASS` via `repro-check.sh run` — base 8af74d4 RED/ERROR for the expected reason, head 6139555 GREEN; `verify-checkpoint` OK on all 9 manifest paths.
- Lint/type/build/security checks: `npm --prefix desktop run compile` → PASS; `node desktop/scripts/verify-preload-format.mjs` → OK; real-Electron runtime smoke `electron scripts/preload-runtime-smoke.cjs` → OK (exit 0); manual verification transcript against the COMPILED guard over real loopback HTTP → 10/10 cases as expected (missing/empty/wrong token → 401; wrong/null origin, localhost-name, LAN-IP hosts → 403 even with a valid token; valid origin+token → backend).
- Deferred-work scan: clean (no TODO/FIXME/stub markers on added lines).

## Regression Protection

- `desktop/src/__tests__/b2-loopback-guard.test.ts` (15) + `b2-loopback-origin.test.ts` (8): every rejection path couples the status assertion with `delegate not called` (backend isolation); pass-through positive controls included.
- `b2-csp.test.ts` (4): CSP on 200/403/404 + a negative control proving the strictness parser rejects permissive policies.
- `b2-token-lifecycle.test.ts` (4): fs-write and console spies; 64-hex format; per-mint uniqueness.
- `b2-security-config.test.ts` (6): defaults + packaged-refusal matrix.
- `b2-csp-pin.test.ts` (2): CSP pin vs the tracked `web_ui/index.html` inline script hash (drift fails CI) + never-unsafe-inline.
- `b2-token-bridge.test.ts` (3): bridge shape + IPC routing + legacy namespace compat.
- Test drift review: `secure-defaults.test.ts` single-namespace assertion updated to the two-namespace contract — intentional, AC-driven, both shapes still pinned (judged "not a weakening" by the independent implementation review).

## Acceptance Criteria -> Evidence

| Acceptance criterion (from intake) | Evidence (command + output, or test name) |
|---|---|
| AC1 missing token rejected before backend logic | C1 `loopback-guard` PASS; manual transcript: missing/empty/wrong token → 401, delegate untouched |
| AC2 wrong origin rejected regardless of token | C7 `loopback-origin` PASS (evil.example/'null'/subdomain/LAN/localhost-name with valid token → 403); mutation probe bites |
| AC3 token only via contextBridge/IPC; never storage/URL | C2 `token-bridge` PASS + driver structural greps (zero hits) + C5 fs/console spies |
| AC4 external navigation blocked | C3 `navigation-lockdown` PASS (will-navigate app://-only; window.open denied for every URL) |
| AC5 strict CSP on every response incl. errors; injection blocked | C4 `csp` PASS (200/403/404; negative control); pin-drift guard + built-dist pin check; relaxations documented inline in `csp.ts`. The issue's "Manual DevTools check" half is superseded by the automated header/injection assertions (same evidence a DevTools inspection would show) — packaged verification on the reference laptop is the E3/#86 residual |
| AC6 threat model documented | `docs/security/desktop.md` (four issue-named threats + B3 contract) |
| AC7 token lifecycle (randomBytes(32) hex, memory-only, never persisted/logged) | C5 `token-lifecycle` PASS; `token.ts` |
| AC8 config keys + packaged-build origin gate | C6 `security-config` PASS (defaults; packaged+env-opt-in refused) |

## Invariant Audit

No formal invariants/architecture-contract doc exists in the repo ("none documented"); the desktop-local contract (`desktop/README.md` security posture + `ARCHITECTURE.md` has no invariant section) was audited instead:

- B1 secure defaults (`contextIsolation`/`sandbox`/`nodeIntegration`/`webviewTag`): not touched — still pinned by `secure-defaults.test.ts` (negative-control spec) — 4/4 pass.
- Single-instance + bootstrap wiring order: not touched — `review-hardening.test.ts` 7/7, `single-instance.test.ts` 4/4.
- `app://` path-traversal safety: not touched (header wrapping only) — `app-protocol.test.ts` 18/18.
- Preload CommonJS/sandbox constraint (PRR95-001): preserved — `verify-preload-format.mjs` OK + real-Electron runtime smoke OK.
- Minimal default set: build OK (compile), typecheck OK (tsc via compile), tests 79/79, no generated artifacts staged (`desktop/dist` and `renderer/` are gitignored), push-protection secret scan clean.

## Risk and Rollback

- Risk level: low (additive main-process layer; renderer byte-zero; no schema/API/persistence change). Residual: if the strict CSP blocks an undocumented renderer capability, the documented fallback is a conscious `csp.ts` policy edit (pin-drift test will point at it); COOP/COEP assume the fully self-hosted renderer (no cross-origin subresources exist).
- Rollback: single-commit revert (`git revert 6139555`); no migrations or config state.

## Waivers (or none)

none

## Merge status

Awaiting explicit user approval; not merged.

PR head: 6139555d9db7b1747ae37324b7330515731ed32c

## Issue Closure

Closes #60

## Feedback round (post-review fixes)

A swarm-pr-review pass (6 base lanes + 11 micro risk families) plus an independent 5-lane PR review produced findings resolved in commit c004204: B3 adapter contract corrections (absolute-URL requirement, case-insensitive headers, reserved `method`/preflight-after-gates), IPv6 and edge-case guard tests, COOP/COEP/CORP header pinning, built-dist CSP pin check (which caught a stale CRLF dist immediately), token-storage greps ported into CI vitest, test-reset hooks, and README corrections. Full closure ledger: `.zcode/pr-review/pr96-review-20260908/closure-ledger.md` (in-repo working notes; 11 rejected candidates listed with reasons). Independent reviewer and final critic both APPROVE the fix diff at c004204.
