### PR TITLE
feat(desktop): B7 hybrid retrieval with RRF fusion, worker-thread reranking, and eval parity (issue #65)

### DIFF
--- a/bench/RESULTS.md
+++ b/bench/RESULTS.md
@@ -229,3 +229,20 @@ synthetic N-page PDF generated in-process. Budget: 200 pages in < 60 s
 | machine | model | pages | chunks | total_s | embeddings_per_second | outcome |
 |---|---|---|---|---|---|---|
 | devstation | bge-small-en-v1.5 | 200 | 200 | 7.7 | 26 | pass |
+
+## Desktop retrieval (B7)
+
+Hybrid desktop retrieval (issue #65): sqlite-vec KNN leg + FTS5 BM25 leg ->
+reciprocal-rank fusion (k=60) -> ettin-reranker-32m-v1 cross-encoder over the
+fused top-30 in the rerank worker thread, measured by
+`bench/retrieval_bench_driver.mjs`: boot the compiled desktop host with real
+weights, ingest the 8-doc eval corpus over /ingest, then 20 sequential timed
+POST /search round trips over the in-corpus eval questions (loopback HTTP, so
+each sample is the full stack: query embed -> vec0 + FTS5 legs -> RRF fuse ->
+rerank -> floor/slice; the cold first query — reranker worker spawn + model
+load — is part of the measured distribution). Budget: p95 <= 1500 ms
+(issue #65 acceptance).
+
+| machine | embedder | reranker | topk | multiplier | p50_ms | p95_ms | max_ms | outcome |
+|---|---|---|---|---|---|---|---|---|
+| devstation | bge-small-en-v1.5 | ettin-reranker-32m-v1 | 10 | 3 | 364 | 426 | 691 | pass |

--- a/bench/append_results.py
+++ b/bench/append_results.py
@@ -37,6 +37,7 @@ SECTION_HEADINGS = {
     "onnx-embed": "## ONNX embed/rerank cost",
     "onnx-rerank": "## ONNX embed/rerank cost",
     "desktop-ingest": "## Desktop ingest (B6)",
+    "desktop-retrieval": "## Desktop retrieval (B7)",
 }
 
 # surface -> header cells of the table that accepts the surface's rows. The
@@ -75,6 +76,17 @@ HEADER_CELLS = {
         "chunks",
         "total_s",
         "embeddings_per_second",
+        "outcome",
+    ],
+    "desktop-retrieval": [
+        "machine",
+        "embedder",
+        "reranker",
+        "topk",
+        "multiplier",
+        "p50_ms",
+        "p95_ms",
+        "max_ms",
         "outcome",
     ],
 }
@@ -123,6 +135,17 @@ REQUIRED_KEYS = {
         "total_s",
         "outcome",
     ),
+    "desktop-retrieval": (
+        "surface",
+        "machine",
+        "embedder",
+        "reranker",
+        "topk",
+        "multiplier",
+        "p50_ms",
+        "p95_ms",
+        "outcome",
+    ),
 }
 
 # Provenance keys every row (pass or fail) must carry.
@@ -139,6 +162,13 @@ IDENTITY_CELLS = {
     "onnx-embed": (0, 1),  # machine, model
     "onnx-rerank": (0, 1),  # machine, model
     "desktop-ingest": (0, 1),  # machine, model (mirrors onnx-embed)
+    "desktop-retrieval": (
+        0,
+        1,
+        2,
+        3,
+        4,
+    ),  # machine, embedder, reranker, topk, multiplier
 }
 
 REGISTRY_HEADING = "## Machine registry"
@@ -180,6 +210,18 @@ def row_cells(row: dict) -> list:
             row.get("model", ""),
             fmt(row.get("top15_ms")),
             fmt(row.get("top30_ms")),
+            row.get("outcome", ""),
+        ]
+    if row.get("surface") == "desktop-retrieval":
+        cells = [
+            row.get("machine", ""),
+            row.get("embedder", ""),
+            row.get("reranker", ""),
+            fmt(row.get("topk")),
+            fmt(row.get("multiplier")),
+            fmt(row.get("p50_ms")),
+            fmt(row.get("p95_ms")),
+            fmt(row.get("max_ms")),
             row.get("outcome", ""),
         ]
     elif row.get("surface") == "desktop-ingest":

--- a/bench/retrieval_bench_driver.mjs
+++ b/bench/retrieval_bench_driver.mjs
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+// B7 bench driver (issue #65): measure the SHIPPING desktop hybrid retrieval
+// pipeline end-to-end — boot the compiled desktop host (real bge-small embed +
+// ettin-reranker-32m-v1 rerank in the worker thread), ingest eval/corpus over
+// /ingest, then time sequential POST /search round trips over the in-corpus
+// eval questions and emit one JSON row compatible with
+// `bench/append_results.py` (surface=desktop-retrieval). Timings are full
+// round trips over loopback HTTP, so they include the whole stack: query
+// embed -> vec0 KNN + FTS5 legs -> RRF fuse -> rerank top-30 -> floor/slice.
+// The first (cold) query — reranker worker spawn + model load — is part of
+// the measured distribution, matching real interactive usage.
+//
+// Requires: `npm --prefix desktop run compile` and staged weights
+// (models/bge-small-en-v1.5 required; models/ettin-reranker-32m-v1 optional —
+// without it the row records reranker=none and the budget still applies).
+//
+// Usage (from repo root):
+//   node bench/retrieval_bench_driver.mjs --queries 20 [--json row.json]
+// Machine tag: BENCH_MACHINE_TAG env (default devstation).
+import fs from 'node:fs';
+import path from 'node:path';
+import { performance } from 'node:perf_hooks';
+import { pathToFileURL, fileURLToPath } from 'node:url';
+import { spawn, spawnSync } from 'node:child_process';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const IS_WIN = process.platform === 'win32';
+const P95_BUDGET_MS = 1500;
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    switch (argv[i]) {
+      case '--queries': args.queries = Number.parseInt(argv[++i], 10); break;
+      case '--json': args.json = argv[++i]; break;
+      default: throw new Error(`unknown argument: ${argv[i]}`);
+    }
+  }
+  if (!Number.isInteger(args.queries) || args.queries < 1) {
+    throw new Error('--queries is required and must be a positive integer');
+  }
+  return args;
+}
+
+function percentile(values, pct) {
+  const ordered = [...values].sort((a, b) => a - b);
+  if (ordered.length === 1) return ordered[0];
+  const pos = ((ordered.length - 1) * pct) / 100;
+  const low = Math.floor(pos);
+  const high = Math.min(low + 1, ordered.length - 1);
+  const frac = pos - low;
+  return ordered[low] * (1 - frac) + ordered[high] * frac;
+}
+
+function loadInCorpusQuestions() {
+  const raw = fs.readFileSync(path.join(repoRoot, 'eval', 'questions.jsonl'), 'utf8');
+  const rows = [];
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const row = JSON.parse(trimmed);
+    if (row.expected_doc_id !== null && row.expected_doc_id !== undefined) rows.push(row);
+  }
+  return rows;
+}
+
+const children = [];
+function killChildren() {
+  for (const child of children.splice(0).reverse()) {
+    try { child.kill(); } catch { /* gone */ }
+    if (IS_WIN && child.pid && child.exitCode === null) {
+      try { spawnSync('taskkill', ['/PID', String(child.pid), '/T', '/F'], { stdio: 'ignore' }); } catch { /* best effort */ }
+    }
+  }
+}
+
+function waitForPortFile(portFile, timeoutMs) {
+  const t0 = Date.now();
+  for (;;) {
+    if (fs.existsSync(portFile)) {
+      const port = Number.parseInt(fs.readFileSync(portFile, 'utf8').trim(), 10);
+      if (Number.isInteger(port) && port > 0) return port;
+    }
+    if (Date.now() - t0 > timeoutMs) throw new Error(`host did not write its port within ${timeoutMs}ms`);
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 50);
+  }
+}
+
+async function fetchJson(url, opts) {
+  const res = await fetch(url, opts);
+  return { status: res.status, body: await res.json().catch(() => null) };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  // Resolve weights the same way the host's resolvers do: explicit env first,
+  // then the repo's staged models/ dir. The embedder is REQUIRED (no staged
+  // weights means nothing to measure); the reranker is optional (row records
+  // reranker=none, retrieval degrades to RRF-only in the host under test).
+  const embedderDir =
+    process.env.TRAININGAPP_EMBEDDING_MODEL_DIR ?? path.join(repoRoot, 'models', 'bge-small-en-v1.5');
+  if (!fs.existsSync(path.join(embedderDir, 'onnx', 'model.onnx'))) {
+    throw new Error(`embedder weights not staged: ${embedderDir} (run scripts/prepare-models.mjs)`);
+  }
+  let rerankerDir = process.env.TRAININGAPP_RERANKER_MODEL_DIR ?? null;
+  if (rerankerDir === null) {
+    const candidate = path.join(repoRoot, 'models', 'ettin-reranker-32m-v1');
+    if (fs.existsSync(path.join(candidate, 'onnx', 'model.onnx'))) rerankerDir = candidate;
+  }
+
+  // The exact retrieval config the host under test will resolve (defaults or
+  // the operator's TRAININGAPP_RETRIEVAL_* overrides) — recorded in the row.
+  const configUrl = pathToFileURL(
+    path.join(repoRoot, 'desktop', 'dist', 'main', 'backend', 'retrieval', 'config.js'),
+  ).href;
+  const { resolveRetrievalConfig } = await import(configUrl);
+  const retrievalConfig = resolveRetrievalConfig(process.env);
+
+  const work = fs.mkdtempSync(path.join(process.env.TEMP ?? repoRoot, 'retrieval-bench-'));
+  try {
+    const token = `bench-${process.pid}-${Date.now()}`;
+    const portFile = path.join(work, 'port.txt');
+    const storePath = path.join(work, 'store.sqlite');
+    const env = { ...process.env };
+    env.TRAININGAPP_EMBEDDING_MODEL_DIR = embedderDir;
+    if (rerankerDir !== null) env.TRAININGAPP_RERANKER_MODEL_DIR = rerankerDir;
+    delete env.TRAININGAPP_DESKTOP_EMBEDDER;
+    delete env.TRAININGAPP_DESKTOP_ENGINE;
+    const host = spawn(
+      process.execPath,
+      [
+        path.join(repoRoot, 'desktop', 'dist', 'main', 'backend', 'dev-server.js'),
+        '--port-file', portFile,
+        '--mode', 'node',
+        '--token', token,
+        '--store-path', storePath,
+      ],
+      { cwd: repoRoot, env, stdio: ['pipe', 'inherit', 'inherit'] },
+    );
+    children.push(host);
+    const hostPort = waitForPortFile(portFile, 30000);
+    const headers = { 'content-type': 'application/json', 'x-desktop-token': token };
+    const base = `http://127.0.0.1:${hostPort}`;
+    const deadline = Date.now() + 30000;
+    for (;;) {
+      try {
+        const res = await fetch(`${base}/health`, { headers });
+        if (res.status === 200) break;
+      } catch { /* not accepting yet */ }
+      if (Date.now() > deadline) throw new Error('host did not become healthy within 30s');
+      await new Promise((r) => setTimeout(r, 100));
+    }
+
+    const ingest = await fetchJson(`${base}/ingest`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ directory: path.join(repoRoot, 'eval', 'corpus') }),
+    });
+    if (ingest.status !== 200 || !ingest.body || ingest.body.documents !== 8) {
+      throw new Error(`ingest failed status=${ingest.status} body=${JSON.stringify(ingest.body)}`);
+    }
+    console.log(
+      `[retrieval_bench_driver] ingested ${ingest.body.documents} docs / ${ingest.body.chunks_added} chunks`,
+    );
+
+    const corpusBasenames = new Set(
+      fs.readdirSync(path.join(repoRoot, 'eval', 'corpus')).filter((name) => name.endsWith('.md')),
+    );
+    const questions = loadInCorpusQuestions().slice(0, args.queries);
+    if (questions.length < args.queries) {
+      throw new Error(`only ${questions.length} in-corpus eval questions available, need ${args.queries}`);
+    }
+
+    const latencies = [];
+    for (const question of questions) {
+      const started = performance.now();
+      const res = await fetchJson(`${base}/search`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ query: question.question, n_results: 5 }),
+      });
+      const ms = performance.now() - started;
+      latencies.push(ms);
+      if (res.status !== 200 || !Array.isArray(res.body) || res.body.length < 1) {
+        throw new Error(`search failed query="${question.id}" status=${res.status}`);
+      }
+      for (const row of res.body) {
+        const source = typeof row.source === 'string' ? row.source.replace(/\\/g, '/').split('/').pop() : null;
+        if (!source || !corpusBasenames.has(source)) {
+          throw new Error(`non store-backed row query="${question.id}" source=${JSON.stringify(row.source)}`);
+        }
+      }
+    }
+
+    const p50 = percentile(latencies, 50);
+    const p95 = percentile(latencies, 95);
+    const max = Math.max(...latencies);
+    console.log(
+      `[retrieval_bench_driver] ${latencies.length} /search round trips; ` +
+        `p50=${p50.toFixed(1)}ms p95=${p95.toFixed(1)}ms max=${max.toFixed(1)}ms`,
+    );
+    const outcome = p95 <= P95_BUDGET_MS ? 'pass' : 'fail';
+    const row = {
+      surface: 'desktop-retrieval',
+      machine: process.env.BENCH_MACHINE_TAG ?? 'devstation',
+      embedder: path.basename(embedderDir),
+      reranker: rerankerDir === null ? 'none' : path.basename(rerankerDir),
+      topk: retrievalConfig.topK,
+      multiplier: retrievalConfig.candidateMultiplier,
+      p50_ms: Math.round(p50),
+      p95_ms: Math.round(p95),
+      max_ms: Math.round(max),
+      outcome,
+    };
+    const rendered = JSON.stringify(row, null, 2);
+    if (args.json) fs.writeFileSync(args.json, rendered);
+    console.log(rendered);
+    process.exitCode = outcome === 'pass' ? 0 : 1;
+  } finally {
+    killChildren();
+    try { fs.rmSync(work, { recursive: true, force: true }); } catch { /* best effort */ }
+  }
+}
+
+main().then(
+  () => {
+    // onnxruntime-node may keep the child's worker threads alive past kill;
+    // the child is force-killed above, so just make sure WE exit.
+    setTimeout(() => process.exit(process.exitCode ?? 0), 250).unref();
+  },
+  (err) => {
+    console.error(`[retrieval_bench_driver] FAILED: ${err instanceof Error ? err.message : err}`);
+    process.exitCode = 1;
+    setTimeout(() => process.exit(1), 250).unref();
+  },
+);

--- a/bench/retrieval_bench_driver.mjs
+++ b/bench/retrieval_bench_driver.mjs
@@ -87,7 +87,9 @@ function waitForPortFile(portFile, timeoutMs) {
 }
 
 async function fetchJson(url, opts) {
-  const res = await fetch(url, opts);
+  // Per-request deadline (PRR-012, PR #102 review): a hung /search must not
+  // stall the driver past this bound now that startup itself is bounded.
+  const res = await fetch(url, { ...opts, signal: AbortSignal.timeout(30000) });
   return { status: res.status, body: await res.json().catch(() => null) };
 }
 

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -233,3 +233,37 @@ Design decisions are frozen in ADR-0006 (`docs/adr/0006-profile-model.md`).
 - **`ingest:progress`**: IPC channel emitting `{docId, phase, percent}`
   (phase: extract | chunk | embed | write | done) per document; the renderer
   consumer lands with B9 (#67).
+
+## Hybrid retrieval (B7, issue #65)
+
+`POST /search` and the retrieval step inside `/ask` + `/ask/stream` run the
+hybrid pipeline in `main/backend/retrieval/`: sqlite-vec top-K UNION FTS5
+top-K -> Reciprocal Rank Fusion (1/(rrfK + rank + 1), dedup by chunk id) ->
+`recencyWeight()` hook (inert until C4/#71) -> the ettin-reranker-32m-v1
+cross-encoder over the fused window IN A DEDICATED WORKER THREAD (never the
+main/event-loop thread) -> the calibrated relevance floor (ADR-0007) -> topK.
+
+- **Config keys** (env-resolved, mirroring the browser `balanced` preset;
+  invalid values fall back per key):
+  `TRAININGAPP_RETRIEVAL_TOPK` (10), `TRAININGAPP_RETRIEVAL_CANDIDATE_MULTIPLIER`
+  (3), `TRAININGAPP_RETRIEVAL_RERANK` (true; 'true'/'1'/'false'/'0'),
+  `TRAININGAPP_RETRIEVAL_RRF_K` (60), `TRAININGAPP_RETRIEVAL_RELEVANCE_FLOOR`
+  (the calibrated ADR-0007 value; finite float in [0, 1)).
+- **Reranker weights**: staged at `models/ettin-reranker-32m-v1/onnx/`
+  (repo, or `<userData>/models`); `TRAININGAPP_RERANKER_MODEL_DIR` overrides.
+  Without weights the pipeline degrades to RRF-only ordering and the
+  relevance floor is NOT applied (it gates reranker-scale sigmoid scores
+  only). A reranker worker failure degrades that single query to the same
+  fused ordering (logged once) — `/search` never fails because of the
+  reranker.
+- **Query embedding** reuses the ingest embedder instance (single model load
+  per process): `bge-small-en-v1.5` (ADR-0006 pin, pending ADR-0001), or the
+  deterministic `TRAININGAPP_DESKTOP_EMBEDDER=hash` fixture in dev/CI.
+  Queries are embedded WITHOUT a model-card instruction prefix to stay in the
+  same vector space as the recorded parity baseline
+  (eval/samples/report-devstation-weighted.json); see ADR-0007 for the
+  re-baseline condition if that changes.
+- **Detached mode**: with no store configured (or no embedder resolvable) the
+  host attaches no retrieval surface and engines keep the B3 deterministic
+  behavior; attaching/detaching is the `attachRetrievalSurface` seam,
+  mirroring B6's document surface.

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -244,10 +244,12 @@ cross-encoder over the fused window IN A DEDICATED WORKER THREAD (never the
 main/event-loop thread) -> the calibrated relevance floor (ADR-0007) -> topK.
 
 - **Config keys** (env-resolved, mirroring the browser `balanced` preset;
-  invalid values fall back per key):
-  `TRAININGAPP_RETRIEVAL_TOPK` (10), `TRAININGAPP_RETRIEVAL_CANDIDATE_MULTIPLIER`
-  (3), `TRAININGAPP_RETRIEVAL_RERANK` (true; 'true'/'1'/'false'/'0'),
-  `TRAININGAPP_RETRIEVAL_RRF_K` (60), `TRAININGAPP_RETRIEVAL_RELEVANCE_FLOOR`
+  invalid or out-of-range values fall back per key):
+  `TRAININGAPP_RETRIEVAL_TOPK` (10, max 1000),
+  `TRAININGAPP_RETRIEVAL_CANDIDATE_MULTIPLIER`
+  (3, max 100), `TRAININGAPP_RETRIEVAL_RERANK` (true; 'true'/'1'/'false'/'0'),
+  `TRAININGAPP_RETRIEVAL_RRF_K` (60, max 10000),
+  `TRAININGAPP_RETRIEVAL_RELEVANCE_FLOOR`
   (the calibrated ADR-0007 value; finite float in [0, 1)).
 - **Reranker weights**: staged at `models/ettin-reranker-32m-v1/onnx/`
   (repo, or `<userData>/models`); `TRAININGAPP_RERANKER_MODEL_DIR` overrides.

--- a/desktop/main/backend/engine.ts
+++ b/desktop/main/backend/engine.ts
@@ -12,6 +12,7 @@ import type {
   EngineSurface,
   IngestFileInput,
   IngestResult,
+  RetrievalSurface,
 } from './types.js';
 
 // Settings defaults mirror config.py's RAGSettings field defaults so the
@@ -78,11 +79,50 @@ function delay(ms: number): Promise<void> {
 export class StubEngine implements EngineSurface {
   private settings: Record<string, number | string | boolean> = { ...DEFAULT_SETTINGS };
 
-  // STUB: real generation lands with B4 (#62). Honors a cancellation flag so
-  // client disconnects stop work, matching the frozen stream semantics.
+  /**
+   * B7 (issue #65): late-bound hybrid retrieval surface. The host attaches it
+   * after the store opens; null restores the deterministic B3 behavior (the
+   * frozen conformance/dev mode). The `desktop-stub` row literal is retained
+   * as the DETACHED-state fallback by contract.
+   */
+  private retrievalSurface: RetrievalSurface | null = null;
+
+  attachRetrievalSurface(surface: RetrievalSurface | null): void {
+    this.retrievalSurface = surface;
+  }
+
+  /**
+   * B7 (issue #65): the retrieval step shared by query() here and by
+   * LlamaEngine.query() (which retrieves before grounding its prompt).
+   * Returns null when no surface is attached or retrieval yields nothing —
+   * callers keep their pre-B7 behavior in that case.
+   */
+  async retrieveContext(
+    question: string,
+    nResults?: number,
+  ): Promise<{ sources: string[]; contextLength: number; texts: string[] } | null> {
+    if (this.retrievalSurface === null) return null;
+    const n = nResults ?? (Number(this.settings.rag_n_results) || 4);
+    const rows = await this.retrievalSurface.search(question, n);
+    if (rows.length === 0) return null;
+    const sources: string[] = [];
+    for (const row of rows) {
+      if (!sources.includes(row.source)) sources.push(row.source);
+    }
+    return {
+      sources,
+      contextLength: rows.reduce((total, row) => total + row.text.length, 0),
+      texts: rows.map((row) => row.text),
+    };
+  }
+
   async query(question: string, opts: EngineQueryOptions = {}): Promise<EngineQueryResult> {
     const started = Date.now();
     const cancellation = opts.cancellationEvent;
+    // B7 (issue #65): when a retrieval surface is attached, /ask carries real
+    // retrieval — sources and context_length come from the hybrid pipeline
+    // (rank order, deduped) instead of the empty stub values.
+    const context = await this.retrieveContext(question, opts.nResults);
     for (const token of STUB_TOKENS) {
       if (cancellation?.isSet()) {
         return { answer: '', sources: [], context_length: 0, inference_time: (Date.now() - started) / 1000, cancelled: true };
@@ -94,14 +134,19 @@ export class StubEngine implements EngineSurface {
       // STUB answer text is deliberately explicit that this is not real
       // inference yet (B4 #62); the wire shape is what B3 certifies.
       answer: 'This desktop backend is not yet backed by real inference (B4, issue #62); wiring and contract conformance only (issue #61).',
-      sources: [],
-      context_length: 0,
+      sources: context?.sources ?? [],
+      context_length: context?.contextLength ?? 0,
       inference_time: (Date.now() - started) / 1000,
     };
   }
 
-  // STUB: real hybrid retrieval is B7 (#65).
+  // B7 (issue #65): the attached hybrid retrieval surface serves /search
+  // (vec0 UNION FTS5 -> RRF -> recency hook -> optional worker reranker ->
+  // calibrated floor). Detached (null), the deterministic B3 row remains.
   async search(query: string, nResults = 5): Promise<Array<{ text: string; source: string; similarity: number }>> {
+    if (this.retrievalSurface !== null) {
+      return this.retrievalSurface.search(query, nResults);
+    }
     return [{ text: `Stub retrieval result for "${query}" (B7, issue #65).`, source: 'desktop-stub', similarity: 0.5 }];
   }
 

--- a/desktop/main/backend/index.ts
+++ b/desktop/main/backend/index.ts
@@ -20,8 +20,11 @@ import { closeStore, openStore, type StoreHandle } from './store/sqlite-store.js
 import { checkStoreIntegrity, recoverStore } from './store/recovery.js';
 import { createBackup } from './store/backup.js';
 import { StoreDocumentSurface } from './store/document-surface.js';
-import { resolveEmbedder } from './ingest/embedder.js';
+import { OnnxEmbedder, resolveEmbedder, type EmbeddingSurface } from './ingest/embedder.js';
 import { resolveIngestConfig, resolveIngestLimits } from './ingest/config.js';
+import { createRetrievalSurface, type RetrievalSurface } from './retrieval/hybrid.js';
+import { resolveRetrievalConfig } from './retrieval/config.js';
+import { resolveRerankerModelDir, WorkerEmbedder, WorkerReranker, type RerankerSurface } from './retrieval/reranker.js';
 import {
   resolveBackendMode,
   type BackendHandle,
@@ -66,6 +69,10 @@ export class NodeBackendHost implements BackendHost {
   private handle: BackendHandle | null = null;
   private store: StoreHandle | null = null;
   private surface: StoreDocumentSurface | null = null;
+  private retrieval: RetrievalSurface | null = null;
+  private reranker: RerankerSurface | null = null;
+  /** The embedder resolved for ingest — B7 reuses the SAME instance for query embedding. */
+  private embedder: EmbeddingSurface | null = null;
 
   /**
    * B6 (issue #64): snapshot the open store into <backupsDir>/<timestamp>/
@@ -122,12 +129,59 @@ export class NodeBackendHost implements BackendHost {
           this.store = await recoverOrDegradeStore(this.config, err);
         }
         if (this.store !== null) {
-          this.surface = attachStoreSurface(this.config, this.engine, this.store, {
+          const env = this.config.env ?? process.env;
+          // Resolve the embedder FIRST (null when unavailable: weights not
+          // staged, bad env) so the B7 wiring below can reuse it.
+          this.embedder = resolveEmbedder({
+            env,
+            dims: this.store.dims,
+            repoRoot: process.env.TRAININGAPP_DESKTOP_REPO_ROOT,
+          });
+          // B7 (issue #65), SINGLE-THREAD ORT OWNERSHIP: onnxruntime-node
+          // aborts the whole process when one module instance is used from
+          // two threads of one process (empirically probed 2026-09-09; trace
+          // repro/mix-probe.mjs). When real ONNX weights are staged AND
+          // reranking is enabled, the retrieval worker is created FIRST and
+          // owns ALL onnxruntime work — ingest and query embeddings are
+          // proxied to it (WorkerEmbedder) so the main thread never loads
+          // ort. The hash fixture (no ORT) stays on the main thread; with
+          // rerank disabled there is no worker and the main thread keeps its
+          // sole-threaded ORT use.
+          const retrievalConfig = resolveRetrievalConfig(env);
+          const rerankerModelDir = resolveRerankerModelDir({
+            env,
+            repoRoot: process.env.TRAININGAPP_DESKTOP_REPO_ROOT,
+          });
+          if (
+            this.embedder instanceof OnnxEmbedder &&
+            retrievalConfig.rerank &&
+            rerankerModelDir !== null
+          ) {
+            this.reranker = new WorkerReranker({
+              modelDir: rerankerModelDir,
+              embedModelDir: this.embedder.weightsDir,
+            });
+            this.embedder = new WorkerEmbedder(this.reranker as WorkerReranker, this.embedder.modelId);
+          }
+          attachStoreSurface(this.config, this.engine, this.store, this.embedder, {
             get: () => this.store,
             set: (handle: StoreHandle | null) => {
               this.store = handle;
             },
           });
+          if (this.embedder !== null) {
+            // B7: attach the hybrid retrieval surface AFTER the document
+            // surface, reusing the same (possibly worker-proxied) embedder.
+            this.retrieval = createRetrievalSurface({
+              store: this.store,
+              embedder: this.embedder,
+              reranker: this.reranker,
+              config: retrievalConfig,
+            });
+            if (typeof this.engine.attachRetrievalSurface === 'function') {
+              this.engine.attachRetrievalSurface(this.retrieval);
+            }
+          }
         }
       }
       return this.handle;
@@ -149,13 +203,25 @@ export class NodeBackendHost implements BackendHost {
       this.engine.attachDocumentSurface(null);
       this.surface = null;
     }
+    if (this.retrieval !== null && typeof this.engine.attachRetrievalSurface === 'function') {
+      this.engine.attachRetrievalSurface(null);
+      this.retrieval = null;
+    }
+    const reranker = this.reranker;
+    this.reranker = null;
     const store = this.store;
     this.store = null;
     try {
-      if (store !== null) closeStore(store);
+      if (reranker !== null && typeof (reranker as WorkerReranker).dispose === 'function') {
+        await (reranker as WorkerReranker).dispose();
+      }
     } finally {
-      // The listener must close even if the store close throws.
-      if (server !== null) await new Promise<void>((resolve) => server.close(() => resolve()));
+      try {
+        if (store !== null) closeStore(store);
+      } finally {
+        // The listener must close even if the store close throws.
+        if (server !== null) await new Promise<void>((resolve) => server.close(() => resolve()));
+      }
     }
   }
 
@@ -282,39 +348,34 @@ interface StoreAccessors {
   set: (handle: StoreHandle | null) => void;
 }
 
-/** Build the B6 document surface (embedder + pipeline) and hand it to the engine. */
+/** Build the B6 document surface (embedder + pipeline) and hand it to the engine.
+ *  The embedder is resolved (and possibly worker-proxied) by the caller so the
+ *  document and retrieval surfaces share ONE embedding source. */
 function attachStoreSurface(
   config: BackendHostConfig,
   engine: EngineSurface,
   store: StoreHandle,
+  embedder: EmbeddingSurface | null,
   accessors: StoreAccessors,
-): StoreDocumentSurface | null {
-  try {
-    const env = config.env ?? process.env;
-    const embedder = resolveEmbedder({
-      env,
-      dims: store.dims,
-      repoRoot: process.env.TRAININGAPP_DESKTOP_REPO_ROOT,
-    });
-    const surface = new StoreDocumentSurface({
-      getStore: accessors.get,
-      setStore: accessors.set,
-      embedder,
-      config: resolveIngestConfig(env),
-      limits: resolveIngestLimits(env),
-      onProgress: config.onIngestProgress,
-    });
-    if (typeof (engine as { attachDocumentSurface?: unknown }).attachDocumentSurface === 'function') {
-      engine.attachDocumentSurface?.(surface);
-    }
-    return surface;
-  } catch (err) {
-    // No usable embedder (weights not staged, bad env): ingestion reports the
-    // staging diagnostic per request; the rest of the host serves.
-    console.error(
-      `[trainingapp-backend] ingest surface unavailable (documents stay stubbed): ${err instanceof Error ? err.message : String(err)}`,
-    );
-    return null;
+): void {
+  if (embedder === null) {
+    // No usable embedder (weights not staged, bad env): the document surface
+    // stays detached and the engine keeps its stub document behavior; the
+    // rest of the host serves.
+    console.error('[trainingapp-backend] ingest surface unavailable (documents stay stubbed): no embedding model staged');
+    return;
+  }
+  const env = config.env ?? process.env;
+  const surface = new StoreDocumentSurface({
+    getStore: accessors.get,
+    setStore: accessors.set,
+    embedder,
+    config: resolveIngestConfig(env),
+    limits: resolveIngestLimits(env),
+    onProgress: config.onIngestProgress,
+  });
+  if (typeof (engine as { attachDocumentSurface?: unknown }).attachDocumentSurface === 'function') {
+    engine.attachDocumentSurface?.(surface);
   }
 }
 

--- a/desktop/main/backend/index.ts
+++ b/desktop/main/backend/index.ts
@@ -131,12 +131,22 @@ export class NodeBackendHost implements BackendHost {
         if (this.store !== null) {
           const env = this.config.env ?? process.env;
           // Resolve the embedder FIRST (null when unavailable: weights not
-          // staged, bad env) so the B7 wiring below can reuse it.
-          this.embedder = resolveEmbedder({
-            env,
-            dims: this.store.dims,
-            repoRoot: process.env.TRAININGAPP_DESKTOP_REPO_ROOT,
-          });
+          // staged, bad env) so the B7 wiring below can reuse it. Mirrors the
+          // B5/B6 degrade contract: a missing model degrades the store surface
+          // to embedder-less operation, it never fails host start (CI has no
+          // staged weights; the LFS pointer must not take the host down).
+          try {
+            this.embedder = resolveEmbedder({
+              env,
+              dims: this.store.dims,
+              repoRoot: process.env.TRAININGAPP_DESKTOP_REPO_ROOT,
+            });
+          } catch (err) {
+            console.error(
+              `[trainingapp-backend] embedding model unavailable (store surface degrades to embedder-less): ${err instanceof Error ? err.message : String(err)}`,
+            );
+            this.embedder = null;
+          }
           // B7 (issue #65), SINGLE-THREAD ORT OWNERSHIP: onnxruntime-node
           // aborts the whole process when one module instance is used from
           // two threads of one process (empirically probed 2026-09-09; trace
@@ -148,20 +158,30 @@ export class NodeBackendHost implements BackendHost {
           // rerank disabled there is no worker and the main thread keeps its
           // sole-threaded ORT use.
           const retrievalConfig = resolveRetrievalConfig(env);
-          const rerankerModelDir = resolveRerankerModelDir({
-            env,
-            repoRoot: process.env.TRAININGAPP_DESKTOP_REPO_ROOT,
-          });
-          if (
-            this.embedder instanceof OnnxEmbedder &&
-            retrievalConfig.rerank &&
-            rerankerModelDir !== null
-          ) {
-            this.reranker = new WorkerReranker({
-              modelDir: rerankerModelDir,
-              embedModelDir: this.embedder.weightsDir,
+          try {
+            const rerankerModelDir = resolveRerankerModelDir({
+              env,
+              repoRoot: process.env.TRAININGAPP_DESKTOP_REPO_ROOT,
             });
-            this.embedder = new WorkerEmbedder(this.reranker as WorkerReranker, this.embedder.modelId);
+            if (
+              this.embedder instanceof OnnxEmbedder &&
+              retrievalConfig.rerank &&
+              rerankerModelDir !== null
+            ) {
+              this.reranker = new WorkerReranker({
+                modelDir: rerankerModelDir,
+                embedModelDir: this.embedder.weightsDir,
+              });
+              this.embedder = new WorkerEmbedder(this.reranker as WorkerReranker, this.embedder.modelId);
+            }
+          } catch (err) {
+            // Reranker unavailable: degrade to fused-ordering retrieval with
+            // the embedder as-is (no worker exists, so main-thread ORT stays
+            // single-threaded). Never fail host start.
+            this.reranker = null;
+            console.error(
+              `[trainingapp-backend] reranker unavailable (retrieval degrades to fused ordering): ${err instanceof Error ? err.message : String(err)}`,
+            );
           }
           attachStoreSurface(this.config, this.engine, this.store, this.embedder, {
             get: () => this.store,

--- a/desktop/main/backend/inference/llama-engine.ts
+++ b/desktop/main/backend/inference/llama-engine.ts
@@ -36,6 +36,7 @@ import type {
   EngineSurface,
   IngestFileInput,
   IngestResult,
+  RetrievalSurface,
 } from '../types.js';
 import { buildPenalties, PENALTY_FULL_CONTEXT_TOKENS, type PenaltyOptions } from './penalties.js';
 import {
@@ -373,19 +374,33 @@ export class LlamaEngine implements EngineSurface {
     const started = Date.now();
     const profile = this.effectiveProfile();
     const modelPath = this.assertModelAvailable(profile);
+    // B7 (issue #65): the retrieval step inside /ask//ask/stream. When the
+    // host attached a retrieval surface, the hybrid pipeline runs BEFORE
+    // generation: sources/context_length become real and the prompt is
+    // grounded by prepending the retrieved chunks to the question string
+    // (zero change when no surface is attached). An /ask cancellation during
+    // an in-flight retrieval lets the work complete and discards the result —
+    // the rerank worker is never terminated mid-query.
+    const context = await this.stub.retrieveContext(question, opts.nResults);
+    const groundedQuestion =
+      context === null
+        ? question
+        : `${'Answer the question using the retrieved context when relevant.'}\n\n${context.texts
+            .map((text, index) => `[${index + 1}] ${text}`)
+            .join('\n\n')}\n\n\nQuestion: ${question}`;
     const run = this.queue.then(async () => {
       const entry = await this.ensureResident(profile, modelPath);
       entry.inFlight += 1;
       try {
-        const result = await entry.backend.generate(question, {
+        const result = await entry.backend.generate(groundedQuestion, {
           history: opts.history,
           streamCallback: opts.streamCallback,
           cancellationEvent: opts.cancellationEvent,
         });
         const out: EngineQueryResult = {
           answer: result.answer,
-          sources: [],
-          context_length: 0,
+          sources: context?.sources ?? [],
+          context_length: context?.contextLength ?? 0,
           inference_time: (Date.now() - started) / 1000,
         };
         if (result.cancelled) out.cancelled = true;
@@ -524,6 +539,16 @@ export class LlamaEngine implements EngineSurface {
    */
   attachDocumentSurface(surface: DocumentSurface | null): void {
     this.documents = surface;
+  }
+
+  /**
+   * B7 (issue #65): the host attaches the store-backed hybrid retrieval
+   * surface after it opens the store (forwarded to the stub that owns the
+   * retrieval seam). While null, search()/query() keep the stub's
+   * deterministic detached behavior (the B3 conformance mode).
+   */
+  attachRetrievalSurface(surface: RetrievalSurface | null): void {
+    this.stub.attachRetrievalSurface(surface);
   }
 
   private documents: DocumentSurface | null = null;

--- a/desktop/main/backend/ingest/embedder.ts
+++ b/desktop/main/backend/ingest/embedder.ts
@@ -92,6 +92,11 @@ export class OnnxEmbedder implements EmbeddingSurface {
 
   constructor(private readonly modelDir: string) {}
 
+  /** The resolved ONNX weights directory (B7 routes embeds through its worker). */
+  get weightsDir(): string {
+    return this.modelDir;
+  }
+
   /** Resolve and validate the weights location WITHOUT loading native code. */
   static stagedModelDir(candidates: Array<string | undefined>): string | null {
     for (const candidate of candidates) {

--- a/desktop/main/backend/retrieval/config.ts
+++ b/desktop/main/backend/retrieval/config.ts
@@ -1,0 +1,91 @@
+// retrieval/config.ts — hybrid retrieval configuration (issue #65, B7).
+//
+// Mirrors the frozen-defaults + env-resolution pattern of
+// desktop/main/backend/ingest/config.ts. The defaults mirror the browser
+// balanced preset (web_ui/src/lib/rag/rag-presets.ts:24: topK 10,
+// candidateMultiplier 3, rerank true) plus RRF k=60, the value both the
+// browser fusion (rrf-fusion.ts) and the Python reference (utils.py rrf_fuse)
+// use. relevanceFloor is the CALIBRATED cross-encoder floor recorded in
+// docs/adr/0007-relevance-floor-calibration.md — deliberately NOT the
+// browser's un-revalidated 0.2 (web_ui/src/lib/rag/rag-orchestrator.ts:163).
+//
+// The floor gates RERANKER-scale sigmoid scores only. It is never applied to
+// raw RRF fused scores (a ~0.03-max scale): when no reranker ran, the floor is
+// bypassed entirely (see retrieval/hybrid.ts).
+
+export interface RetrievalConfig {
+  /** Final result slice (`retrieval.topK`); per-leg fetch is topK * candidateMultiplier. */
+  topK: number;
+  /** Over-retrieval factor per leg and the reranker candidate window size. */
+  candidateMultiplier: number;
+  /** Whether the worker cross-encoder reranks the fused window. */
+  rerank: boolean;
+  /** Reciprocal Rank Fusion constant: score += 1/(rrfK + rank + 1). */
+  rrfK: number;
+  /** Calibrated floor on reranker sigmoid scores (scores < floor are dropped). */
+  relevanceFloor: number;
+}
+
+export const RETRIEVAL_TOPK_ENV = 'TRAININGAPP_RETRIEVAL_TOPK';
+export const RETRIEVAL_CANDIDATE_MULTIPLIER_ENV = 'TRAININGAPP_RETRIEVAL_CANDIDATE_MULTIPLIER';
+export const RETRIEVAL_RERANK_ENV = 'TRAININGAPP_RETRIEVAL_RERANK';
+export const RETRIEVAL_RRF_K_ENV = 'TRAININGAPP_RETRIEVAL_RRF_K';
+export const RETRIEVAL_RELEVANCE_FLOOR_ENV = 'TRAININGAPP_RETRIEVAL_RELEVANCE_FLOOR';
+
+/**
+ * Calibrated on the ettin-reranker-32m-v1 cross-encoder over the A4 tier-0
+ * eval set (positives = expected-document chunks, negatives = other docs);
+ * procedure and histogram in docs/adr/0007-relevance-floor-calibration.md.
+ * Must stay in lockstep with the ADR's `floor:` line (pinned by C2).
+ */
+export const CALIBRATED_RELEVANCE_FLOOR = 0.569387;
+
+export const DEFAULT_RETRIEVAL_CONFIG: Readonly<RetrievalConfig> = Object.freeze({
+  topK: 10,
+  candidateMultiplier: 3,
+  rerank: true,
+  rrfK: 60,
+  relevanceFloor: CALIBRATED_RELEVANCE_FLOOR,
+});
+
+const POSITIVE_INT_PATTERN = /^\d+$/;
+
+function positiveInt(value: string | undefined, fallback: number): number {
+  if (value !== undefined && POSITIVE_INT_PATTERN.test(value)) {
+    const parsed = Number.parseInt(value, 10);
+    if (parsed >= 1) return parsed;
+  }
+  return fallback;
+}
+
+function boolOrFallback(value: string | undefined, fallback: boolean): boolean {
+  if (value === 'true' || value === '1') return true;
+  if (value === 'false' || value === '0') return false;
+  return fallback;
+}
+
+function floorOrFallback(value: string | undefined, fallback: number): number {
+  if (value !== undefined && value.length > 0) {
+    const parsed = Number.parseFloat(value);
+    if (Number.isFinite(parsed) && parsed >= 0 && parsed < 1) return parsed;
+  }
+  return fallback;
+}
+
+/** Resolve the retrieval config from an env-like record (defaults on invalid input). */
+export function resolveRetrievalConfig(env?: Record<string, string | undefined>): RetrievalConfig {
+  const source = env ?? process.env;
+  return {
+    topK: positiveInt(source[RETRIEVAL_TOPK_ENV], DEFAULT_RETRIEVAL_CONFIG.topK),
+    candidateMultiplier: positiveInt(
+      source[RETRIEVAL_CANDIDATE_MULTIPLIER_ENV],
+      DEFAULT_RETRIEVAL_CONFIG.candidateMultiplier,
+    ),
+    rerank: boolOrFallback(source[RETRIEVAL_RERANK_ENV], DEFAULT_RETRIEVAL_CONFIG.rerank),
+    rrfK: positiveInt(source[RETRIEVAL_RRF_K_ENV], DEFAULT_RETRIEVAL_CONFIG.rrfK),
+    relevanceFloor: floorOrFallback(
+      source[RETRIEVAL_RELEVANCE_FLOOR_ENV],
+      DEFAULT_RETRIEVAL_CONFIG.relevanceFloor,
+    ),
+  };
+}

--- a/desktop/main/backend/retrieval/config.ts
+++ b/desktop/main/backend/retrieval/config.ts
@@ -50,10 +50,18 @@ export const DEFAULT_RETRIEVAL_CONFIG: Readonly<RetrievalConfig> = Object.freeze
 
 const POSITIVE_INT_PATTERN = /^\d+$/;
 
-function positiveInt(value: string | undefined, fallback: number): number {
+// Upper sanity bounds (PRR-011, PR #102 review): an unbounded topK (or
+// multiplier) turns legK = topK * multiplier into an absurd vec0 KNN `k`
+// (e.g. ~3e9 from TOPK=999999999). Out-of-range values fall back to the
+// default, matching the established per-key invalid-input behavior.
+const TOPK_MAX = 1000;
+const CANDIDATE_MULTIPLIER_MAX = 100;
+const RRF_K_MAX = 10000;
+
+function positiveInt(value: string | undefined, fallback: number, max: number): number {
   if (value !== undefined && POSITIVE_INT_PATTERN.test(value)) {
     const parsed = Number.parseInt(value, 10);
-    if (parsed >= 1) return parsed;
+    if (parsed >= 1 && parsed <= max) return parsed;
   }
   return fallback;
 }
@@ -76,13 +84,14 @@ function floorOrFallback(value: string | undefined, fallback: number): number {
 export function resolveRetrievalConfig(env?: Record<string, string | undefined>): RetrievalConfig {
   const source = env ?? process.env;
   return {
-    topK: positiveInt(source[RETRIEVAL_TOPK_ENV], DEFAULT_RETRIEVAL_CONFIG.topK),
+    topK: positiveInt(source[RETRIEVAL_TOPK_ENV], DEFAULT_RETRIEVAL_CONFIG.topK, TOPK_MAX),
     candidateMultiplier: positiveInt(
       source[RETRIEVAL_CANDIDATE_MULTIPLIER_ENV],
       DEFAULT_RETRIEVAL_CONFIG.candidateMultiplier,
+      CANDIDATE_MULTIPLIER_MAX,
     ),
     rerank: boolOrFallback(source[RETRIEVAL_RERANK_ENV], DEFAULT_RETRIEVAL_CONFIG.rerank),
-    rrfK: positiveInt(source[RETRIEVAL_RRF_K_ENV], DEFAULT_RETRIEVAL_CONFIG.rrfK),
+    rrfK: positiveInt(source[RETRIEVAL_RRF_K_ENV], DEFAULT_RETRIEVAL_CONFIG.rrfK, RRF_K_MAX),
     relevanceFloor: floorOrFallback(
       source[RETRIEVAL_RELEVANCE_FLOOR_ENV],
       DEFAULT_RETRIEVAL_CONFIG.relevanceFloor,

--- a/desktop/main/backend/retrieval/hybrid.ts
+++ b/desktop/main/backend/retrieval/hybrid.ts
@@ -136,10 +136,14 @@ export async function hybridRetrieve(
   const rrfK = options.rrfK ?? 60;
   const legK = topK * candidateMultiplier;
   const recency = options.recency ?? recencyWeight;
+  // Defense-in-depth cap (PRR-010, PR #102 review): the HTTP layer bounds
+  // /search and /ask queries, but EngineSurface callers bypass it — keep any
+  // single query from amplifying into a multi-megabyte embed/FTS5 expression.
+  const boundedQuery = query.length > 8000 ? query.slice(0, 8000) : query;
 
   // Vector leg: embed the query exactly once, then the interop-pinned vec0
   // KNN form (contracts/tests/store-interop are the canonical query shape).
-  const [queryVector] = await options.embedder.embed([query]);
+  const [queryVector] = await options.embedder.embed([boundedQuery]);
   const vectorRows = options.store.db
     .prepare(
       'SELECT chunk_id, distance FROM embeddings WHERE embedding MATCH ? AND k = ? ORDER BY distance',
@@ -148,7 +152,7 @@ export async function hybridRetrieve(
   const vectorLeg = vectorRows.map((row) => row.chunk_id).slice(0, legK);
 
   // FTS5 leg: sanitized user query, best match first (rank is negated bm25).
-  const ftsMatch = sanitizeFtsQuery(query);
+  const ftsMatch = sanitizeFtsQuery(boundedQuery);
   const ftsLeg = (
     ftsMatch === null
       ? []
@@ -180,14 +184,19 @@ export async function hybridRetrieve(
     // order) with calibrated relevance; window-out candidates are dropped.
     const window = ordered.slice(0, legK);
     const scores = await options.reranker.score(
-      query,
+      boundedQuery,
       window.map((chunk) => chunk.text),
     );
     const floor = options.relevanceFloor;
     ordered = window
       .map((chunk, index) => {
-        const score = scores[index];
-        return { ...chunk, score: typeof score === 'number' ? score : 0 };
+        const raw = scores[index];
+        const score = typeof raw === 'number' ? raw : Number(raw);
+        // NaN poisoning path: the q8 model could emit NaN, typeof 'number'
+        // passes it, and a NaN sort comparator breaks ordering (V8 treats it
+        // as 0). Map any non-finite score to the lowest useful score instead
+        // (PRR-005, PR #102 review).
+        return { ...chunk, score: Number.isFinite(score) ? score : 0 };
       })
       .filter((chunk) => (floor === undefined ? true : chunk.score >= floor))
       .sort((a, b) => b.score - a.score);
@@ -218,14 +227,19 @@ export function createRetrievalSurface(options: {
   const effectiveReranker =
     config.rerank === false ? null : (options.reranker ?? null);
   let rerankerWarned = false;
+  // Latched for the surface's lifetime: after the first reranker failure every
+  // later query stays on fused ordering. A per-call retry would re-walk the
+  // broken worker on each query while only the log line latched (PRR-004,
+  // PR #102 review).
+  let reranker = effectiveReranker;
   return {
     async search(query, nResults) {
       const topK = config.topK ?? 10;
-      let reranker = effectiveReranker;
       if (reranker !== null) {
         // Production isolation: a broken reranker worker must never 500
         // /search — that query degrades to fused, floor-free ordering (the
-        // same semantics as rerank disabled) after a single warning.
+        // same semantics as rerank disabled) after a single warning, and the
+        // latch keeps later queries on the degraded path.
         try {
           return await runSearch(query, nResults, topK, reranker, config, options);
         } catch (err) {

--- a/desktop/main/backend/retrieval/hybrid.ts
+++ b/desktop/main/backend/retrieval/hybrid.ts
@@ -1,0 +1,270 @@
+// retrieval/hybrid.ts — the B7 hybrid retrieval pipeline (issue #65).
+//
+// Pipeline: query embedding (injected EmbeddingSurface) -> vec0 KNN top-legK
+// UNION chunks_fts FTS5 top-legK -> Reciprocal Rank Fusion (score +=
+// 1/(rrfK + rank + 1), dedup by chunk id — same formula as the browser fusion
+// web_ui/src/lib/search/rrf-fusion.ts and the Python reference utils.py
+// rrf_fuse) -> recencyWeight(chunk) multiplier -> optional worker cross-encoder
+// rerank over the fused window (reranker scores REPLACE the fused scores;
+// window-out candidates are dropped; the calibrated relevanceFloor applies to
+// reranker scores ONLY) -> topK slice.
+//
+// recencyWeight is the documented C4 extension point (issue #71): it returns
+// exactly 1 for every input while Knowledge Pack recency/version precedence is
+// unbuilt; C4 replaces the implementation without touching this pipeline.
+//
+// better-sqlite3 is synchronous, so the store legs run on the calling thread;
+// the reranker (ONNX inference) runs in a dedicated worker thread
+// (retrieval/reranker.ts + rerank-worker.ts) — never on the main/event-loop
+// thread (the web_ui defect this design must not reproduce,
+// web_ui/src/lib/search/reranker.ts:187-233).
+import type { StoreHandle } from '../store/sqlite-store.js';
+import type { EmbeddingSurface } from '../ingest/embedder.js';
+
+/** One retrieved chunk with its final score (fused RRF*recency, or reranker). */
+export interface RetrievedChunk {
+  chunkId: string;
+  text: string;
+  source: string;
+  score: number;
+}
+
+/** Cross-encoder scoring surface (implemented by the worker-backed reranker). */
+export interface RerankerSurface {
+  score(query: string, candidates: string[]): Promise<number[]>;
+}
+
+export interface HybridRetrievalOptions {
+  store: StoreHandle;
+  embedder: EmbeddingSurface;
+  /** Final slice; default 10 (the browser balanced preset). */
+  topK?: number;
+  /** Per-leg fetch and rerank window K = topK * candidateMultiplier; default 3. */
+  candidateMultiplier?: number;
+  /** RRF constant; default 60. */
+  rrfK?: number;
+  reranker?: RerankerSurface | null;
+  /** Floor on RERANKER scores only; rows with score < floor are dropped (== floor kept). */
+  relevanceFloor?: number;
+  /** Recency multiplier per fused chunk; default recencyWeight (inert until C4/#71). */
+  recency?: (chunk: RetrievedChunk) => number;
+}
+
+export interface RetrievalSurface {
+  search(
+    query: string,
+    nResults?: number,
+  ): Promise<Array<{ text: string; source: string; similarity: number }>>;
+}
+
+/** Reciprocal Rank Fusion over ranked chunk-id legs; dedup by chunk id. */
+export function rrfFuse(vectorLeg: string[], ftsLeg: string[], rrfK: number): Map<string, number> {
+  const fused = new Map<string, number>();
+  for (const [rank, chunkId] of vectorLeg.entries()) {
+    fused.set(chunkId, (fused.get(chunkId) ?? 0) + 1 / (rrfK + rank + 1));
+  }
+  for (const [rank, chunkId] of ftsLeg.entries()) {
+    fused.set(chunkId, (fused.get(chunkId) ?? 0) + 1 / (rrfK + rank + 1));
+  }
+  return fused;
+}
+
+/**
+ * C4 (issue #71) extension point: recency/version weighting of fused chunks.
+ * Inert by contract until Knowledge Pack precedence lands — exactly 1 for
+ * every input, asserted by C6.
+ */
+export function recencyWeight(_chunk: unknown): number {
+  return 1;
+}
+
+/**
+ * FTS5 MATCH does not accept raw user syntax safely (quotes, `*`, `AND`/`OR`/
+ * `NOT`/`NEAR`, `^`, `:` are all operators). Wrap each remaining term in double
+ * quotes (a quoted single term is observably identical to the bare term) and
+ * drop operator/bare-quote/star tokens outright. A query reduced to nothing
+ * yields an empty FTS leg instead of a thrown syntax error.
+ */
+export function sanitizeFtsQuery(query: string): string | null {
+  const operators = new Set(['and', 'or', 'not', 'near']);
+  const terms: string[] = [];
+  for (const raw of query.split(/\s+/)) {
+    if (raw.length === 0) continue;
+    const lowered = raw.toLowerCase();
+    if (operators.has(lowered)) continue;
+    if (/["*():^&]/.test(raw)) continue;
+    terms.push(`"${raw}"`);
+  }
+  if (terms.length === 0) return null;
+  return terms.join(' ');
+}
+
+interface ChunkRow {
+  id: string;
+  text: string;
+  path: string;
+}
+
+function loadChunkRows(store: StoreHandle, chunkIds: string[]): Map<string, ChunkRow> {
+  const rows = new Map<string, ChunkRow>();
+  if (chunkIds.length === 0) return rows;
+  const placeholders = chunkIds.map(() => '?').join(', ');
+  const found = store.db
+    .prepare(
+      `SELECT c.id AS id, c.text AS text, d.path AS path
+       FROM chunks c JOIN docs d ON c.doc_id = d.id
+       WHERE c.id IN (${placeholders})`,
+    )
+    .all(...chunkIds) as Array<{ id: string; text: string; path: string }>;
+  for (const row of found) {
+    rows.set(row.id, row);
+  }
+  return rows;
+}
+
+/**
+ * The hybrid pipeline. Empty store -> [] (the reranker is never called). The
+ * relevanceFloor gates reranker-scale sigmoid scores only; when no reranker
+ * runs, RRF-scale fused scores compete for the topK slice untouched.
+ */
+export async function hybridRetrieve(
+  query: string,
+  options: HybridRetrievalOptions,
+): Promise<RetrievedChunk[]> {
+  const topK = options.topK ?? 10;
+  const candidateMultiplier = options.candidateMultiplier ?? 3;
+  const rrfK = options.rrfK ?? 60;
+  const legK = topK * candidateMultiplier;
+  const recency = options.recency ?? recencyWeight;
+
+  // Vector leg: embed the query exactly once, then the interop-pinned vec0
+  // KNN form (contracts/tests/store-interop are the canonical query shape).
+  const [queryVector] = await options.embedder.embed([query]);
+  const vectorRows = options.store.db
+    .prepare(
+      'SELECT chunk_id, distance FROM embeddings WHERE embedding MATCH ? AND k = ? ORDER BY distance',
+    )
+    .all(JSON.stringify(queryVector), legK) as Array<{ chunk_id: string; distance: number }>;
+  const vectorLeg = vectorRows.map((row) => row.chunk_id).slice(0, legK);
+
+  // FTS5 leg: sanitized user query, best match first (rank is negated bm25).
+  const ftsMatch = sanitizeFtsQuery(query);
+  const ftsLeg = (
+    ftsMatch === null
+      ? []
+      : (options.store.db
+          .prepare('SELECT chunk_id FROM chunks_fts WHERE chunks_fts MATCH ? ORDER BY bm25(chunks_fts) LIMIT ?')
+          .all(ftsMatch, legK) as Array<{ chunk_id: string }>)
+  ).map((row) => row.chunk_id);
+
+  const fused = rrfFuse(vectorLeg, ftsLeg, rrfK);
+  if (fused.size === 0) return [];
+  const rows = loadChunkRows(options.store, [...fused.keys()]);
+
+  // Fused score * recency, ordered descending.
+  let ordered: RetrievedChunk[] = [...fused.entries()]
+    .map(([chunkId, score]) => {
+      const row = rows.get(chunkId);
+      const chunk: RetrievedChunk = {
+        chunkId,
+        text: row?.text ?? '',
+        source: row?.path ?? '',
+        score,
+      };
+      return { ...chunk, score: score * recency(chunk) };
+    })
+    .sort((a, b) => b.score - a.score);
+
+  if (options.reranker) {
+    // The reranker re-scores the fused window (first legK candidates, in fused
+    // order) with calibrated relevance; window-out candidates are dropped.
+    const window = ordered.slice(0, legK);
+    const scores = await options.reranker.score(
+      query,
+      window.map((chunk) => chunk.text),
+    );
+    const floor = options.relevanceFloor;
+    ordered = window
+      .map((chunk, index) => {
+        const score = scores[index];
+        return { ...chunk, score: typeof score === 'number' ? score : 0 };
+      })
+      .filter((chunk) => (floor === undefined ? true : chunk.score >= floor))
+      .sort((a, b) => b.score - a.score);
+  }
+
+  return ordered.slice(0, topK);
+}
+
+/**
+ * Adapter from the pipeline to the frozen /search wire shape
+ * (contracts/api.openapi.yaml SearchResult: {text, source, similarity}).
+ * similarity carries the final score verbatim (fused RRF*recency when no
+ * reranker ran, the cross-encoder sigmoid otherwise).
+ */
+export function createRetrievalSurface(options: {
+  store: StoreHandle;
+  embedder: EmbeddingSurface;
+  reranker?: RerankerSurface | null;
+  config?: {
+    topK?: number;
+    candidateMultiplier?: number;
+    rerank?: boolean;
+    rrfK?: number;
+    relevanceFloor?: number;
+  };
+}): RetrievalSurface {
+  const config = options.config ?? {};
+  const effectiveReranker =
+    config.rerank === false ? null : (options.reranker ?? null);
+  let rerankerWarned = false;
+  return {
+    async search(query, nResults) {
+      const topK = config.topK ?? 10;
+      let reranker = effectiveReranker;
+      if (reranker !== null) {
+        // Production isolation: a broken reranker worker must never 500
+        // /search — that query degrades to fused, floor-free ordering (the
+        // same semantics as rerank disabled) after a single warning.
+        try {
+          return await runSearch(query, nResults, topK, reranker, config, options);
+        } catch (err) {
+          if (!rerankerWarned) {
+            rerankerWarned = true;
+            console.error(
+              `[trainingapp-backend] reranker failed once (degrading to fused ordering): ${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
+          reranker = null;
+        }
+      }
+      return runSearch(query, nResults, topK, reranker, config, options);
+    },
+  };
+}
+
+async function runSearch(
+  query: string,
+  nResults: number | undefined,
+  topK: number,
+  reranker: RerankerSurface | null,
+  config: { candidateMultiplier?: number; rerank?: boolean; rrfK?: number; relevanceFloor?: number },
+  options: { store: StoreHandle; embedder: EmbeddingSurface },
+): Promise<Array<{ text: string; source: string; similarity: number }>> {
+  const chunks = await hybridRetrieve(query, {
+    store: options.store,
+    embedder: options.embedder,
+    topK,
+    candidateMultiplier: config.candidateMultiplier,
+    rrfK: config.rrfK,
+    reranker,
+    // The floor is meaningful only when a reranker will run (hybridRetrieve
+    // enforces the same rule internally; passing it unconditionally is safe).
+    relevanceFloor: config.relevanceFloor,
+  });
+  return chunks.slice(0, nResults ?? topK).map((chunk) => ({
+    text: chunk.text,
+    source: chunk.source,
+    similarity: chunk.score,
+  }));
+}

--- a/desktop/main/backend/retrieval/rerank-worker.ts
+++ b/desktop/main/backend/retrieval/rerank-worker.ts
@@ -1,0 +1,155 @@
+// retrieval/rerank-worker.ts — the PRODUCTION retrieval worker entry (B7/#65).
+//
+// Runs in a dedicated node:worker_threads thread. This worker owns ALL
+// onnxruntime work for retrieval: cross-encoder reranking AND query
+// embedding. Single-thread ORT ownership is REQUIRED: onnxruntime-node 1.21
+// aborts the whole process (fatal, exit 134) when the same module is used
+// from TWO threads of one process — empirically probed 2026-09-09 (main
+// embed -> worker rerank -> main embed = abort; trace repro/mix-probe.mjs).
+// The host therefore never calls ORT on the main thread when this worker
+// exists (WorkerEmbedder proxies query/ingest embeddings here).
+//
+// Message protocol (rerank half pinned by C4):
+//   main  -> worker: { kind: 'rerank', jobId, query, candidates }
+//                  | { kind: 'embed',  jobId, texts }
+//   worker -> main:  { kind: 'rerank:result', jobId, scores }
+//                or  { kind: 'rerank:error',   jobId, message }
+//                or  { kind: 'embed:result',   jobId, vectors }
+//                or  { kind: 'embed:error',    jobId, message }
+//
+// Models: ettin-reranker-32m-v1 (the web_ui baseline reranker,
+// web_ui/src/lib/models/model-manifest.ts:72-76) and bge-small-en-v1.5
+// (ADR-0006 pin) via transformers.js over the native onnxruntime backend
+// (fp32 for bge, matching ingest/embedder.ts; q8 for ettin, matching the
+// browser baseline reranker.ts:179-208). Scoring bypasses the
+// text-classification pipeline's softmax (a single logit collapses to 1.0)
+// and applies sigmoid(logit) per (query, candidate) pair — the baseline
+// semantics (reranker.ts:7-13, 312-320). ADR-0001 (#55) may re-pin the
+// models; that is a modelDir/config change, not a protocol change.
+import { parentPort, workerData } from 'node:worker_threads';
+
+type WorkerJob =
+  | { kind: 'rerank'; jobId: number; query: string; candidates: string[] }
+  | { kind: 'embed'; jobId: number; texts: string[] };
+
+interface TokenizeOutput {
+  tensors: Record<string, { data: unknown; dims: number[] }>;
+}
+
+interface RerankModel {
+  (inputs: unknown): Promise<{ logits: { data: Float32Array | BigInt64Array | number[]; dims: number[] } }>;
+}
+
+interface Tokenizer {
+  (
+    text: string | string[],
+    opts?: { text_pair?: string | string[]; padding?: boolean; truncation?: boolean },
+  ): Promise<TokenizeOutput>;
+}
+
+interface EmbedOutput {
+  tolist(): number[][];
+}
+
+interface EmbedPipeline {
+  (texts: string[], opts: { pooling: 'cls'; normalize: boolean }): Promise<EmbedOutput>;
+}
+
+let rerankPromise: Promise<{ tokenizer: Tokenizer; model: RerankModel }> | null = null;
+let embedPromise: Promise<EmbedPipeline> | null = null;
+
+function sigmoid(logit: number): number {
+  return 1 / (1 + Math.exp(-logit));
+}
+
+async function loadRerank(modelDir: string): Promise<{ tokenizer: Tokenizer; model: RerankModel }> {
+  if (rerankPromise === null) {
+    rerankPromise = (async () => {
+      const transformers = await import('@huggingface/transformers');
+      const tokenizer = (await transformers.AutoTokenizer.from_pretrained(modelDir)) as unknown as Tokenizer;
+      const model = (await transformers.AutoModelForSequenceClassification.from_pretrained(modelDir, {
+        dtype: 'q8',
+      })) as unknown as RerankModel;
+      return { tokenizer, model };
+    })();
+    rerankPromise.catch(() => {
+      // Allow a retry after a transient load failure (weights swapped in).
+      rerankPromise = null;
+    });
+  }
+  return rerankPromise;
+}
+
+async function loadEmbed(modelDir: string): Promise<EmbedPipeline> {
+  if (embedPromise === null) {
+    embedPromise = (async () => {
+      const transformers = await import('@huggingface/transformers');
+      const createPipeline = transformers.pipeline as unknown as (
+        task: 'feature-extraction',
+        modelPath: string,
+        options: { dtype: string },
+      ) => Promise<EmbedPipeline>;
+      return createPipeline('feature-extraction', modelDir, { dtype: 'fp32' });
+    })();
+    embedPromise.catch(() => {
+      embedPromise = null;
+    });
+  }
+  return embedPromise;
+}
+
+async function scoreBatch(
+  rerankModelDir: string,
+  query: string,
+  candidates: string[],
+): Promise<number[]> {
+  if (candidates.length === 0) return [];
+  const { tokenizer, model } = await loadRerank(rerankModelDir);
+  // True pair encoding ([CLS] query [SEP] candidate [SEP]) with token_type_ids.
+  // transformers.js requires text and text_pair to be the SAME shape: pass the
+  // query repeated per candidate as the text array and the candidates as the
+  // text_pair array, keeping the (query, candidate) order of every pair.
+  const inputs = await tokenizer(candidates.map(() => query), {
+    text_pair: candidates,
+    padding: true,
+    truncation: true,
+  });
+  const output = await model(inputs);
+  const logits = output.logits;
+  const width = logits.dims.length >= 2 ? Number(logits.dims[1] ?? 1) : 1;
+  const scores: number[] = [];
+  for (let index = 0; index < candidates.length; index += 1) {
+    const value = logits.data[index * width];
+    scores.push(sigmoid(typeof value === 'number' ? value : Number(value)));
+  }
+  return scores;
+}
+
+const port = parentPort;
+if (port !== null) {
+  port.on('message', (raw: unknown) => {
+    void (async () => {
+      const message = raw as WorkerJob;
+      if (!message || (message.kind !== 'rerank' && message.kind !== 'embed')) return;
+      const dirs = ((workerData ?? {}) as { modelDir?: string | null; embedModelDir?: string | null });
+      try {
+        if (message.kind === 'rerank') {
+          if (!dirs.modelDir) throw new Error('retrieval worker started without modelDir');
+          const scores = await scoreBatch(dirs.modelDir, message.query, message.candidates);
+          port.postMessage({ kind: 'rerank:result', jobId: message.jobId, scores });
+        } else {
+          if (!dirs.embedModelDir) throw new Error('retrieval worker started without embedModelDir');
+          const pipeline = await loadEmbed(dirs.embedModelDir);
+          const output = await pipeline(message.texts, { pooling: 'cls', normalize: true });
+          port.postMessage({ kind: 'embed:result', jobId: message.jobId, vectors: output.tolist() });
+        }
+      } catch (err) {
+        port.postMessage({
+          kind: message.kind === 'rerank' ? 'rerank:error' : 'embed:error',
+          jobId: message.jobId,
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    })();
+  });
+}

--- a/desktop/main/backend/retrieval/reranker.ts
+++ b/desktop/main/backend/retrieval/reranker.ts
@@ -151,7 +151,15 @@ export class WorkerReranker {
       });
       worker.on('error', (err) => this.failAll(err));
       worker.on('exit', (code) => {
-        if (code !== 0) this.failAll(new Error(`rerank worker exited with code ${code}`));
+        // Orphan exit (worker died on its own while this.worker still points
+        // at it) must settle pending jobs on ANY exit code — a clean exit with
+        // unanswered jobs would otherwise leave their promises pending forever
+        // (PRR-007, PR #102 review). A dispose-terminated worker is exempt:
+        // this.worker was already nulled and dispose() owns the rejection
+        // timing (the frozen C4 deferral contract).
+        if (this.worker === worker && this.pending.size > 0) {
+          this.failAll(new Error(`rerank worker exited with code ${code}`));
+        }
         if (this.worker === worker) this.worker = null;
       });
       this.worker = worker;
@@ -205,16 +213,21 @@ export class WorkerReranker {
     this.disposed = true;
     const worker = this.worker;
     this.worker = null;
-    if (worker !== null) {
-      await worker.terminate();
-    }
-    if (this.pending.size > 0) {
-      const err = new Error('WorkerReranker disposed with jobs in flight');
-      // Defer one macrotask: a caller that awaits dispose() and only THEN
-      // attaches a rejection handler to the in-flight job (the frozen C4
-      // pattern) would otherwise trip Node's unhandled-rejection detector,
-      // because the rejection would fire before the handler exists.
-      setImmediate(() => this.failAll(err));
+    // The pending-job rejection must run even if terminate() rejects, or the
+    // in-flight promises would be orphaned (PRR-006, PR #102 review).
+    try {
+      if (worker !== null) {
+        await worker.terminate();
+      }
+    } finally {
+      if (this.pending.size > 0) {
+        const err = new Error('WorkerReranker disposed with jobs in flight');
+        // Defer one macrotask: a caller that awaits dispose() and only THEN
+        // attaches a rejection handler to the in-flight job (the frozen C4
+        // pattern) would otherwise trip Node's unhandled-rejection detector,
+        // because the rejection would fire before the handler exists.
+        setImmediate(() => this.failAll(err));
+      }
     }
   }
 }

--- a/desktop/main/backend/retrieval/reranker.ts
+++ b/desktop/main/backend/retrieval/reranker.ts
@@ -1,0 +1,241 @@
+// retrieval/reranker.ts — worker-thread cross-encoder reranker runner (B7/#65).
+//
+// WorkerReranker keeps ONE dedicated node:worker_threads Worker alive and
+// serializes rerank jobs through it (per-instance jobId counter + pending
+// map; results resolve by jobId, not call order). The whole point of the
+// thread is AC4: ONNX inference is synchronous native compute, so running it
+// on the main/event-loop thread would stall /health (the defect the issue
+// explicitly forbids reproducing from web_ui reranker.ts).
+//
+// The worker is spawned LAZILY on the first score() call: constructing the
+// runner is cheap and weight-free, and hosts that never serve a reranked query
+// never pay for a thread or a model load. dispose() terminates the worker,
+// rejects every in-flight job, and is idempotent.
+import { Worker } from 'node:worker_threads';
+import type { RerankerSurface } from './hybrid.js';
+
+export type { RerankerSurface };
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import fs from 'node:fs';
+
+export interface RerankerRunnerOptions {
+  /** Worker entry; defaults to the compiled rerank-worker.js sibling of this module. */
+  workerPath?: string;
+  /** Forwarded to the worker via workerData (the ettin model dir). */
+  modelDir?: string;
+  /** Forwarded via workerData: the bge-small model dir for embed jobs. */
+  embedModelDir?: string;
+}
+
+interface RerankJob {
+  kind: 'rerank';
+  jobId: number;
+  query: string;
+  candidates: string[];
+}
+
+type WorkerResponse =
+  | { kind: 'rerank:result'; jobId: number; scores: number[] }
+  | { kind: 'rerank:error'; jobId: number; message: string }
+  | { kind: 'embed:result'; jobId: number; vectors: number[][] }
+  | { kind: 'embed:error'; jobId: number; message: string };
+
+interface PendingJob {
+  resolve: (payload: number[] | number[][]) => void;
+  reject: (err: Error) => void;
+}
+
+/** A real reranker weight file is ~127MB; a Git-LFS pointer is ~134 bytes. */
+export const RERANKER_WEIGHTS_MIN_BYTES = 10 * 1024 * 1024;
+
+/** Model dir relative to a models root (matches the staged repo layout). */
+export const DEFAULT_RERANKER_MODEL_SUBPATH = 'ettin-reranker-32m-v1';
+export const RERANKER_MODEL_DIR_ENV = 'TRAININGAPP_RERANKER_MODEL_DIR';
+export { RERANKER_WEIGHTS_MIN_BYTES as STAGED_RERANKER_WEIGHTS_MIN_BYTES };
+
+function defaultWorkerPath(): string {
+  return path.join(path.dirname(fileURLToPath(import.meta.url)), 'rerank-worker.js');
+}
+
+function isValidModelDir(dir: string): boolean {
+  for (const candidate of [path.join(dir, 'onnx', 'model_quantized.onnx'), path.join(dir, 'onnx', 'model.onnx')]) {
+    try {
+      if (fs.statSync(candidate).size >= RERANKER_WEIGHTS_MIN_BYTES) return true;
+    } catch {
+      /* try the next candidate */
+    }
+  }
+  return false;
+}
+
+function moduleWalkUp(startDir: string, relative: string): string | undefined {
+  let dir = path.resolve(startDir);
+  for (let i = 0; i < 32; i += 1) {
+    const candidate = path.join(dir, relative);
+    if (fs.existsSync(candidate)) return candidate;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return undefined;
+}
+
+export interface ResolveRerankerOptions {
+  env?: Record<string, string | undefined>;
+  /** Electron injects app.getPath('userData'); models live under <userData>/models. */
+  userDataPath?: string;
+  /** Repository root (dev/CI); the staged models/ dir is the last candidate. */
+  repoRoot?: string;
+}
+
+/**
+ * Resolve the staged reranker model dir WITHOUT loading native code or
+ * spawning a worker. Returns null when nothing usable is staged — the caller
+ * (the host) then degrades to RRF-only retrieval with no relevance floor,
+ * exactly like rerank disabled.
+ */
+export function resolveRerankerModelDir(opts: ResolveRerankerOptions = {}): string | null {
+  const env = opts.env ?? process.env;
+  const explicit = env[RERANKER_MODEL_DIR_ENV];
+  const candidates = [
+    explicit,
+    opts.userDataPath ? path.join(opts.userDataPath, 'models', DEFAULT_RERANKER_MODEL_SUBPATH) : undefined,
+    opts.repoRoot ? path.join(opts.repoRoot, 'models', DEFAULT_RERANKER_MODEL_SUBPATH) : undefined,
+    moduleWalkUp(path.dirname(fileURLToPath(import.meta.url)), path.join('models', DEFAULT_RERANKER_MODEL_SUBPATH)),
+  ];
+  for (const candidate of candidates) {
+    if (candidate && candidate.length > 0 && isValidModelDir(candidate)) return candidate;
+  }
+  return null;
+}
+
+export class WorkerReranker {
+  private worker: Worker | null = null;
+  private workerPath: string;
+  private modelDir?: string;
+  private embedModelDir?: string;
+  private nextJobId = 1;
+  private pending = new Map<number, PendingJob>();
+  private disposed = false;
+
+  constructor(options: RerankerRunnerOptions = {}) {
+    this.workerPath = options.workerPath ?? defaultWorkerPath();
+    this.modelDir = options.modelDir;
+    this.embedModelDir = options.embedModelDir;
+  }
+
+  private ensureWorker(): Worker {
+    if (this.disposed) {
+      throw new Error('WorkerReranker has been disposed');
+    }
+    if (this.worker === null) {
+      const worker = new Worker(this.workerPath, {
+        workerData: { modelDir: this.modelDir ?? null, embedModelDir: this.embedModelDir ?? null },
+      });
+      worker.on('message', (raw: unknown) => {
+        const message = raw as WorkerResponse;
+        if (!message || typeof message.jobId !== 'number') return;
+        const job = this.pending.get(message.jobId);
+        if (!job) return;
+        this.pending.delete(message.jobId);
+        if (message.kind === 'rerank:result' && Array.isArray(message.scores)) {
+          job.resolve(message.scores);
+        } else if (message.kind === 'embed:result' && Array.isArray(message.vectors)) {
+          job.resolve(message.vectors);
+        } else if ((message.kind === 'rerank:error' || message.kind === 'embed:error')) {
+          job.reject(new Error(message.message));
+        } else {
+          job.reject(new Error(`unexpected rerank worker message: ${String((message as { kind?: unknown }).kind)}`));
+        }
+      });
+      worker.on('error', (err) => this.failAll(err));
+      worker.on('exit', (code) => {
+        if (code !== 0) this.failAll(new Error(`rerank worker exited with code ${code}`));
+        if (this.worker === worker) this.worker = null;
+      });
+      this.worker = worker;
+    }
+    return this.worker;
+  }
+
+  private failAll(err: Error): void {
+    for (const [jobId, job] of this.pending) {
+      this.pending.delete(jobId);
+      job.reject(err);
+    }
+  }
+
+  /** Score candidates against the query (cross-encoder sigmoid scores). */
+  async score(query: string, candidates: string[]): Promise<number[]> {
+    const worker = this.ensureWorker();
+    const jobId = this.nextJobId;
+    this.nextJobId += 1;
+    const job: RerankJob = { kind: 'rerank', jobId, query, candidates };
+    return new Promise<number[]>((resolve, reject) => {
+      this.pending.set(jobId, {
+        resolve: (payload) => resolve(payload as number[]),
+        reject,
+      });
+      worker.postMessage(job);
+    });
+  }
+
+  /**
+   * Embed texts through the worker's bge pipeline (same single ORT thread as
+   * rerank). Only meaningful when the worker was constructed with an
+   * embedModelDir; the WorkerEmbedder proxy is the intended entry point.
+   */
+  async embed(texts: string[]): Promise<number[][]> {
+    const worker = this.ensureWorker();
+    const jobId = this.nextJobId;
+    this.nextJobId += 1;
+    const job = { kind: 'embed' as const, jobId, texts };
+    return new Promise<number[][]>((resolve, reject) => {
+      this.pending.set(jobId, {
+        resolve: (payload) => resolve(payload as number[][]),
+        reject,
+      });
+      worker.postMessage(job);
+    });
+  }
+
+  /** Terminate the worker, reject in-flight jobs, idempotent. */
+  async dispose(): Promise<void> {
+    this.disposed = true;
+    const worker = this.worker;
+    this.worker = null;
+    if (worker !== null) {
+      await worker.terminate();
+    }
+    if (this.pending.size > 0) {
+      const err = new Error('WorkerReranker disposed with jobs in flight');
+      // Defer one macrotask: a caller that awaits dispose() and only THEN
+      // attaches a rejection handler to the in-flight job (the frozen C4
+      // pattern) would otherwise trip Node's unhandled-rejection detector,
+      // because the rejection would fire before the handler exists.
+      setImmediate(() => this.failAll(err));
+    }
+  }
+}
+
+/**
+ * Main-thread proxy that routes embeddings through the retrieval worker so
+ * onnxruntime stays on a SINGLE thread of this process (cross-thread ort
+ * aborts the process; see rerank-worker.ts header). Satisfies the same
+ * EmbeddingSurface contract as ingest/embedder.ts.
+ */
+export class WorkerEmbedder {
+  readonly modelId: string;
+  constructor(
+    private readonly worker: WorkerReranker,
+    modelId: string,
+  ) {
+    this.modelId = modelId;
+  }
+
+  embed(texts: string[]): Promise<number[][]> {
+    if (texts.length === 0) return Promise.resolve([]);
+    return this.worker.embed(texts);
+  }
+}

--- a/desktop/main/backend/types.ts
+++ b/desktop/main/backend/types.ts
@@ -9,6 +9,9 @@
 //
 // This module must stay electron-free: it is imported by the headless
 // dev-server entry that CI and the acceptance checks run under plain node.
+import type { RetrievalSurface } from './retrieval/hybrid.js';
+
+export type { RetrievalSurface };
 
 export type BackendMode = 'node' | 'sidecar';
 
@@ -227,4 +230,12 @@ export interface EngineSurface {
    * stub otherwise. Attaching null detaches (host stop).
    */
   attachDocumentSurface?(surface: DocumentSurface | null): void;
+  /**
+   * B7 (issue #65): late-bound hybrid retrieval surface, mirroring the B6
+   * document seam. The host builds it (store + query embedder + optional
+   * worker reranker + retrieval.* config) after the store opens; engines that
+   * support it delegate search()/query() retrieval there, falling back to
+   * their stub otherwise. Attaching null detaches (host stop / B3 mode).
+   */
+  attachRetrievalSurface?(surface: RetrievalSurface | null): void;
 }

--- a/desktop/src/__tests__/b7-hybrid-retrieval.test.ts
+++ b/desktop/src/__tests__/b7-hybrid-retrieval.test.ts
@@ -1,0 +1,521 @@
+// b7-hybrid-retrieval.test.ts — FROZEN ACCEPTANCE SPEC (issue #65 trace, AC1 / check C1).
+//
+// This file is a frozen acceptance spec authored by the issue-tracer v3 CHECK
+// AUTHOR. It pins the hybrid retrieval pipeline the implementer must provide at
+// desktop/main/backend/retrieval/hybrid.ts. It must FAIL at the base revision
+// (module does not exist) and the implementer makes it pass WITHOUT editing it.
+//
+// FROZEN PRODUCTION CONTRACT (module desktop/main/backend/retrieval/hybrid.ts):
+//
+//   export interface RetrievedChunk {
+//     chunkId: string;  // chunks.id
+//     text: string;     // chunks.text
+//     source: string;   // docs.path of the owning document
+//     score: number;    // fused RRF*recency score, or the reranker score when one ran
+//   }
+//   export interface RerankerSurface {
+//     score(query: string, candidates: string[]): Promise<number[]>;
+//   }
+//   export interface HybridRetrievalOptions {
+//     store: StoreHandle;              // structural handle from store/sqlite-store.ts
+//     embedder: EmbeddingSurface;      // ingest/embedder.ts
+//     topK?: number;                   // final slice; default 10
+//     candidateMultiplier?: number;    // per-leg/rerank window K = topK*multiplier; default 3
+//     rrfK?: number;                   // RRF k; default 60
+//     reranker?: RerankerSurface | null;
+//     relevanceFloor?: number;         // drops reranked rows with score < floor (== floor kept)
+//     recency?: (chunk: RetrievedChunk) => number;  // default recencyWeight (always 1)
+//   }
+//   export function rrfFuse(vectorLeg: string[], ftsLeg: string[], rrfK: number): Map<string, number>
+//   export async function hybridRetrieve(query: string, options: HybridRetrievalOptions): Promise<RetrievedChunk[]>
+//   export function recencyWeight(chunk: unknown): number
+//   export interface RetrievalSurface {
+//     search(query: string, nResults?: number): Promise<Array<{ text: string; source: string; similarity: number }>>;
+//   }
+//   export function createRetrievalSurface(options: {
+//     store: StoreHandle; embedder: EmbeddingSurface; reranker?: RerankerSurface | null;
+//     config?: { topK?: number; candidateMultiplier?: number; rerank?: boolean; rrfK?: number; relevanceFloor?: number };
+//   }): RetrievalSurface
+//
+// FROZEN SEMANTICS pinned by the assertions below:
+//   - vector leg: options.embedder.embed([query]) (called exactly once, with the
+//     query text), then the vec0 KNN form
+//       SELECT chunk_id, distance FROM embeddings WHERE embedding MATCH ? AND k = ?
+//         ORDER BY distance
+//     with the query vector JSON-stringified, truncated to legK.
+//   - FTS5 leg: chunks_fts MATCH <raw query> ordered by bm25, truncated to legK.
+//   - legK = topK * candidateMultiplier (both default: 10 * 3).
+//   - fusion: score(chunk) = sum over legs of 1/(rrfK + rank + 1), rank 0-based
+//     per leg, deduped by chunk id; the fused score is MULTIPLIED by
+//     recencyWeight(chunk) (inert while the hook returns 1).
+//   - rrfK default 60 (asserted end-to-end via exact arithmetic).
+//   - results ordered by score descending.
+//   - when a reranker is provided: the rerank window is the first legK fused
+//     candidates IN FUSED ORDER; reranker.score(query, windowTexts) is awaited
+//     once; its scores REPLACE the RRF scores; candidates outside the window are
+//     dropped; rows with reranker score < relevanceFloor are dropped (== floor
+//     kept); the final topK slice is taken.
+//   - when NO reranker is provided: the relevanceFloor is NOT applied (it gates
+//     reranker-scale scores only; RRF scores live on a ~0.03 scale and gating
+//     them would empty every hash/CI store-backed response); all fused
+//     candidates compete for the final topK slice.
+//   - an empty store returns [] (and never calls the reranker).
+import { afterEach, describe, expect, it } from 'vitest';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { StoreHandle } from '../../main/backend/store/sqlite-store.js';
+import type { EmbeddingSurface } from '../../main/backend/ingest/embedder.js';
+import { openStore } from '../../main/backend/store/sqlite-store.js';
+import { HashEmbedder } from '../../main/backend/ingest/embedder.js';
+import {
+  createRetrievalSurface,
+  hybridRetrieve,
+  recencyWeight,
+  rrfFuse,
+  type RerankerSurface,
+  type RetrievedChunk,
+} from '../../main/backend/retrieval/hybrid.js';
+
+const THIS_DIR = path.dirname(fileURLToPath(import.meta.url));
+const DIMS = 8;
+/** RRF k default frozen by AC1/AC2 (retrieval.rrfK = 60). */
+const RRF_K = 60;
+
+/** Repo-root discovery via the established contracts marker (b4/b5/b6 convention). */
+function findRepoRoot(dir: string): string {
+  let current = dir;
+  for (let i = 0; i < 32; i += 1) {
+    if (fs.existsSync(path.join(current, 'contracts', 'api.openapi.yaml'))) return current;
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  throw new Error('could not locate the repo root (marker contracts/api.openapi.yaml not found)');
+}
+
+const REPO_ROOT = findRepoRoot(THIS_DIR);
+const NATIVE_DEPS_PRESENT = fs.existsSync(path.join(REPO_ROOT, 'desktop', 'node_modules', 'better-sqlite3'));
+const itReal = NATIVE_DEPS_PRESENT ? it : it.skip;
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir !== undefined) fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeTempDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function sha256Hex(text: string): string {
+  return createHash('sha256').update(text, 'utf8').digest('hex');
+}
+
+interface SeedDoc {
+  docId: string;
+  path: string;
+  chunks: Array<{ chunkId: string; text: string }>;
+}
+
+/** Hand-seed docs/chunks/embeddings/chunks_fts exactly like the B5 interop writer. */
+async function seedStore(store: StoreHandle, docs: SeedDoc[], embedder: EmbeddingSurface): Promise<void> {
+  const insertDoc = store.db.prepare(
+    'INSERT INTO docs (id, source_class, path, sha256, title, published_at, pack_id) VALUES (?, ?, ?, ?, ?, ?, ?)',
+  );
+  const insertChunk = store.db.prepare(
+    'INSERT INTO chunks (id, doc_id, chunk_index, text, content_hash) VALUES (?, ?, ?, ?, ?)',
+  );
+  const insertFts = store.db.prepare('INSERT INTO chunks_fts (chunk_id, text) VALUES (?, ?)');
+  const insertEmbedding = store.db.prepare('INSERT INTO embeddings (chunk_id, embedding) VALUES (?, ?)');
+  const allTexts = docs.flatMap((doc) => doc.chunks.map((chunk) => chunk.text));
+  store.db.exec('BEGIN IMMEDIATE');
+  try {
+    for (const doc of docs) {
+      insertDoc.run(doc.docId, 'test', doc.path, sha256Hex(doc.chunks.map((c) => c.text).join('\n')), doc.docId, null, null);
+      doc.chunks.forEach((chunk, index) => {
+        insertChunk.run(chunk.chunkId, doc.docId, index, chunk.text, sha256Hex(chunk.text));
+        insertFts.run(chunk.chunkId, chunk.text);
+      });
+    }
+    store.db.exec('COMMIT');
+  } catch (err) {
+    try {
+      store.db.exec('ROLLBACK');
+    } catch {
+      /* closed by caller */
+    }
+    throw err;
+  }
+  // Embeddings outside the transaction (vec0 rows cannot join a BEGIN in some
+  // sqlite-vec builds; the interop writer inserts them plainly too).
+  const embedded = await embedder.embed(allTexts);
+  docs.flatMap((doc) => doc.chunks).forEach((chunk, index) => {
+    insertEmbedding.run(chunk.chunkId, JSON.stringify(embedded[index]));
+  });
+}
+
+interface Fixture {
+  store: StoreHandle;
+  embedder: HashEmbedder;
+  texts: Record<string, string>;
+  paths: Record<string, string>;
+  dbPath: string;
+}
+
+/** Two docs x two chunks. chunk c1 owns the unique FTS token "b7zebra". */
+async function makeFixture(prefix: string): Promise<Fixture> {
+  const dir = makeTempDir(prefix);
+  const docOne = path.join(dir, 'docs', 'b7doc-one.md');
+  const docTwo = path.join(dir, 'docs', 'b7doc-two.md');
+  fs.mkdirSync(path.dirname(docOne), { recursive: true });
+  const texts: Record<string, string> = {
+    c1: 'b7zebra marker one',
+    c2: 'beta gamma two',
+    c3: 'delta epsilon three',
+    c4: 'zeta eta four',
+  };
+  const embedder = new HashEmbedder({ dims: DIMS });
+  const dbPath = path.join(dir, 'store.sqlite');
+  const store = openStore({ dbPath, dims: DIMS, repoRoot: REPO_ROOT });
+  await seedStore(
+    store,
+    [
+      { docId: 'd1', path: docOne, chunks: [{ chunkId: 'c1', text: texts.c1 }, { chunkId: 'c2', text: texts.c2 }] },
+      { docId: 'd2', path: docTwo, chunks: [{ chunkId: 'c3', text: texts.c3 }, { chunkId: 'c4', text: texts.c4 }] },
+    ],
+    embedder,
+  );
+  return { store, embedder, texts, paths: { c1: docOne, c2: docOne, c3: docTwo, c4: docTwo }, dbPath };
+}
+
+/** The vector leg the test derives independently (interop-pinned vec0 KNN form). */
+function knnLeg(store: StoreHandle, queryVector: number[], k: number): string[] {
+  const rows = store.db
+    .prepare('SELECT chunk_id, distance FROM embeddings WHERE embedding MATCH ? AND k = ? ORDER BY distance')
+    .all(JSON.stringify(queryVector), k) as Array<{ chunk_id: string; distance: number }>;
+  return rows.map((row) => row.chunk_id);
+}
+
+/** The FTS5 leg the test derives independently (single plain token => unambiguous). */
+function ftsLeg(store: StoreHandle, query: string): string[] {
+  const rows = store.db
+    .prepare('SELECT chunk_id FROM chunks_fts WHERE chunks_fts MATCH ? ORDER BY bm25(chunks_fts)')
+    .all(query) as Array<{ chunk_id: string }>;
+  return rows.map((row) => row.chunk_id);
+}
+
+/** Reference RRF scores for a two-leg fixture, using the frozen formula. */
+function expectedScores(vectorLeg: string[], ftsResult: string[]): Map<string, number> {
+  const scores = new Map<string, number>();
+  vectorLeg.forEach((id, rank) => scores.set(id, (scores.get(id) ?? 0) + 1 / (RRF_K + rank + 1)));
+  ftsResult.forEach((id, rank) => scores.set(id, (scores.get(id) ?? 0) + 1 / (RRF_K + rank + 1)));
+  return scores;
+}
+
+/** Counting embedder wrapper: pins "query embedding via the injected surface". */
+function countingEmbedder(inner: HashEmbedder): { embedder: EmbeddingSurface; calls: string[][] } {
+  const calls: string[][] = [];
+  const embedder: EmbeddingSurface = {
+    modelId: inner.modelId,
+    embed: async (texts) => {
+      calls.push([...texts]);
+      return inner.embed(texts);
+    },
+  };
+  return { embedder, calls };
+}
+
+describe('b7 C1 (AC1): rrfFuse — exact RRF arithmetic and dedup by chunk id', () => {
+  it('fuses two ranked legs with score 1/(rrfK + rank + 1), 0-based ranks, one entry per chunk', () => {
+    const fused = rrfFuse(['a', 'b', 'c'], ['b', 'a', 'd'], 60);
+    expect(fused.size).toBe(4);
+    // Exact doubles: the test computes the SAME expressions the pipeline must.
+    expect(fused.get('a')).toBe(1 / (60 + 0 + 1) + 1 / (60 + 1 + 1));
+    expect(fused.get('b')).toBe(1 / (60 + 1 + 1) + 1 / (60 + 0 + 1));
+    expect(fused.get('c')).toBe(1 / (60 + 2 + 1));
+    expect(fused.get('d')).toBe(1 / (60 + 2 + 1));
+    // Dedup: a chunk present in BOTH legs contributes from both legs but appears once.
+    expect(fused.get('a')).toBeGreaterThan(fused.get('c'));
+  });
+
+  it('empty legs fuse to an empty map', () => {
+    expect(rrfFuse([], [], 60).size).toBe(0);
+  });
+
+  it('rrfK is a real parameter (k=1 changes every score)', () => {
+    const fused = rrfFuse(['x'], [], 1);
+    expect(fused.get('x')).toBe(1 / (1 + 0 + 1));
+  });
+});
+
+describe('b7 C1 (AC1): hybridRetrieve — store-backed pipeline over vec0 + chunks_fts', () => {
+  itReal(
+    'fuses both legs with exact default-rrfK arithmetic, dedups, orders by score, fills text and source',
+    async () => {
+      const fx = await makeFixture('b7-c1-pipeline-');
+      try {
+        const { embedder, calls } = countingEmbedder(fx.embedder);
+        const query = 'b7zebra';
+        // Reference legs (independently derived from the seeded store). The
+        // REFERENCE embed uses the raw embedder so the counting wrapper sees
+        // ONLY the pipeline's own call (CHECK_WRONG amendment, issue #65 trace:
+        // the frozen original counted the reference embed too, making the
+        // exactly-once assertion unsatisfiable by any implementation).
+        const queryVector = (await fx.embedder.embed([query]))[0];
+        const vectorLeg = knnLeg(fx.store, queryVector, 4);
+        const ftsResult = ftsLeg(fx.store, query);
+        expect(ftsResult).toEqual(['c1']); // only c1 carries the token
+        const expected = expectedScores(vectorLeg, ftsResult);
+
+        const rows = await hybridRetrieve(query, { store: fx.store, embedder, topK: 4, candidateMultiplier: 1 });
+
+        // The injected embedder embedded the query exactly once, with the query text.
+        expect(calls).toHaveLength(1);
+        expect(calls[0]).toEqual([query]);
+
+        // Same chunk set as the reference fusion, each exactly once (dedup).
+        expect(rows.map((row) => row.chunkId).sort()).toEqual([...expected.keys()].sort());
+
+        // Exact fused scores with the DEFAULT rrfK=60 (no rrfK option passed).
+        for (const row of rows) {
+          expect(row.score).toBe(expected.get(row.chunkId));
+        }
+        // The both-legs chunk c1 keeps BOTH contributions (rank-0 FTS hit + its vector rank).
+        const c1 = rows.find((row) => row.chunkId === 'c1');
+        expect(c1).toBeDefined();
+        const c1VectorRank = vectorLeg.indexOf('c1');
+        expect(c1?.score).toBe(1 / (RRF_K + c1VectorRank + 1) + 1 / (RRF_K + 0 + 1));
+
+        // Descending order, populated text/source straight from the store.
+        for (let i = 1; i < rows.length; i += 1) {
+          expect(rows[i - 1].score).toBeGreaterThanOrEqual(rows[i].score);
+        }
+        for (const row of rows) {
+          expect(row.text).toBe(fx.texts[row.chunkId]);
+          expect(row.source).toBe(fx.paths[row.chunkId]);
+        }
+      } finally {
+        fx.store.close();
+      }
+    },
+  );
+
+  itReal('a query with no FTS hit still returns the vector leg (UNION semantics)', async () => {
+    const fx = await makeFixture('b7-c1-union-');
+    try {
+      const query = 'qqqxyzzy'; // matches no chunk text => empty FTS leg
+      expect(ftsLeg(fx.store, query)).toEqual([]);
+      const queryVector = (await fx.embedder.embed([query]))[0];
+      const vectorLeg = knnLeg(fx.store, queryVector, 4);
+      const expected = expectedScores(vectorLeg, []);
+      const rows = await hybridRetrieve(query, { store: fx.store, embedder: fx.embedder, topK: 4, candidateMultiplier: 1 });
+      expect(rows.map((row) => row.chunkId).sort()).toEqual([...expected.keys()].sort());
+      for (const row of rows) expect(row.score).toBe(expected.get(row.chunkId));
+    } finally {
+      fx.store.close();
+    }
+  });
+
+  itReal('an empty store returns [] and never calls the reranker', async () => {
+    const dir = makeTempDir('b7-c1-empty-');
+    const store = openStore({ dbPath: path.join(dir, 'store.sqlite'), dims: DIMS, repoRoot: REPO_ROOT });
+    let rerankerCalls = 0;
+    const reranker: RerankerSurface = {
+      score: async () => {
+        rerankerCalls += 1;
+        return [];
+      },
+    };
+    try {
+      const rows = await hybridRetrieve('anything', { store, embedder: new HashEmbedder({ dims: DIMS }), reranker });
+      expect(rows).toEqual([]);
+      expect(rerankerCalls).toBe(0);
+    } finally {
+      store.close();
+    }
+  });
+
+  itReal('the recency hook is consulted once per fused chunk and multiplies the fused score', async () => {
+    const fx = await makeFixture('b7-c1-recency-');
+    try {
+      const queryVector = (await fx.embedder.embed(['b7zebra']))[0];
+      const expected = expectedScores(knnLeg(fx.store, queryVector, 4), ftsLeg(fx.store, 'b7zebra'));
+      const seen: RetrievedChunk[] = [];
+      const rows = await hybridRetrieve('b7zebra', {
+        store: fx.store,
+        embedder: fx.embedder,
+        topK: 4,
+        candidateMultiplier: 1,
+        recency: (chunk) => {
+          seen.push(chunk);
+          return 0.5;
+        },
+      });
+      expect(seen).toHaveLength(4); // once per fused chunk, with populated rows
+      for (const chunk of seen) {
+        expect(typeof chunk.chunkId).toBe('string');
+        expect(chunk.text).toBe(fx.texts[chunk.chunkId]);
+      }
+      // 0.5 is a power of two: the halved fused score is EXACT.
+      for (const row of rows) expect(row.score).toBe((expected.get(row.chunkId) ?? 0) * 0.5);
+      for (let i = 1; i < rows.length; i += 1) expect(rows[i - 1].score).toBeGreaterThanOrEqual(rows[i].score);
+    } finally {
+      fx.store.close();
+    }
+  });
+
+  itReal(
+    'the reranker receives the fused candidate window in fused order; its scores replace RRF scores; the floor drops below-floor rows; the topK slice applies',
+    async () => {
+      const fx = await makeFixture('b7-c1-rerank-');
+      try {
+        const query = 'b7zebra';
+        const queryVector = (await fx.embedder.embed([query]))[0];
+        const expected = expectedScores(knnLeg(fx.store, queryVector, 4), ftsLeg(fx.store, query));
+        const fusedOrder = [...expected.entries()].sort((a, b) => b[1] - a[1]).map(([id]) => id);
+
+        const calls: Array<{ query: string; candidates: string[] }> = [];
+        const scoreTable = [0.9, 0.05, 0.8, 0.02];
+        const reranker: RerankerSurface = {
+          score: async (q, candidates) => {
+            calls.push({ query: q, candidates: [...candidates] });
+            return candidates.map((_, i) => scoreTable[i]);
+          },
+        };
+
+        // topK=2, candidateMultiplier=2 => legK=4 => the rerank window is ALL 4 fused chunks.
+        const rows = await hybridRetrieve(query, {
+          store: fx.store,
+          embedder: fx.embedder,
+          topK: 2,
+          candidateMultiplier: 2,
+          reranker,
+          relevanceFloor: 0.5,
+        });
+
+        // The reranker got the fused candidate set once, in fused order, with the raw texts.
+        expect(calls).toHaveLength(1);
+        expect(calls[0].query).toBe(query);
+        expect(calls[0].candidates).toEqual(fusedOrder.map((id) => fx.texts[id]));
+
+        // Floor 0.5 drops the 0.05 and 0.02 rows; survivors ordered by RERANKER score; sliced to topK=2.
+        expect(rows).toHaveLength(2);
+        expect(rows[0].chunkId).toBe(fusedOrder[0]);
+        expect(rows[0].score).toBe(0.9);
+        expect(rows[1].chunkId).toBe(fusedOrder[2]);
+        expect(rows[1].score).toBe(0.8);
+
+        // Boundary: a reranker score EXACTLY equal to the floor is kept.
+        const boundary = await hybridRetrieve(query, {
+          store: fx.store,
+          embedder: fx.embedder,
+          topK: 2,
+          candidateMultiplier: 2,
+          reranker: { score: async () => [0.9, 0.05, 0.8, 0.02] },
+          relevanceFloor: 0.9,
+        });
+        expect(boundary).toHaveLength(1);
+        expect(boundary[0].chunkId).toBe(fusedOrder[0]);
+        expect(boundary[0].score).toBe(0.9);
+      } finally {
+        fx.store.close();
+      }
+    },
+  );
+
+  itReal('candidates beyond the legK fused window are dropped when a reranker runs', async () => {
+    const fx = await makeFixture('b7-c1-window-');
+    try {
+      const query = 'b7zebra';
+      const queryVector = (await fx.embedder.embed([query]))[0];
+      const expected = expectedScores(knnLeg(fx.store, queryVector, 4), ftsLeg(fx.store, query));
+      const fusedOrder = [...expected.entries()].sort((a, b) => b[1] - a[1]).map(([id]) => id);
+      const seen: string[] = [];
+      const rows = await hybridRetrieve(query, {
+        store: fx.store,
+        embedder: fx.embedder,
+        topK: 2,
+        candidateMultiplier: 1, // legK=2: only the top-2 fused chunks reach the reranker
+        reranker: {
+          score: async (_q, candidates) => {
+            seen.push(...candidates);
+            return candidates.map((_, i) => (i === 0 ? 0.3 : 0.4));
+          },
+        },
+      });
+      expect(seen).toEqual([fx.texts[fusedOrder[0]], fx.texts[fusedOrder[1]]]);
+      // Only window chunks can appear, ordered by reranker score (0.4 before 0.3).
+      expect(rows).toHaveLength(2);
+      expect(rows[0].chunkId).toBe(fusedOrder[1]);
+      expect(rows[0].score).toBe(0.4);
+      expect(rows[1].chunkId).toBe(fusedOrder[0]);
+      expect(rows[1].score).toBe(0.3);
+    } finally {
+      fx.store.close();
+    }
+  });
+
+  itReal('without a reranker the relevance floor is NOT applied to RRF-scale scores', async () => {
+    const fx = await makeFixture('b7-c1-nofloor-');
+    try {
+      // A floor of 1.0 on RRF scores (~0.016-0.033) would drop EVERYTHING; the
+      // floor gates reranker scores only (frozen semantics; see file header).
+      const rows = await hybridRetrieve('b7zebra', {
+        store: fx.store,
+        embedder: fx.embedder,
+        topK: 4,
+        candidateMultiplier: 1,
+        relevanceFloor: 1.0,
+      });
+      expect(rows).toHaveLength(4);
+      for (const row of rows) expect(row.score).toBeLessThan(1.0);
+    } finally {
+      fx.store.close();
+    }
+  });
+});
+
+describe('b7 C1 (AC1): createRetrievalSurface — wire shape adapter', () => {
+  itReal('maps RetrievedChunk rows onto the frozen /search row shape with similarity = score', async () => {
+    const fx = await makeFixture('b7-c1-surface-');
+    try {
+      const surface = createRetrievalSurface({ store: fx.store, embedder: fx.embedder });
+      const rows = await surface.search('b7zebra', 5);
+      expect(rows.length).toBeGreaterThanOrEqual(1);
+      expect(rows.length).toBeLessThanOrEqual(5);
+      const queryVector = (await fx.embedder.embed(['b7zebra']))[0];
+      const expected = expectedScores(knnLeg(fx.store, queryVector, 4), ftsLeg(fx.store, 'b7zebra'));
+      // Every returned row identifies a seeded chunk: text, source and
+      // similarity are store-backed, and similarity mirrors the fused score.
+      const textToChunk = new Map(Object.entries(fx.texts).map(([id, text]) => [text, id]));
+      const sources = new Set(Object.values(fx.paths));
+      expect(rows.length).toBeGreaterThanOrEqual(1);
+      for (const row of rows) {
+        expect(textToChunk.has(row.text)).toBe(true);
+        expect(sources.has(row.source)).toBe(true);
+        expect(row.similarity).toBe(expected.get(textToChunk.get(row.text) as string));
+      }
+    } finally {
+      fx.store.close();
+    }
+  });
+
+  itReal('the default recency hook is the exported recencyWeight (inert)', async () => {
+    const fx = await makeFixture('b7-c1-defrecency-');
+    try {
+      const rows = await hybridRetrieve('b7zebra', { store: fx.store, embedder: fx.embedder, topK: 4, candidateMultiplier: 1 });
+      expect(recencyWeight({})).toBe(1);
+      for (const row of rows) expect(row.score).toBeGreaterThan(0);
+    } finally {
+      fx.store.close();
+    }
+  });
+});

--- a/desktop/src/__tests__/b7-ort-ownership-guardrail.test.ts
+++ b/desktop/src/__tests__/b7-ort-ownership-guardrail.test.ts
@@ -1,0 +1,96 @@
+/**
+ * B7 guardrail (issue #65): SINGLE-THREAD ORT OWNERSHIP.
+ *
+ * onnxruntime-node 1.21 aborts the whole process (exit 134) when the same
+ * module is used from the main thread AND a user worker thread. The B7 fix
+ * concentrates ALL native ONNX work (embedding + reranking) inside the one
+ * rerank worker (`retrieval/rerank-worker.ts`); the main thread only talks to
+ * it through the WorkerEmbedder/WorkerReranker proxies, and the ingest
+ * embedder (`ingest/embedder.ts`) remains the only other allowed ONNX owner
+ * (it is not used concurrently with the worker — see index.ts wiring).
+ *
+ * This source scan fails when the transformers.js / onnxruntime-node stack is
+ * imported or its model APIs are called OUTSIDE those owner files, or when a
+ * second worker thread appears outside the WorkerReranker spawn site.
+ * Discovered empirically via repro/mix-probe.mjs (main embed -> worker rerank
+ * -> main embed == deterministic OnFatalError abort).
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const backendDir = path.resolve(__dirname, '..', '..', 'main', 'backend');
+
+// Files allowed to import/run the native ONNX stack (see module header).
+// Forward slashes: compared against rel paths normalized via split(sep).join('/').
+const ONNX_OWNER_FILES = new Set(['ingest/embedder.ts', 'retrieval/rerank-worker.ts']);
+// The only permitted worker-thread spawn site (owns all ONNX work).
+const WORKER_SPAWN_OWNER = 'retrieval/reranker.ts';
+
+const ONNX_API_PATTERN =
+  /from_pretrained|pipeline\(|AutoModelForSequenceClassification|AutoTokenizer|InferenceSession|session\.run/;
+const ONNX_IMPORT_PATTERN = /import\('@huggingface\/transformers'\)|from 'onnxruntime-node'|require\('onnxruntime-node'\)/;
+const WORKER_SPAWN_PATTERN = /new Worker\(/;
+
+function listTypeScriptFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...listTypeScriptFiles(full));
+    } else if (entry.endsWith('.ts')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function relativeSource(file: string): { rel: string; lines: string[] } {
+  return {
+    rel: path.relative(backendDir, file).split(path.sep).join('/'),
+    lines: readFileSync(file, 'utf8').split(/\r?\n/),
+  };
+}
+
+describe('B7 single-thread ORT ownership guardrail (issue #65)', () => {
+  it('keeps every ONNX model API call inside the owner files', () => {
+    const violations: string[] = [];
+    for (const file of listTypeScriptFiles(backendDir)) {
+      const { rel, lines } = relativeSource(file);
+      if (ONNX_OWNER_FILES.has(rel)) continue;
+      lines.forEach((line, index) => {
+        if (ONNX_API_PATTERN.test(line)) {
+          violations.push(`${rel}:${index + 1}: ${line.trim()}`);
+        }
+      });
+    }
+    expect(violations, `ONNX API calls outside owner files:\n${violations.join('\n')}`).toEqual([]);
+  });
+
+  it('keeps every transformers.js / onnxruntime-node import inside the owner files', () => {
+    const violations: string[] = [];
+    for (const file of listTypeScriptFiles(backendDir)) {
+      const { rel, lines } = relativeSource(file);
+      if (ONNX_OWNER_FILES.has(rel)) continue;
+      lines.forEach((line, index) => {
+        if (ONNX_IMPORT_PATTERN.test(line)) {
+          violations.push(`${rel}:${index + 1}: ${line.trim()}`);
+        }
+      });
+    }
+    expect(violations, `ONNX stack imports outside owner files:\n${violations.join('\n')}`).toEqual([]);
+  });
+
+  it('allows worker threads only at the reranker spawn site', () => {
+    const violations: string[] = [];
+    for (const file of listTypeScriptFiles(backendDir)) {
+      const { rel, lines } = relativeSource(file);
+      lines.forEach((line, index) => {
+        if (WORKER_SPAWN_PATTERN.test(line) && rel !== WORKER_SPAWN_OWNER) {
+          violations.push(`${rel}:${index + 1}: ${line.trim()}`);
+        }
+      });
+    }
+    expect(violations, `worker spawns outside ${WORKER_SPAWN_OWNER}:\n${violations.join('\n')}`).toEqual([]);
+  });
+});

--- a/desktop/src/__tests__/b7-recency-hook.test.ts
+++ b/desktop/src/__tests__/b7-recency-hook.test.ts
@@ -1,0 +1,79 @@
+// b7-recency-hook.test.ts — FROZEN ACCEPTANCE SPEC (issue #65 trace, AC6 / check C6).
+//
+// This file is a frozen acceptance spec authored by the issue-tracer v3 CHECK
+// AUTHOR. It pins the no-op recency hook the implementer must export from
+// desktop/main/backend/retrieval/hybrid.ts:
+//
+//   export function recencyWeight(chunk: unknown): number;
+//
+// The Knowledge Pack recency logic is OUT of scope for issue #65 (it lands with
+// C4/#71); for THIS issue the hook must be provably INERT: it returns EXACTLY
+// the number 1 for every input shape — falsy fields, missing fields, weird
+// types — without throwing and without reading anything. It must FAIL at the
+// base revision (retrieval/hybrid.js does not exist).
+import { describe, expect, it } from 'vitest';
+import { recencyWeight } from '../../main/backend/retrieval/hybrid.js';
+
+/** Every input shape the hook must survive inertly. */
+const INPUTS: unknown[] = [
+  undefined,
+  null,
+  false,
+  0,
+  -1,
+  Number.NaN,
+  Number.POSITIVE_INFINITY,
+  42,
+  0.5,
+  '',
+  'chunk',
+  '2020-01-01T00:00:00Z',
+  Symbol('b7-recency-symbol'),
+  BigInt(7),
+  [],
+  [1, 2, 3],
+  ['publishedAt'],
+  {},
+  Object.create(null),
+  Object.freeze({ frozen: true }),
+  new Date('2020-06-01T00:00:00Z'),
+  new Map([['publishedAt', 'x']]),
+  new Set(['publishedAt']),
+  () => 'a function',
+  { chunkId: 'c1' },
+  { text: 'some text' },
+  { source: 'docs/a.md' },
+  { score: 0.25 },
+  { chunkId: 'c1', text: 't', source: 's', score: 1 },
+  { publishedAt: '2020-01-01T00:00:00Z' },
+  { publishedAt: null },
+  { publishedAt: undefined },
+  { publishedAt: 0 },
+  { publishedAt: 1234567890 },
+  { publishedAt: { nested: { deeper: true } } },
+  { publishedAt: ['an', 'array'] },
+  { pack_id: 'pack-1', supersededAt: null },
+  { doc: { path: 'x' }, chunk: { index: 3 }, pack: null },
+  { get chunkId() { return 'getter'; } },
+  { toString: 7, constructor: 8, valueOf: null },
+  new Error('an error object'),
+  Promise.resolve('a promise'),
+];
+
+describe('b7 C6 (AC6): recencyWeight is inert — exactly 1 for every input shape', () => {
+  it('returns the number 1 (strict equality) for every constructed input', () => {
+    for (const input of INPUTS) {
+      expect(recencyWeight(input)).toBe(1);
+    }
+  });
+
+  it('returns the number 1 when called with no argument at all', () => {
+    expect(recencyWeight()).toBe(1);
+  });
+
+  it('returns the number 1 repeatedly (no state, no drift)', () => {
+    for (let i = 0; i < 100; i += 1) {
+      expect(recencyWeight({ publishedAt: new Date(Date.now() - i * 1000).toISOString() })).toBe(1);
+    }
+  });
+});

--- a/desktop/src/__tests__/b7-rerank-worker.test.ts
+++ b/desktop/src/__tests__/b7-rerank-worker.test.ts
@@ -1,0 +1,155 @@
+// b7-rerank-worker.test.ts — FROZEN ACCEPTANCE SPEC (issue #65 trace, AC4 / check C4).
+//
+// This file is a frozen acceptance spec authored by the issue-tracer v3 CHECK
+// AUTHOR. It pins the worker-thread reranker runner the implementer must
+// provide at desktop/main/backend/retrieval/reranker.ts (with the production
+// worker ENTRY at desktop/main/backend/retrieval/rerank-worker.ts — the real
+// ONNX worker is the implementer's concern; this spec proves the RUNNER against
+// a fixture worker and needs NO model weights). It must FAIL at the base
+// revision (module does not exist).
+//
+// FROZEN PRODUCTION CONTRACT (module desktop/main/backend/retrieval/reranker.ts):
+//
+//   export interface RerankerRunnerOptions {
+//     workerPath?: string;  // absolute path to a worker entry; defaults to the
+//                           // compiled rerank-worker.js sibling of this module
+//     modelDir?: string;    // forwarded to the worker (workerData) for the
+//                           // production reranker; fixture workers ignore it
+//   }
+//   export class WorkerReranker implements RerankerSurface {
+//     constructor(options?: RerankerRunnerOptions);
+//     score(query: string, candidates: string[]): Promise<number[]>;
+//     dispose(): Promise<void>;  // terminates the worker; REJECTS in-flight jobs; idempotent
+//   }
+//
+// FROZEN WORKER MESSAGE PROTOCOL (the fixture below speaks it; the production
+// worker entry must speak the same):
+//   main -> worker:  { kind: 'rerank', jobId: number, query: string, candidates: string[] }
+//   worker -> main:  { kind: 'rerank:result', jobId: number, scores: number[] }
+//                or  { kind: 'rerank:error',   jobId: number, message: string }
+//
+// TOLERANCE JUSTIFICATION (the responsiveness assertions):
+//   The fixture worker BUSY-SLEEPS ~800ms on ITS OWN thread. If the rerank ran
+//   on the main/event-loop thread instead (the defect AC4 exists to prevent),
+//   the loop would be blocked for that whole window: a 5ms setInterval would
+//   tick ~0-2 times and a 25ms setTimeout probe could not settle before the
+//   block ends (~775ms+). With the work genuinely off-thread, the interval
+//   ticks ~160 times (even with Windows timer coarsening stretching 5ms to the
+//   ~15.6ms scheduler quantum: >= 51 ticks) and the probe settles in ~25-45ms.
+//   Bounds chosen with wide margins both ways: ticksDuring >= 40 (blocked can
+//   never reach it), probeMs < 300 (off-thread can never exceed it).
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { WorkerReranker } from '../../main/backend/retrieval/reranker.js';
+
+/**
+ * Fixture worker: busy-sleeps ~800ms on its own thread, then answers with
+ * deterministic descending scores (n-i)/n. Written to a temp dir AT RUNTIME so
+ * the spec stays self-contained and weight-free.
+ */
+const FIXTURE_WORKER_SOURCE = [
+  "import { parentPort } from 'node:worker_threads';",
+  'parentPort.on(\'message\', (msg) => {',
+  "  if (!msg || msg.kind !== 'rerank') return;",
+  '  const deadline = Date.now() + 800;',
+  '  while (Date.now() < deadline) { /* busy sleep: blocks ONLY this worker thread */ }',
+  '  const scores = msg.candidates.map((_, i) => (msg.candidates.length - i) / msg.candidates.length);',
+  "  parentPort.postMessage({ kind: 'rerank:result', jobId: msg.jobId, scores });",
+  '});',
+  '',
+].join('\n');
+
+function writeFixtureWorker(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'b7-c4-fixture-'));
+  const file = path.join(dir, 'fixture-rerank-worker.mjs');
+  fs.writeFileSync(file, FIXTURE_WORKER_SOURCE, 'utf8');
+  return file;
+}
+
+/** Remove the fixture's temp dir (best effort; vitest process exit also cleans /tmp). */
+function cleanupFixture(workerPath: string): void {
+  try {
+    fs.rmSync(path.dirname(workerPath), { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+}
+
+describe('b7 C4 (AC4): WorkerReranker runs the rerank OFF the main event loop', () => {
+  it(
+    'main loop stays responsive while the fixture worker busy-sleeps, and the job round-trips',
+    async () => {
+      const fixturePath = writeFixtureWorker();
+      const runner = new WorkerReranker({ workerPath: fixturePath });
+      let ticks = 0;
+      const timer = setInterval(() => {
+        ticks += 1;
+      }, 5);
+      try {
+        const ticksBeforeJob = ticks;
+        const jobStartedAt = Date.now();
+        const job = runner.score('b7 rerank query', ['alpha', 'beta', 'gamma', 'delta']);
+
+        // Concurrent promise settles promptly: a 25ms timer probe measured
+        // DURING the in-flight window. Off-thread: ~25-45ms (Windows timer
+        // coarsening adds at most ~20ms). Main-thread-blocked: >= ~750ms.
+        const probeStartedAt = Date.now();
+        await new Promise((resolve) => setTimeout(resolve, 25));
+        const probeMs = Date.now() - probeStartedAt;
+        expect(probeMs).toBeLessThan(300);
+
+        const scores = await job;
+        const jobMs = Date.now() - jobStartedAt;
+        const ticksDuring = ticks - ticksBeforeJob;
+
+        // The busy window really elapsed (the runner did not fake the work).
+        expect(jobMs).toBeGreaterThanOrEqual(700);
+        // The 5ms tick counter advanced THROUGH the in-flight window: with the
+        // work off-thread this is ~160 (>= 51 even under full Windows timer
+        // coarsening); a blocked event loop would tick ~0-2 times.
+        expect(ticksDuring).toBeGreaterThanOrEqual(40);
+
+        // Round-trip: deterministic fixture scores (n-i)/n, exact doubles.
+        expect(scores).toEqual([1, 0.75, 0.5, 0.25]);
+
+        // A second job over a different candidate list round-trips too.
+        const second = await runner.score('another query', ['x', 'y']);
+        expect(second).toEqual([1, 0.5]);
+
+        await runner.dispose();
+      } finally {
+        clearInterval(timer);
+        cleanupFixture(fixturePath);
+      }
+    },
+    20000,
+  );
+
+  it(
+    'dispose() terminates a busy worker promptly and rejects the in-flight job; dispose is idempotent',
+    async () => {
+      const fixturePath = writeFixtureWorker();
+      const runner = new WorkerReranker({ workerPath: fixturePath });
+      try {
+        const job = runner.score('terminate me', ['a', 'b', 'c']);
+        // Let the worker receive the job and enter its busy window.
+        await new Promise((resolve) => setTimeout(resolve, 150));
+        const disposeStartedAt = Date.now();
+        await runner.dispose();
+        const disposeMs = Date.now() - disposeStartedAt;
+        // Termination is prompt (well inside the remaining ~650ms busy window;
+        // generous bound for worker teardown on a loaded CI box).
+        expect(disposeMs).toBeLessThan(5000);
+        // A terminated worker cannot answer: the pending job must REJECT.
+        await expect(job).rejects.toThrow();
+        // Idempotent.
+        await runner.dispose();
+      } finally {
+        cleanupFixture(fixturePath);
+      }
+    },
+    20000,
+  );
+});

--- a/desktop/src/__tests__/b7-retrieval-config.test.ts
+++ b/desktop/src/__tests__/b7-retrieval-config.test.ts
@@ -1,0 +1,174 @@
+// b7-retrieval-config.test.ts — FROZEN ACCEPTANCE SPEC (issue #65 trace, AC2 / check C2).
+//
+// This file is a frozen acceptance spec authored by the issue-tracer v3 CHECK
+// AUTHOR. It pins the retrieval configuration module the implementer must
+// provide at desktop/main/backend/retrieval/config.ts, mirroring the frozen
+// defaults + env resolution pattern of desktop/main/backend/ingest/config.ts.
+// It must FAIL at the base revision (module does not exist).
+//
+// FROZEN PRODUCTION CONTRACT (module desktop/main/backend/retrieval/config.ts):
+//
+//   export interface RetrievalConfig {
+//     topK: number;               // retrieval.topK, default 10
+//     candidateMultiplier: number;// retrieval.candidateMultiplier, default 3
+//     rerank: boolean;            // retrieval.rerank, default true
+//     rrfK: number;               // retrieval.rrfK, default 60
+//     relevanceFloor: number;     // retrieval.relevanceFloor, CALIBRATED value (not 0.2)
+//   }
+//   export const DEFAULT_RETRIEVAL_CONFIG: Readonly<RetrievalConfig>;  // Object.freeze'd
+//   export function resolveRetrievalConfig(env?: Record<string, string | undefined>): RetrievalConfig;
+//   export const RETRIEVAL_TOPK_ENV = 'TRAININGAPP_RETRIEVAL_TOPK';
+//   export const RETRIEVAL_CANDIDATE_MULTIPLIER_ENV = 'TRAININGAPP_RETRIEVAL_CANDIDATE_MULTIPLIER';
+//   export const RETRIEVAL_RERANK_ENV = 'TRAININGAPP_RETRIEVAL_RERANK';
+//   export const RETRIEVAL_RRF_K_ENV = 'TRAININGAPP_RETRIEVAL_RRF_K';
+//   export const RETRIEVAL_RELEVANCE_FLOOR_ENV = 'TRAININGAPP_RETRIEVAL_RELEVANCE_FLOOR';
+//
+// Env parsing rules frozen here:
+//   - topK / candidateMultiplier / rrfK: positive integers only ('25' ok;
+//     'abc', '0', '-3', '2.5', '' all fall back to that key's default).
+//   - rerank: 'true'/'1' -> true, 'false'/'0' -> false, anything else -> default (true).
+//   - relevanceFloor: a finite float in [0, 1) ('0.42' ok; 'abc', '-0.1', '1.5' -> default).
+//   - Cross-field sanity ALWAYS holds on the resolved config: topK >= 1,
+//     candidateMultiplier >= 1, rrfK >= 1, 0 <= relevanceFloor < 1.
+//
+// The calibrated floor must be RECORDED in docs/adr/0007-relevance-floor-calibration.md
+// as a line of the exact form `floor: <float>` (first such line wins), together
+// with a `## Procedure` section; the recorded number must equal
+// DEFAULT_RETRIEVAL_CONFIG.relevanceFloor exactly and must NOT be 0.2 (the
+// browser's un-revalidated value, web_ui rag-orchestrator.ts MIN_CROSS_SCORE).
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  DEFAULT_RETRIEVAL_CONFIG,
+  RETRIEVAL_CANDIDATE_MULTIPLIER_ENV,
+  RETRIEVAL_RERANK_ENV,
+  RETRIEVAL_RRF_K_ENV,
+  RETRIEVAL_RELEVANCE_FLOOR_ENV,
+  RETRIEVAL_TOPK_ENV,
+  resolveRetrievalConfig,
+} from '../../main/backend/retrieval/config.js';
+
+const THIS_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+/** Repo-root discovery via the established contracts marker. */
+function findRepoRoot(dir: string): string {
+  let current = dir;
+  for (let i = 0; i < 32; i += 1) {
+    if (fs.existsSync(path.join(current, 'contracts', 'api.openapi.yaml'))) return current;
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  throw new Error('could not locate the repo root (marker contracts/api.openapi.yaml not found)');
+}
+
+const REPO_ROOT = findRepoRoot(THIS_DIR);
+const ADR_PATH = path.join(REPO_ROOT, 'docs', 'adr', '0007-relevance-floor-calibration.md');
+
+describe('b7 C2 (AC2): resolveRetrievalConfig frozen defaults', () => {
+  it('defaults: topK=10, candidateMultiplier=3, rerank=true, rrfK=60', () => {
+    const config = resolveRetrievalConfig({});
+    expect(config.topK).toBe(10);
+    expect(config.candidateMultiplier).toBe(3);
+    expect(config.rerank).toBe(true);
+    expect(config.rrfK).toBe(60);
+    // The frozen-defaults pattern (mirrors ingest/config.ts DEFAULT_INGEST_CONFIG).
+    expect(DEFAULT_RETRIEVAL_CONFIG.topK).toBe(10);
+    expect(DEFAULT_RETRIEVAL_CONFIG.candidateMultiplier).toBe(3);
+    expect(DEFAULT_RETRIEVAL_CONFIG.rerank).toBe(true);
+    expect(DEFAULT_RETRIEVAL_CONFIG.rrfK).toBe(60);
+    expect(Object.isFrozen(DEFAULT_RETRIEVAL_CONFIG)).toBe(true);
+  });
+
+  it('the env-var names are exactly the documented TRAININGAPP_RETRIEVAL_* keys', () => {
+    expect(RETRIEVAL_TOPK_ENV).toBe('TRAININGAPP_RETRIEVAL_TOPK');
+    expect(RETRIEVAL_CANDIDATE_MULTIPLIER_ENV).toBe('TRAININGAPP_RETRIEVAL_CANDIDATE_MULTIPLIER');
+    expect(RETRIEVAL_RERANK_ENV).toBe('TRAININGAPP_RETRIEVAL_RERANK');
+    expect(RETRIEVAL_RRF_K_ENV).toBe('TRAININGAPP_RETRIEVAL_RRF_K');
+    expect(RETRIEVAL_RELEVANCE_FLOOR_ENV).toBe('TRAININGAPP_RETRIEVAL_RELEVANCE_FLOOR');
+  });
+});
+
+describe('b7 C2 (AC2): the calibrated relevance floor (distinct from the browser 0.2)', () => {
+  it('the default floor is a number in [0, 1) and is NOT 0.2', () => {
+    const floor = DEFAULT_RETRIEVAL_CONFIG.relevanceFloor;
+    expect(typeof floor).toBe('number');
+    expect(Number.isFinite(floor)).toBe(true);
+    expect(floor).toBeGreaterThanOrEqual(0);
+    expect(floor).toBeLessThan(1);
+    expect(floor).not.toBe(0.2);
+    expect(resolveRetrievalConfig({}).relevanceFloor).toBe(floor);
+  });
+
+  it('docs/adr/0007-relevance-floor-calibration.md records the same value plus a Procedure section', () => {
+    expect(fs.existsSync(ADR_PATH)).toBe(true);
+    const contents = fs.readFileSync(ADR_PATH, 'utf8');
+    expect(contents).toContain('## Procedure');
+    const match = contents.match(/^floor:[ \t]*([0-9]*\.?[0-9]+)[ \t]*$/m);
+    expect(match).not.toBeNull();
+    const documented = Number.parseFloat(match?.[1] ?? '');
+    expect(Number.isFinite(documented)).toBe(true);
+    expect(documented).not.toBe(0.2);
+    // The ADR number and the shipped default are the SAME double.
+    expect(documented).toBe(DEFAULT_RETRIEVAL_CONFIG.relevanceFloor);
+  });
+});
+
+describe('b7 C2 (AC2): env overrides', () => {
+  it('valid values override every key', () => {
+    expect(resolveRetrievalConfig({ [RETRIEVAL_TOPK_ENV]: '25' }).topK).toBe(25);
+    expect(resolveRetrievalConfig({ [RETRIEVAL_CANDIDATE_MULTIPLIER_ENV]: '7' }).candidateMultiplier).toBe(7);
+    expect(resolveRetrievalConfig({ [RETRIEVAL_RRF_K_ENV]: '17' }).rrfK).toBe(17);
+    expect(resolveRetrievalConfig({ [RETRIEVAL_RELEVANCE_FLOOR_ENV]: '0.42' }).relevanceFloor).toBe(0.42);
+    expect(resolveRetrievalConfig({ [RETRIEVAL_RERANK_ENV]: 'false' }).rerank).toBe(false);
+    expect(resolveRetrievalConfig({ [RETRIEVAL_RERANK_ENV]: '0' }).rerank).toBe(false);
+    expect(resolveRetrievalConfig({ [RETRIEVAL_RERANK_ENV]: 'true' }).rerank).toBe(true);
+    expect(resolveRetrievalConfig({ [RETRIEVAL_RERANK_ENV]: '1' }).rerank).toBe(true);
+    // Non-overridden keys keep their defaults in the same resolution.
+    const both = resolveRetrievalConfig({ [RETRIEVAL_TOPK_ENV]: '5', [RETRIEVAL_RRF_K_ENV]: '9' });
+    expect(both).toMatchObject({ topK: 5, rrfK: 9, candidateMultiplier: 3, rerank: true });
+  });
+
+  it('invalid values fall back to that key default (never NaN, never throw)', () => {
+    for (const bad of ['abc', '0', '-3', '2.5', '', ' 8', 'null']) {
+      expect(resolveRetrievalConfig({ [RETRIEVAL_TOPK_ENV]: bad }).topK).toBe(10);
+      expect(resolveRetrievalConfig({ [RETRIEVAL_CANDIDATE_MULTIPLIER_ENV]: bad }).candidateMultiplier).toBe(3);
+      expect(resolveRetrievalConfig({ [RETRIEVAL_RRF_K_ENV]: bad }).rrfK).toBe(60);
+    }
+    for (const bad of ['yes', 'maybe', '', 'TRUE?', 'on']) {
+      expect(resolveRetrievalConfig({ [RETRIEVAL_RERANK_ENV]: bad }).rerank).toBe(true);
+    }
+    for (const bad of ['abc', '-0.1', '1.5', '2', '', 'zero']) {
+      expect(resolveRetrievalConfig({ [RETRIEVAL_RELEVANCE_FLOOR_ENV]: bad }).relevanceFloor).toBe(
+        DEFAULT_RETRIEVAL_CONFIG.relevanceFloor,
+      );
+    }
+  });
+
+  it('cross-field sanity holds under adversarial env combinations', () => {
+    const adversarial = [
+      { [RETRIEVAL_TOPK_ENV]: '0', [RETRIEVAL_CANDIDATE_MULTIPLIER_ENV]: '0', [RETRIEVAL_RRF_K_ENV]: '-1' },
+      { [RETRIEVAL_TOPK_ENV]: '-999999', [RETRIEVAL_CANDIDATE_MULTIPLIER_ENV]: 'abc' },
+      { [RETRIEVAL_TOPK_ENV]: '3.5', [RETRIEVAL_CANDIDATE_MULTIPLIER_ENV]: '2.5' },
+      { [RETRIEVAL_RELEVANCE_FLOOR_ENV]: '7', [RETRIEVAL_RRF_K_ENV]: '0' },
+    ];
+    for (const env of adversarial) {
+      const config = resolveRetrievalConfig(env);
+      expect(config.topK).toBeGreaterThanOrEqual(1);
+      expect(config.candidateMultiplier).toBeGreaterThanOrEqual(1);
+      expect(config.rrfK).toBeGreaterThanOrEqual(1);
+      expect(config.relevanceFloor).toBeGreaterThanOrEqual(0);
+      expect(config.relevanceFloor).toBeLessThan(1);
+      expect(typeof config.rerank).toBe('boolean');
+    }
+  });
+
+  it('resolveRetrievalConfig() with no argument reads process.env without crashing', () => {
+    const config = resolveRetrievalConfig();
+    expect(config.topK).toBeGreaterThanOrEqual(1);
+    expect(config.candidateMultiplier).toBeGreaterThanOrEqual(1);
+    expect(config.rrfK).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/desktop/src/__tests__/b7-retrieval-fts-sanitize.test.ts
+++ b/desktop/src/__tests__/b7-retrieval-fts-sanitize.test.ts
@@ -1,0 +1,92 @@
+// b7-retrieval-fts-sanitize.test.ts — SUPPLEMENTARY spec (issue #65, AC1 edge
+// cases; NOT a frozen acceptance check). Pins the FTS5 leg sanitization: user
+// queries containing FTS5 operators/quotes/stars must never throw; plain
+// tokens behave identically to the raw MATCH form.
+import { afterEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { openStore } from '../../main/backend/store/sqlite-store.js';
+import { HashEmbedder } from '../../main/backend/ingest/embedder.js';
+import { hybridRetrieve, sanitizeFtsQuery } from '../../main/backend/retrieval/hybrid.js';
+
+const THIS_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+function findRepoRoot(dir: string): string {
+  let current = dir;
+  for (let i = 0; i < 32; i += 1) {
+    if (fs.existsSync(path.join(current, 'contracts', 'api.openapi.yaml'))) return current;
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  throw new Error('could not locate the repo root (marker contracts/api.openapi.yaml not found)');
+}
+
+const REPO_ROOT = findRepoRoot(THIS_DIR);
+const NATIVE_DEPS_PRESENT = fs.existsSync(path.join(REPO_ROOT, 'desktop', 'node_modules', 'better-sqlite3'));
+const itReal = NATIVE_DEPS_PRESENT ? it : it.skip;
+const DIMS = 8;
+
+const tempDirs: string[] = [];
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir !== undefined) fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function seed(prefix: string): ReturnType<typeof Object> | any {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  const dbPath = path.join(dir, 'store.sqlite');
+  const store = openStore({ dbPath, dims: DIMS, repoRoot: REPO_ROOT });
+  const text = 'travel policy mileage rate guidance';
+  store.db
+    .prepare("INSERT INTO docs (id, source_class, path, sha256) VALUES ('d1', 'test', ?, ?)")
+    .run(path.join(dir, 'travel-policy.md'), 'sha');
+  store.db
+    .prepare("INSERT INTO chunks (id, doc_id, chunk_index, text, content_hash) VALUES ('c1', 'd1', 0, ?, ?)")
+    .run(text, 'sha');
+  store.db.prepare('INSERT INTO chunks_fts (chunk_id, text) VALUES (?, ?)').run('c1', text);
+  return { store, embedder: new HashEmbedder({ dims: DIMS }) };
+}
+
+describe('b7 supplementary: FTS5 query sanitization (issue #65 AC1 edge case)', () => {
+  it('sanitizeFtsQuery quotes plain tokens and drops operator/bare-quote/star tokens', () => {
+    expect(sanitizeFtsQuery('travel policy')).toBe('"travel" "policy"');
+    expect(sanitizeFtsQuery('"travel"')).toBeNull();
+    expect(sanitizeFtsQuery('travel*')).toBeNull();
+    expect(sanitizeFtsQuery('AND OR NOT')).toBeNull();
+    expect(sanitizeFtsQuery('a AND b')).toBe('"a" "b"');
+    expect(sanitizeFtsQuery('col:val ^x NEAR(y,z)')).toBeNull();
+    expect(sanitizeFtsQuery('   ')).toBeNull();
+  });
+
+  itReal('operator-heavy queries never throw and plain queries still match', async () => {
+    const fx = seed('b7-fts-');
+    try {
+      const plain = await hybridRetrieve('travel policy', {
+        store: fx.store,
+        embedder: fx.embedder,
+        topK: 4,
+        candidateMultiplier: 1,
+      });
+      expect(plain.length).toBeGreaterThanOrEqual(1);
+      expect(plain[0].text).toContain('travel policy');
+
+      for (const dirty of ['"travel"', 'travel*', 'AND OR NOT', 'a: NEAR(b c) ^', '   ']) {
+        const rows = await hybridRetrieve(dirty, {
+          store: fx.store,
+          embedder: fx.embedder,
+          topK: 4,
+          candidateMultiplier: 1,
+        });
+        expect(Array.isArray(rows)).toBe(true);
+      }
+    } finally {
+      fx.store.close();
+    }
+  });
+});

--- a/desktop/src/__tests__/b7-review-hardening.test.ts
+++ b/desktop/src/__tests__/b7-review-hardening.test.ts
@@ -1,0 +1,226 @@
+// b7-review-hardening.test.ts — ADDITIVE regression tests for the PR #102
+// review findings (PRR-004/005/008/011/017/018). Deliberately a NEW file: the
+// frozen B7 acceptance specs must not be edited (issue-tracer checkpoint
+// contract). Mirrors the C1 spec's fixture style (HashEmbedder, dims 8,
+// interop-pinned store seed).
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { StoreHandle } from '../../main/backend/store/sqlite-store.js';
+import type { EmbeddingSurface } from '../../main/backend/ingest/embedder.js';
+import { openStore } from '../../main/backend/store/sqlite-store.js';
+import { HashEmbedder } from '../../main/backend/ingest/embedder.js';
+import { resolveRetrievalConfig } from '../../main/backend/retrieval/config.js';
+import {
+  createRetrievalSurface,
+  hybridRetrieve,
+  sanitizeFtsQuery,
+  type RerankerSurface,
+} from '../../main/backend/retrieval/hybrid.js';
+
+const THIS_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = findRepoRoot(THIS_DIR);
+const NATIVE_DEPS_PRESENT = fs.existsSync(path.join(REPO_ROOT, 'desktop', 'node_modules', 'better-sqlite3'));
+const itReal = NATIVE_DEPS_PRESENT ? it : it.skip;
+const DIMS = 8;
+
+function findRepoRoot(dir: string): string {
+  let current = dir;
+  for (let i = 0; i < 32; i += 1) {
+    if (fs.existsSync(path.join(current, 'contracts', 'api.openapi.yaml'))) return current;
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  throw new Error('could not locate the repo root (marker contracts/api.openapi.yaml not found)');
+}
+
+function sha256Hex(input: string): string {
+  return createHash('sha256').update(input).digest('hex');
+}
+
+const tempDirs: string[] = [];
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      /* best effort */
+    }
+  }
+});
+
+interface Fixture {
+  store: StoreHandle;
+  embedder: EmbeddingSurface;
+}
+
+async function makeFixture(prefix: string): Promise<Fixture> {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  const docOne = path.join(dir, 'docs', 'hardening-one.md');
+  const docTwo = path.join(dir, 'docs', 'hardening-two.md');
+  fs.mkdirSync(path.dirname(docOne), { recursive: true });
+  const embedder = new HashEmbedder({ dims: DIMS });
+  const store = openStore({ dbPath: path.join(dir, 'store.sqlite'), dims: DIMS, repoRoot: REPO_ROOT });
+  const insertDoc = store.db.prepare(
+    'INSERT INTO docs (id, source_class, path, sha256, title, published_at, pack_id) VALUES (?, ?, ?, ?, ?, ?, ?)',
+  );
+  const insertChunk = store.db.prepare(
+    'INSERT INTO chunks (id, doc_id, chunk_index, text, content_hash) VALUES (?, ?, ?, ?, ?)',
+  );
+  const insertFts = store.db.prepare('INSERT INTO chunks_fts (chunk_id, text) VALUES (?, ?)');
+  const insertEmbedding = store.db.prepare('INSERT INTO embeddings (chunk_id, embedding) VALUES (?, ?)');
+  const docs = [
+    {
+      docId: 'd1',
+      path: docOne,
+      chunks: [
+        { chunkId: 'c1', text: 'b7zebra marker one' },
+        { chunkId: 'c2', text: 'beta gamma two' },
+      ],
+    },
+    {
+      docId: 'd2',
+      path: docTwo,
+      chunks: [
+        { chunkId: 'c3', text: 'delta epsilon three' },
+        { chunkId: 'c4', text: 'zeta eta four' },
+      ],
+    },
+  ];
+  store.db.exec('BEGIN IMMEDIATE');
+  try {
+    for (const doc of docs) {
+      insertDoc.run(doc.docId, 'test', doc.path, sha256Hex(doc.chunks.map((c) => c.text).join('\n')), doc.docId, null, null);
+      doc.chunks.forEach((chunk, index) => {
+        insertChunk.run(chunk.chunkId, doc.docId, index, chunk.text, sha256Hex(chunk.text));
+        insertFts.run(chunk.chunkId, chunk.text);
+      });
+    }
+    store.db.exec('COMMIT');
+  } catch (err) {
+    try {
+      store.db.exec('ROLLBACK');
+    } catch {
+      /* closed by caller */
+    }
+    throw err;
+  }
+  const allTexts = docs.flatMap((doc) => doc.chunks.map((chunk) => chunk.text));
+  const vectors = await embedder.embed(allTexts);
+  let vectorIndex = 0;
+  docs.forEach((doc) => {
+    doc.chunks.forEach((chunk) => {
+      insertEmbedding.run(chunk.chunkId, JSON.stringify(vectors[vectorIndex]));
+      vectorIndex += 1;
+    });
+  });
+  return { store, embedder };
+}
+
+describe('b7 review hardening (PR #102 findings)', () => {
+  itReal('PRR-004: a failed reranker latches off for the surface lifetime (no per-query retry)', async () => {
+    const fx = await makeFixture('b7-hard-latch-');
+    try {
+      let calls = 0;
+      const flaky: RerankerSurface = {
+        score: vi.fn(async () => {
+          calls += 1;
+          throw new Error('worker exploded');
+        }),
+      };
+      const surface = createRetrievalSurface({
+        store: fx.store,
+        embedder: fx.embedder,
+        reranker: flaky,
+      });
+      const first = await surface.search('b7zebra', 4);
+      expect(first.length).toBeGreaterThanOrEqual(1); // degraded, not thrown
+      const second = await surface.search('b7zebra', 4);
+      expect(second.length).toBeGreaterThanOrEqual(1);
+      // The latch: the broken reranker is never consulted again.
+      expect(calls).toBe(1);
+    } finally {
+      fx.store.close();
+    }
+  });
+
+  itReal('PRR-005: non-finite reranker scores map to a finite score instead of poisoning the sort', async () => {
+    const fx = await makeFixture('b7-hard-nan-');
+    try {
+      const NaNReranker: RerankerSurface = { score: async () => [Number.NaN, 0.9, Number.NaN, 0.4] };
+      const rows = await hybridRetrieve('b7zebra', {
+        store: fx.store,
+        embedder: fx.embedder,
+        reranker: NaNReranker,
+        relevanceFloor: undefined,
+        topK: 4,
+        candidateMultiplier: 1,
+      });
+      expect(rows.length).toBeGreaterThanOrEqual(1);
+      for (const row of rows) expect(Number.isFinite(row.score)).toBe(true);
+      for (let i = 1; i < rows.length; i += 1) {
+        expect(rows[i - 1].score).toBeGreaterThanOrEqual(rows[i].score);
+      }
+    } finally {
+      fx.store.close();
+    }
+  });
+
+  itReal('PRR-008: a reranker that throws on every score degrades to the fused, floor-free ordering', async () => {
+    const fx = await makeFixture('b7-hard-degrade-');
+    try {
+      const broken: RerankerSurface = { score: async () => Promise.reject(new Error('dead')) };
+      const withBrokenFloor = createRetrievalSurface({
+        store: fx.store,
+        embedder: fx.embedder,
+        reranker: broken,
+        // A floor that would empty reranked RRF-scale results if wrongly applied.
+        config: { relevanceFloor: 1.0 },
+      });
+      const rows = await withBrokenFloor.search('b7zebra', 4);
+      expect(rows.length).toBeGreaterThanOrEqual(1);
+      for (const row of rows) expect(row.similarity).toBeLessThan(1.0);
+    } finally {
+      fx.store.close();
+    }
+  });
+
+  it('PRR-011: absurd env integers fall back to defaults (upper sanity bounds)', () => {
+    const env = (k: string, v: string): Record<string, string> => ({ [k]: v });
+    expect(resolveRetrievalConfig(env('TRAININGAPP_RETRIEVAL_TOPK', '999999999')).topK).toBe(10);
+    expect(resolveRetrievalConfig(env('TRAININGAPP_RETRIEVAL_TOPK', '1001')).topK).toBe(10);
+    expect(resolveRetrievalConfig(env('TRAININGAPP_RETRIEVAL_TOPK', '1000')).topK).toBe(1000);
+    expect(
+      resolveRetrievalConfig(env('TRAININGAPP_RETRIEVAL_CANDIDATE_MULTIPLIER', '999')).candidateMultiplier,
+    ).toBe(3);
+    expect(resolveRetrievalConfig(env('TRAININGAPP_RETRIEVAL_RRF_K', '99999999')).rrfK).toBe(60);
+  });
+
+  it('PRR-017: sanitizeFtsQuery preserves hyphen and tilde tokens', () => {
+    expect(sanitizeFtsQuery('well-known')).toBe('"well-known"');
+    expect(sanitizeFtsQuery('~prefix')).toBe('"~prefix"');
+    // The star in c* is an FTS5 operator and IS dropped (frozen rule); the
+    // hyphenated and tilde tokens must survive untouched.
+    expect(sanitizeFtsQuery('a "b" AND c*')).toBe('"a"');
+    expect(sanitizeFtsQuery('state-of-the-art ~2')).toBe('"state-of-the-art" "~2"');
+  });
+
+  itReal('PRR-018: surface rows are ordered by descending similarity', async () => {
+    const fx = await makeFixture('b7-hard-order-');
+    try {
+      const surface = createRetrievalSurface({ store: fx.store, embedder: fx.embedder });
+      const rows = await surface.search('b7zebra', 5);
+      expect(rows.length).toBeGreaterThanOrEqual(2);
+      for (let i = 1; i < rows.length; i += 1) {
+        expect(rows[i - 1].similarity).toBeGreaterThanOrEqual(rows[i].similarity);
+      }
+    } finally {
+      fx.store.close();
+    }
+  });
+});

--- a/desktop/src/__tests__/b7-wiring.test.ts
+++ b/desktop/src/__tests__/b7-wiring.test.ts
@@ -1,0 +1,278 @@
+// b7-wiring.test.ts — FROZEN ACCEPTANCE SPEC (issue #65 trace, AC5 / check C5).
+//
+// This file is a frozen acceptance spec authored by the issue-tracer v3 CHECK
+// AUTHOR. It pins the host/engine wiring of the hybrid retrieval surface: with
+// a real store (openStore + HashEmbedder), the retrieval surface attached
+// through the same late-binding seam as attachDocumentSurface makes POST
+// /search return store-backed rows (never the B3 'desktop-stub' row) and makes
+// the /ask response's sources come from retrieval. It must FAIL at the base
+// revision (retrieval/hybrid.js does not exist).
+//
+// FROZEN WIRING CONTRACT the implementer must provide:
+//   1. EngineSurface grows an optional late-binding seam named EXACTLY
+//      attachRetrievalSurface, mirroring attachDocumentSurface
+//      (desktop/main/backend/types.ts):
+//        attachRetrievalSurface?(surface: RetrievalSurface | null): void
+//      where RetrievalSurface is the interface exported from
+//      desktop/main/backend/retrieval/hybrid.ts (createRetrievalSurface builds it).
+//   2. When a retrieval surface is attached, engine.search() delegates to it
+//      (both StubEngine and LlamaEngine); attaching null detaches and restores
+//      the stub behavior.
+//   3. When a retrieval surface is attached, StubEngine.query() populates the
+//      /ask response's `sources` from the retrieval results' `source` values
+//      (ranked order; empty retrieval => empty sources).
+//   4. NodeBackendHost.start(), after opening a configured store, builds the
+//      retrieval surface (resolveEmbedder + resolveRetrievalConfig; reranker
+//      optional) and attaches it to the engine through the same seam — with the
+//      same failure isolation as the document surface. When no reranker weights
+//      are resolvable (e.g. TRAININGAPP_DESKTOP_EMBEDDER=hash dev/CI mode) the
+//      surface must degrade to RRF-only retrieval WITHOUT applying the
+//      relevance floor to RRF-scale scores (an empty response would otherwise
+//      masquerade as the stub being gone).
+import { afterEach, describe, expect, it } from 'vitest';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { Server } from 'node:http';
+import { NodeBackendHost } from '../../main/backend/index.js';
+import { StubEngine } from '../../main/backend/engine.js';
+import { createBackendServer, listenOnRandomPort } from '../../main/backend/server.js';
+import { createLoopbackGuard } from '../../main/security/loopback-guard.js';
+import { openStore } from '../../main/backend/store/sqlite-store.js';
+import { HashEmbedder } from '../../main/backend/ingest/embedder.js';
+import { createRetrievalSurface } from '../../main/backend/retrieval/hybrid.js';
+import { LlamaEngine, type LlamaEngineBackend } from '../../main/backend/inference/llama-engine.js';
+
+const THIS_DIR = path.dirname(fileURLToPath(import.meta.url));
+const TOKEN = 'b7-wiring-token';
+const DIMS = 8;
+const GB = 1024 ** 3;
+
+/** Repo-root discovery via the established contracts marker. */
+function findRepoRoot(dir: string): string {
+  let current = dir;
+  for (let i = 0; i < 32; i += 1) {
+    if (fs.existsSync(path.join(current, 'contracts', 'api.openapi.yaml'))) return current;
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  throw new Error('could not locate the repo root (marker contracts/api.openapi.yaml not found)');
+}
+
+const REPO_ROOT = findRepoRoot(THIS_DIR);
+const NATIVE_DEPS_PRESENT = fs.existsSync(path.join(REPO_ROOT, 'desktop', 'node_modules', 'better-sqlite3'));
+const itReal = NATIVE_DEPS_PRESENT ? it : it.skip;
+
+const tempDirs: string[] = [];
+const openServers: Server[] = [];
+
+afterEach(() => {
+  while (openServers.length > 0) {
+    const server = openServers.pop();
+    server?.close();
+  }
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir !== undefined) fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeTempDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function sha256Hex(text: string): string {
+  return createHash('sha256').update(text, 'utf8').digest('hex');
+}
+
+const MARKER = 'b7wiringzebra';
+const MARKER_TEXT = `${MARKER} unique marker contents for the wiring check`;
+
+interface SeededStore {
+  dbPath: string;
+  docPath: string;
+}
+
+/** One doc, one chunk carrying the marker token; embeddings via HashEmbedder. */
+async function seedMarkerStore(): Promise<SeededStore> {
+  const dir = makeTempDir('b7-c5-seed-');
+  const docPath = path.join(dir, 'docs', 'b7wiring-doc.md');
+  fs.mkdirSync(path.dirname(docPath), { recursive: true });
+  const dbPath = path.join(dir, 'store.sqlite');
+  const store = openStore({ dbPath, dims: DIMS, repoRoot: REPO_ROOT });
+  const embedder = new HashEmbedder({ dims: DIMS });
+  const vector = (await embedder.embed([MARKER_TEXT]))[0];
+  store.db.exec('BEGIN IMMEDIATE');
+  try {
+    store.db
+      .prepare('INSERT INTO docs (id, source_class, path, sha256, title, published_at, pack_id) VALUES (?, ?, ?, ?, ?, ?, ?)')
+      .run('d1', 'test', docPath, sha256Hex(MARKER_TEXT), 'd1', null, null);
+    store.db
+      .prepare('INSERT INTO chunks (id, doc_id, chunk_index, text, content_hash) VALUES (?, ?, ?, ?, ?)')
+      .run('c1', 'd1', 0, MARKER_TEXT, sha256Hex(MARKER_TEXT));
+    store.db.prepare('INSERT INTO chunks_fts (chunk_id, text) VALUES (?, ?)').run('c1', MARKER_TEXT);
+    store.db.exec('COMMIT');
+  } catch (err) {
+    try {
+      store.db.exec('ROLLBACK');
+    } catch {
+      /* closed below */
+    }
+    store.close();
+    throw err;
+  }
+  store.db.prepare('INSERT INTO embeddings (chunk_id, embedding) VALUES (?, ?)').run('c1', JSON.stringify(vector));
+  store.close();
+  return { dbPath, docPath };
+}
+
+async function postJson(port: number, route: string, body: unknown): Promise<{ status: number; body: unknown }> {
+  const response = await fetch(`http://127.0.0.1:${port}${route}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'x-desktop-token': TOKEN },
+    body: JSON.stringify(body),
+  });
+  return { status: response.status, body: await response.json().catch(() => null) };
+}
+
+interface SearchRow {
+  text: string;
+  source: string;
+  similarity: number;
+}
+
+/** Shared assertions: store-backed /search and populated /ask sources. */
+async function assertStoreBackedRoutes(port: number): Promise<void> {
+  const search = await postJson(port, '/search', { query: MARKER, n_results: 5 });
+  expect(search.status).toBe(200);
+  const rows = search.body as SearchRow[];
+  expect(Array.isArray(rows)).toBe(true);
+  expect(rows.length).toBeGreaterThanOrEqual(1);
+  // The seeded doc text is found; NO row is the B3 stub row.
+  expect(rows.some((row) => typeof row.text === 'string' && row.text.includes(MARKER))).toBe(true);
+  expect(rows.every((row) => typeof row.source === 'string' && !row.source.includes('desktop-stub'))).toBe(true);
+  expect(rows.some((row) => typeof row.source === 'string' && row.source.endsWith('b7wiring-doc.md'))).toBe(true);
+  for (const row of rows) expect(typeof row.similarity).toBe('number');
+
+  const ask = await postJson(port, '/ask', { question: `What does the ${MARKER} say?`, n_results: 5 });
+  expect(ask.status).toBe(200);
+  const askBody = ask.body as { sources?: string[] };
+  expect(Array.isArray(askBody.sources)).toBe(true);
+  expect(askBody.sources?.length).toBeGreaterThanOrEqual(1);
+  expect(askBody.sources?.some((source) => source.endsWith('b7wiring-doc.md'))).toBe(true);
+}
+
+describe('b7 C5 (AC5): NodeBackendHost wiring — the host attaches the retrieval surface', () => {
+  itReal(
+    'host with a configured store serves store-backed /search and populated /ask sources for a StubEngine',
+    async () => {
+      const seeded = await seedMarkerStore();
+      const host = new NodeBackendHost({
+        token: TOKEN,
+        storePath: seeded.dbPath,
+        storeEmbeddingDims: DIMS,
+        env: { TRAININGAPP_DESKTOP_EMBEDDER: 'hash' },
+        engine: new StubEngine(),
+      });
+      const handle = await host.start();
+      try {
+        await assertStoreBackedRoutes(handle.port);
+      } finally {
+        await host.stop();
+
+      }
+    },
+    20000,
+  );
+});
+
+describe('b7 C5 (AC5): engine seam — attachRetrievalSurface on the guarded server', () => {
+  itReal(
+    'StubEngine.search delegates to the attached surface; attachRetrievalSurface(null) restores the stub',
+    async () => {
+      const seeded = await seedMarkerStore();
+      const store = openStore({ dbPath: seeded.dbPath, dims: DIMS, repoRoot: REPO_ROOT });
+      const surface = createRetrievalSurface({ store, embedder: new HashEmbedder({ dims: DIMS }) });
+      const engine = new StubEngine();
+      expect(typeof (engine as { attachRetrievalSurface?: unknown }).attachRetrievalSurface).toBe('function');
+      (engine as { attachRetrievalSurface: (s: unknown) => void }).attachRetrievalSurface(surface);
+      const server = createBackendServer({
+        guard: createLoopbackGuard({ token: TOKEN, allowedOrigins: ['null'] }),
+        tokenHeaderName: 'X-Desktop-Token',
+        allowedOrigins: ['null'],
+        engine,
+      });
+      openServers.push(server);
+      const port = await listenOnRandomPort(server);
+      try {
+        await assertStoreBackedRoutes(port);
+
+        // Detach: the B3 stub row comes back (the seam is a two-way late bind).
+        (engine as { attachRetrievalSurface: (s: unknown) => void }).attachRetrievalSurface(null);
+        const stubbed = await postJson(port, '/search', { query: MARKER, n_results: 5 });
+        expect(stubbed.status).toBe(200);
+        const stubRows = stubbed.body as SearchRow[];
+        expect(stubRows.length).toBeGreaterThanOrEqual(1);
+        expect(stubRows.every((row) => row.source.includes('desktop-stub'))).toBe(true);
+      } finally {
+        store.close();
+
+      }
+    },
+    20000,
+  );
+});
+
+/** Minimal fake generation backend (b4 convention): no native llama, no weights. */
+class FakeLlamaBackend implements LlamaEngineBackend {
+  async generate(
+    _question: string,
+    opts: { streamCallback?: (token: string) => void },
+  ): Promise<{ answer: string; cancelled: boolean }> {
+    opts.streamCallback?.('fake ');
+    return { answer: 'fake answer', cancelled: false };
+  }
+
+  async dispose(): Promise<void> {}
+}
+
+describe('b7 C5 (AC5): LlamaEngine.search delegates to the attached retrieval surface', () => {
+  itReal('returns the surface rows once attached, and the stub row once detached', async () => {
+    const seeded = await seedMarkerStore();
+    const store = openStore({ dbPath: seeded.dbPath, dims: DIMS, repoRoot: REPO_ROOT });
+    const dir = makeTempDir('b7-c5-models-');
+    const quality = path.join(dir, 'quality-dummy.gguf');
+    const fast = path.join(dir, 'fast-dummy.gguf');
+    fs.writeFileSync(quality, 'x', 'utf8');
+    fs.writeFileSync(fast, 'x', 'utf8');
+    try {
+      const engine = new LlamaEngine({
+        profile: 'fast',
+        freeMemBytes: () => 8 * GB,
+        cpuCount: () => 8,
+        models: { quality, fast },
+        llamaFactory: async () => new FakeLlamaBackend(),
+      });
+      const surface = createRetrievalSurface({ store, embedder: new HashEmbedder({ dims: DIMS }) });
+      expect(typeof (engine as { attachRetrievalSurface?: unknown }).attachRetrievalSurface).toBe('function');
+      (engine as { attachRetrievalSurface: (s: unknown) => void }).attachRetrievalSurface(surface);
+
+      const rows = await engine.search(MARKER, 5);
+      expect(rows.length).toBeGreaterThanOrEqual(1);
+      expect(rows.some((row) => row.text.includes(MARKER))).toBe(true);
+      expect(rows.some((row) => row.source.endsWith('b7wiring-doc.md'))).toBe(true);
+      expect(rows.every((row) => !row.source.includes('desktop-stub'))).toBe(true);
+
+      (engine as { attachRetrievalSurface: (s: unknown) => void }).attachRetrievalSurface(null);
+      const stubRows = await engine.search(MARKER, 5);
+      expect(stubRows.every((row) => row.source.includes('desktop-stub'))).toBe(true);
+    } finally {
+      store.close();
+    }
+  });
+});

--- a/docs/adr/0007-relevance-floor-calibration.md
+++ b/docs/adr/0007-relevance-floor-calibration.md
@@ -1,0 +1,90 @@
+# ADR-0007: Calibrated relevance floor for the desktop hybrid retrieval pipeline
+
+- Status: Accepted
+- Date: 2026-09-09
+- Deciders: B7 workstream (issue #65), consuming A4's tier-0 eval set (#54)
+- Scope: `desktop/main/backend/retrieval/` — the `retrieval.relevanceFloor`
+  default (desktop/main/backend/retrieval/config.ts
+  `CALIBRATED_RELEVANCE_FLOOR`)
+
+## Context
+
+Issue #65 requires the Electron desktop backend's hybrid retrieval (sqlite-vec
++ FTS5 -> RRF -> cross-encoder reranker) to ship a relevance floor that is
+RE-CALIBRATED against the reranker actually selected — not a copy of the
+browser's un-revalidated `MIN_CROSS_SCORE = 0.2`
+(web_ui/src/lib/rag/rag-orchestrator.ts:163). The floor gates the reranker's
+sigmoid scores: after reranking, fused candidates with score < floor are
+dropped (`>= floor` is kept). The floor is NEVER applied to raw RRF fused
+scores — their ~0.03-max scale would empty every response (frozen C1
+assertion).
+
+The reranker in this pipeline is **ettin-reranker-32m-v1** — the same 32M
+ModernBERT cross-encoder the web_ui browser-mode baseline runs
+(q8 ONNX, sigmoid(logit) scoring). Issue #55 (ADR-0001) may later re-pin a
+different model; per the issue's exit gate, this calibration is INVALIDATED by
+that change and must be re-run against the ADR-ratified model.
+
+## Procedure
+
+1. **Corpus**: the A4 tier-0 eval corpus (eval/corpus, 8 documents) ingested
+   through the B6 pipeline; 11 chunks. Labels come from the A4 tier-0 question
+   set (eval/questions.jsonl): the 50 in-corpus questions with
+   `expected_doc_id` (6 out-of-corpus abstention questions are excluded — they
+   have no positive label).
+2. **Model + scoring path**: the PRODUCTION worker path —
+   `desktop/main/backend/retrieval/reranker.ts` `WorkerReranker` spawning
+   `rerank-worker.ts`, loading `models/ettin-reranker-32m-v1/onnx` via
+   transformers.js (q8), scoring every (question, chunk) pair with true pair
+   tokenization and sigmoid(logit). 50 questions x 11 chunks = 550 scores.
+3. **Labels**: a (question, chunk) score is a POSITIVE when the chunk's
+   document basename equals the question's `expected_doc_id`, otherwise a
+   NEGATIVE. Result: 71 positives, 479 negatives.
+4. **Threshold selection**: pool all 550 scores; candidate thresholds are the
+   midpoints of adjacent distinct sorted scores; pick the threshold maximizing
+   F1 over the pooled set, counting `score >= threshold` as predicted
+   relevant (smallest threshold wins ties).
+5. **Record**: the selected threshold is written as the `floor:` line in this
+   ADR and shipped as `CALIBRATED_RELEVANCE_FLOOR` in
+   desktop/main/backend/retrieval/config.ts. The frozen C2 check asserts the
+   two are the same double; the frozen C3 check re-derives the floor through
+   the production worker and asserts |recomputed - documented| <= 0.05.
+
+## Result
+
+Calibration run 2026-09-09 (Windows dev station, ettin-reranker-32m-v1 q8,
+transformers.js over onnxruntime-node):
+
+- positives = 71, negatives = 479
+- positive score min = 0.5513, negative score max = 0.6681 (the classes
+  overlap — expected with whole-document chunks and a small corpus)
+- F1-maximizing threshold = 0.569387 (F1 = 0.2281 on the pooled set)
+
+floor: 0.569387
+
+The low absolute F1 reflects the coarse labels (any chunk of the expected
+document counts as relevant, so most negatives are "other documents of the
+same corpus" rather than true non-relevant text) — the floor is a separating
+hyperparameter for THIS reranker's score distribution, not a quality metric.
+On the browser side the comparable setting is the un-measured 0.2; the
+ettin distribution measured here centers well above it, so 0.2 would pass
+almost every candidate (no filtering), while 0.57 keeps the top of the
+distribution.
+
+## Consequences
+
+- `retrieval.relevanceFloor` defaults to 0.569387; operators can override via
+  `TRAININGAPP_RETRIEVAL_RELEVANCE_FLOOR` (any finite float in [0, 1)).
+- The floor is inert whenever the reranker is absent (weights not staged) or
+  disabled (`retrieval.rerank=false` / a reranker worker failure) — RRF-only
+  ordering is never floor-gated.
+- **Re-validation trigger (issue #55 / ADR-0001)**: when the bake-off ratifies
+  a different reranker (or a different quantization of this one), re-run the
+  procedure above and update the `floor:` line and the constant together.
+  The frozen C3 driver (repro/c3-floor-docs.sh in the issue trace) automates
+  the re-derivation check.
+- The bge-small QUERY-side instruction prefix (model-card asymmetric usage)
+  was deliberately NOT adopted: the recorded parity baseline
+  (eval/samples/report-devstation-weighted.json) was produced without it, and
+  AC7's comparison must stay in one vector space. Adopting it later requires
+  a fresh baseline run.


### PR DESCRIPTION
Closes #65

[Workstream B] PR 7 of 9 — Hybrid retrieval (sqlite-vec + FTS5 → RRF → reranker) with eval parity. Replaces the B3 stub on the desktop backend with the full hybrid pipeline, validated end-to-end under the issue-tracer contract (`.agents/issue-traces/65-hybrid-retrieval-rrf-reranker/`).

## Root Cause

Issue #65 is a FEATURE roadmap slot: the desktop backend had no retrieval implementation. `StubEngine.search()` (desktop/main/backend/engine.ts) returned a single hardcoded `desktop-stub` row on every path — `/search` (server.ts → engine.search) and the retrieval step inside `/ask`//ask/stream (llama-engine.ts returned `sources: []`). None of the Required-scope capabilities (vector KNN, FTS5, fusion, reranking, floor) existed anywhere in desktop/main. The implementation also surfaced a hidden runtime constraint: onnxruntime-node 1.21 **aborts the whole process (exit 134)** when the same ONNX module is used from the main thread and a user worker thread (empirically proven: main embed → worker rerank → main embed = deterministic `OnFatalError`; main-only embeds stable).

## Fix

Minimal, complete implementation of the Required scope:

- `desktop/main/backend/retrieval/hybrid.ts` — vec0 KNN leg ∪ FTS5 BM25 leg (legK = topK × candidateMultiplier), reciprocal-rank fusion `1/(rrfK + rank + 1)` deduped by chunk id, `recencyWeight()` hook (returns 1.0; the C4/#71 extension point), ettin cross-encoder rerank over the fused window with scores replacing RRF scores, calibrated relevance floor, topK slice; FTS5 query sanitization (operators/quotes/stars dropped, tokens quoted — never throws); empty store returns `[]` without touching the reranker; per-query reranker failure degrades to fused ordering (logged once).
- `desktop/main/backend/retrieval/config.ts` — frozen defaults `topK=10, candidateMultiplier=3, rerank=true, rrfK=60, relevanceFloor=0.569387` (re-calibrated — NOT the browser's un-revalidated 0.2; see `docs/adr/0007-relevance-floor-calibration.md`) with per-key `TRAININGAPP_RETRIEVAL_*` env overrides and per-key fallback on invalid values.
- `desktop/main/backend/retrieval/reranker.ts` + `rerank-worker.ts` — **single-thread ORT ownership**: ALL onnxruntime work (embedding AND reranking) lives in ONE worker thread; the main thread uses `WorkerEmbedder`/`WorkerReranker` proxies exclusively. This is a deliberate strict superset of the plan's "reranker in worker" (documented at index.ts and in the worker header) — the planned "embedder on main" wiring deterministically aborts the process.
- Wiring — `EngineSurface.attachRetrievalSurface` seam (mirrors B6's document surface); `NodeBackendHost.start()` resolves the embedder once, wraps it in `WorkerEmbedder` when a reranker exists, attaches the retrieval surface after the store surface; `StubEngine`/`LlamaEngine` ground prompts from retrieved chunks and populate sources/context_length; detaching the surface restores the frozen `desktop-stub` conformance row (asserted by C5).
- Bench — `desktop-retrieval` surface registered in `bench/append_results.py` (5 points); committed `bench/retrieval_bench_driver.mjs`; `bench/RESULTS.md` § Desktop retrieval (B7): `devstation | bge-small-en-v1.5 | ettin-reranker-32m-v1 | 10 | 3 | p50=364 | p95=426 | max=691 | pass` (budget p95 ≤ 1500 ms).

## Recurrence Prevention (defect class)

- Defect class: native ONNX inference loaded/run outside the single owning worker thread (aborts the process under onnxruntime-node's single-thread ORT ownership).
- Sweep result: 11 hits across 4 repo-wide predicates (ONNX API calls 4, native-stack imports 3, worker spawns 1, stub sentinel 3) — every hit dispositioned to the sanctioned owner files or the intentional frozen stub sentinel; see `.agents/issue-traces/65-hybrid-retrieval-rrf-reranker/08a-recurrence-sweep.md`.
- Guardrail: permanent vitest source scan (`desktop/src/__tests__/b7-ort-ownership-guardrail.test.ts`, runs in the standard suite) that fails when ONNX APIs/imports appear outside the two owner files or a second worker appears. Demonstrated RED (injected main-thread ONNX import → `engine.ts:276` flagged) then GREEN (reverted): transcripts in the trace `repro/guardrail-{red,green}.log`.

## Tests

- Regression test: `cd desktop && npx vitest run` → 43 files / **291 passed** (0 failures, 0 unhandled errors)
- Frozen acceptance specs: `run-check.sh C1` → 12 passed; `C2` → 8 passed; `C4` → 2 passed; `C5` → 3 passed; `C6` → 3 passed (all RED/ERROR at the frozen pre-fix checkpoint)
- Drivers: `C3` → `C3 PASS floor=0.569387` (re-derived through the production reranker worker, Δ < 0.001); `C7` → `C7 PASS recall@5=0.640 mrr=0.384` (errors=0, honest parity — a vacuous first pass with 55/56 errors was caught during validation and re-run after the ORT fix); `C8` → `C8 PASS p95=517ms` (20 store-backed round trips); `C9` → `C9 PASS` (10/10 conformance, GREEN-to-GREEN preserving)
- Lint/type/build: `npm --prefix desktop run compile` (tsc) clean; `black --check` + `flake8 --max-line-length=100` clean on `bench/append_results.py`
- Deferred-work scan: `scan-deferred.sh` → clean (base=origin/master)

## Regression Protection

- 7 new spec files under `desktop/src/__tests__/b7-*.test.ts` (fusion math, config freezing + env overrides, worker isolation via event-loop tick counting, host wiring incl. detach, recency-hook inertness, FTS sanitization fuzzing, ORT-ownership guardrail)
- Adversarial: worker-dispose rejects in-flight jobs (idempotent); operator-heavy FTS queries never throw; per-query reranker crash degrades to RRF-only ordering
- Test drift review: two sanctioned checkpoint AMENDs, neither weakening a check — seq 12 `CHECK_WRONG` (the original C1 reference embed made its own assertion unsatisfiable by construction; amended spec keeps the exactly-once semantic) and seq 13 `FORMAT_ONLY` (the `checkpoint-tree-id:` binding line the phase 2.5 validator demanded; acceptance table byte-identical). `verify-checkpoint` exits 0 on all 13 rows.

## Acceptance Criteria -> Evidence

| Acceptance criterion | Evidence |
|---|---|
| AC1 hybrid.ts: vec0 ∪ FTS5 → RRF k=60 → recency hook → worker rerank → floor → topK | C1 `Tests 12 passed (12)`; hybrid.ts pipeline |
| AC2 config keys + calibrated floor | C2 `Tests 8 passed (8)`; config.ts frozen defaults; ADR-0007 |
| AC3 floor re-calibration documented (≠ 0.2) | C3 `C3 PASS floor=0.569387` (production worker re-derivation within ±0.05) |
| AC4 reranker in dedicated worker thread, never main | C4 `Tests 2 passed (2)` (event-loop tick counter ≥40 during in-flight job); single-thread ORT ownership wiring + guardrail |
| AC5 /search + /ask//ask/stream wired, B3 stub replaced (detach restores stub) | C5 `Tests 3 passed (3)` over real loopback HTTP |
| AC6 recencyWeight() returns 1.0 (C4/#71 hook inert) | C6 `Tests 3 passed (3)` over 40+ input shapes |
| AC7 eval parity vs web_ui baseline | C7 `C7 PASS recall@5=0.640 mrr=0.384` errors=0 vs baseline 0.640/0.324 (recall@1 0.180≥0.100, recall@3 0.420≥0.340) |
| AC8 p95 ≤ 1.5 s + bench/RESULTS.md row | C8 `C8 PASS p95=517ms`; RESULTS.md row p95=426 ms (committed driver) |
| AC9 /search conformance | C9 `CONFORMANCE: PASS 10/10` |

## Invariant Audit

The desktop backend contract docs (`desktop/README.md`, ADRs 0005–0007) plus the cross-workstream frozen contracts:

- B3 `/search` response shape + stub-row detach behavior: touched, preserved — C5 asserts the stub row returns verbatim on `attachRetrievalSurface(null)`; C9 conformance 10/10.
- B6 store/ingest surfaces: not touched semantically — embedder gains a read-only `weightsDir` getter; `attachStoreSurface` unchanged; full desktop suite green.
- sqlite-vec store schema (ADR-0005, frozen in #63): not touched — read-only KNN queries via the frozen interop API.
- Eval harness contract (A4): not touched — `eval/runner.py` consumed as-is; baseline JSON untouched.

## Risk and Rollback

- Risk level: medium (new runtime path on the desktop backend; reranker weights are operator-staged — without them retrieval degrades to RRF-only with no floor, by design and logged once)
- Rollback: revert commit 55b1646 (single commit, no migrations; the store is untouched)
- Residual risk: the ORT cross-thread abort is enforced by guardrail test + worker-only wiring; a future main-thread ONNX call would be caught by the suite. Cross-thread ORT behavior is a property of onnxruntime-node 1.21 and should be re-verified on upgrade (guardrail + C7/C8 cover it).

## Scope-outs (no follow-up issue required)

- Sidecar-mode hosts intentionally keep B3 behavior (hybrid retrieval requires the in-process Node backend; the B6 precedent).
- `recencyWeight()` stays 1.0 — the Knowledge Pack recency hook is C4 / issue #71, which already tracks it.
- The bench row is measured on `devstation` (machine-tagged provenance; the reference-laptop row lands via the RESULTS.md runbook when an operator runs it there).

## Review pass (post-publication hardening)

A full swarm review of this PR validated 17 findings (1 initially Critical,
re-banded MEDIUM follow-up after two critic passes; 9 MEDIUM; 5 LOW; 4
rejected with evidence). The actionable fixes landed in efafa40: reranker
failure latch, non-finite score guard, 8000-char query cap, env-int upper
bounds, worker dispose/exit settlement, bench-driver fetch deadlines, and a
6-test additive hardening spec. Suite grew 291 -> 297 (green with weights and
in the CI-equivalent no-weights environment). The MEDIUM follow-up (an
in-repo eval-parity floor, analogous to bench-floors) is tracked in a
follow-up issue filed at merge.

## Waivers (or none)

none.

## Merge status

User approval to resolve review findings and merge was recorded 2026-09-10 (trace 10b-merge-approval.md, bound to head efafa407d4a8e3314ae286005d816179ec5eec93); merge pending CI green on that head.

---

PR record: https://github.com/ZaxbyHub/trainingapp/pull/102 · head SHA: efafa407d4a8e3314ae286005d816179ec5eec93 (head 3: PR-review hardening; head 2 e23b460: CI no-weights degrade fix; head 1 55b1646: initial implementation) · base: master · issue comment: https://github.com/ZaxbyHub/trainingapp/issues/65#issuecomment-5611770772
PR head: efafa407d4a8e3314ae286005d816179ec5eec93
