### PR TITLE
[Workstream B] feat(desktop): enforce a 16 GB runtime memory and concurrency budget (B8, #66)

### DIFF
--- a/api_server.py
+++ b/api_server.py
@@ -540,6 +540,22 @@ async def get_stats(auth: dict = Security(require_auth())):
     )
 
 
+@app.get("/telemetry/memory")
+async def get_memory_telemetry(auth: dict = Security(require_auth())):
+    """
+    Memory telemetry snapshot + downgrade state (issue #66, B8).
+
+    The B8 telemetry subsystem lives on the Electron/Node desktop surface
+    (desktop/main/backend/memory/); this Python host never wires it, so the
+    route exists to keep the shared contract (contracts/api.openapi.yaml
+    v2.4.0) consistent across backends and always answers the documented
+    unwired 503 — the path is known, never 404-absent.
+    """
+    raise HTTPException(
+        status_code=503, detail="Memory telemetry is not wired on this host"
+    )
+
+
 @app.post("/ask", response_model=QuestionResponse)
 async def ask_question(request: QuestionRequest, auth: dict = Security(require_auth())):
     """Ask a question about the ingested documents."""

--- a/bench/RESULTS.md
+++ b/bench/RESULTS.md
@@ -261,7 +261,7 @@ per ADR-0008: main-process RSS is the WHOLE process (incl. native heaps);
 |---|---|---|---|
 | devstation | main process RSS, no-model sustained ingest (75 s, 7667 cycles) | ~1108 MB | soak telemetry `chromiumRssMb` (soak-devstation.log) |
 | devstation | main process RSS with resident llama.cpp + sustained ingest+query | 9.2-9.8 GB | soak telemetry `chromiumRssMb` (soak-devstation-fast.log) — see anomaly note |
-| devstation | `llmRssMb` (baseline-relative, resident lfm2.5 + context) | ~9.7 GB | soak telemetry (same run) |
+| devstation | `llmRssMb` (baseline-relative delta — SUBSUMED in the main-RSS row above; DO NOT SUM the two) | ~9.7 GB | soak telemetry (same run) |
 | devstation | embedding session (worker external+arrayBuffers) | ~8-20 MB | soak telemetry |
 | devstation | reranker session (same single ORT worker) | ~8-20 MB | soak telemetry |
 | devstation | sqlite driver heap | ~0 MB (small store) | soak telemetry |
@@ -278,7 +278,11 @@ sampler excludes; either way it is the dominant budget line and it is
 precisely why the issue demands the physical 16 GB reference-laptop soak
 (CI/in-process numbers do not substitute — the reference run and its
 sum-vs-ceiling verdict are PENDING that hardware). The downgrade latch and
-recovery path were exercised separately by the frozen unit specs (C2/C9).
+recovery hysteresis are exercised at unit level by the frozen C2/C9 specs,
+and the REAL host loop (downgrade -> recovery -> upgrade -> quiet
+post-upgrade ticks, the oscillation regression) by
+`desktop/src/__tests__/b8-host-loop.test.ts` (added after PR-review finding
+PRR-F1/PRR-F6; the frozen specs alone do not drive the host loop).
 
 Reproduce: `node desktop/test/soak/memory-soak.mjs --duration-s 60 --docs 6 --model-dir models --report soak.log`
 (add `TRAININGAPP_DESKTOP_INFERENCE_PROFILE=fast` for the bounded-decode run

--- a/bench/RESULTS.md
+++ b/bench/RESULTS.md
@@ -246,3 +246,40 @@ load — is part of the measured distribution). Budget: p95 <= 1500 ms
 | machine | embedder | reranker | topk | multiplier | p50_ms | p95_ms | max_ms | outcome |
 |---|---|---|---|---|---|---|---|---|
 | devstation | bge-small-en-v1.5 | ettin-reranker-32m-v1 | 10 | 3 | 364 | 426 | 691 | pass |
+
+## Desktop runtime memory (B8, issue #66)
+
+Provisional component accounting from the B8 in-process telemetry
+(`GET /telemetry/memory`) during a sustained ingest+query soak
+(`desktop/test/soak/memory-soak.mjs`, 2026-09-11, real staged weights:
+`lfm2.5-vl-450m` resident via the Fast profile, `bge-small-en-v1.5` +
+`ettin-reranker-32m-v1` ONNX in the retrieval worker). Attribution semantics
+per ADR-0008: main-process RSS is the WHOLE process (incl. native heaps);
+`llmRssMb` is baseline-relative; sessions are worker thread counters.
+
+| machine | component | measured | source |
+|---|---|---|---|
+| devstation | main process RSS, no-model sustained ingest (75 s, 7667 cycles) | ~1108 MB | soak telemetry `chromiumRssMb` (soak-devstation.log) |
+| devstation | main process RSS with resident llama.cpp + sustained ingest+query | 9.2-9.8 GB | soak telemetry `chromiumRssMb` (soak-devstation-fast.log) — see anomaly note |
+| devstation | `llmRssMb` (baseline-relative, resident lfm2.5 + context) | ~9.7 GB | soak telemetry (same run) |
+| devstation | embedding session (worker external+arrayBuffers) | ~8-20 MB | soak telemetry |
+| devstation | reranker session (same single ORT worker) | ~8-20 MB | soak telemetry |
+| devstation | sqlite driver heap | ~0 MB (small store) | soak telemetry |
+| devstation | llama.cpp lfm2.5-vl-450m peak RSS, spawn-isolated | 617-619 MB | native llama.cpp table above (node-llama-cpp rows) |
+| devstation | llama.cpp gemma-4-e2b-it peak RSS, spawn-isolated | 2761-2819 MB | native llama.cpp table above |
+| reference-i5 | full sum under 16 GB with headroom | **PENDING** — physical soak (AC1) | desktop/test/soak/README.md procedure |
+
+**Anomaly note (honest measurement):** the in-process main-RSS under a
+resident node-llama-cpp context measured ~8.6 GB above the no-model baseline
+on this 128 GB host, versus 617-619 MB peak-RSS for the same model in the
+spawn-isolated bench rows above. The in-process figure plausibly includes
+mmap-prefault + context/compute arena accounting that the spawn-isolated
+sampler excludes; either way it is the dominant budget line and it is
+precisely why the issue demands the physical 16 GB reference-laptop soak
+(CI/in-process numbers do not substitute — the reference run and its
+sum-vs-ceiling verdict are PENDING that hardware). The downgrade latch and
+recovery path were exercised separately by the frozen unit specs (C2/C9).
+
+Reproduce: `node desktop/test/soak/memory-soak.mjs --duration-s 60 --docs 6 --model-dir models --report soak.log`
+(add `TRAININGAPP_DESKTOP_INFERENCE_PROFILE=fast` for the bounded-decode run
+above; the reference-laptop procedure is in `desktop/test/soak/README.md`).

--- a/contracts/api.openapi.yaml
+++ b/contracts/api.openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Document Q&A API
-  version: "2.3.0"
+  version: "2.4.0"
   description: |
     RAG-based document question answering API.
 
@@ -328,6 +328,26 @@ paths:
                 $ref: "#/components/schemas/StatsResponse"
         "503":
           description: Engine not initialized
+  /telemetry/memory:
+    get:
+      tags: [ops]
+      summary: Current memory telemetry snapshot and profile-downgrade state (B8, issue #66)
+      description: >
+        MB-denominated per-component RSS attribution plus system free/total RAM
+        (snapshot), and the sustained-pressure downgrade state (downgrade).
+        Component attribution semantics are documented in docs/adr/0008-memory-budget.md.
+        Transport-token-guarded like every route: it reveals process memory.
+        A host without a telemetry provider answers 503 (the path is known, never 404).
+      operationId: getTelemetryMemory
+      responses:
+        "200":
+          description: Current memory snapshot and downgrade state
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TelemetryMemoryResponse"
+        "503":
+          description: Memory telemetry is not wired on this host
 components:
   securitySchemes:
     bearerAuth:
@@ -623,6 +643,37 @@ components:
         documents:
           type: array
           items: { type: string }
+    MemorySnapshot:
+      type: object
+      description: Per-component memory attribution in MB (1 MB = 1024*1024 bytes). B8 (issue #66).
+      required:
+        [chromiumRssMb, llmRssMb, embeddingSessionRssMb, rerankerSessionRssMb, sqliteRssMb, systemFreeMb, systemTotalMb]
+      properties:
+        chromiumRssMb: { type: number, description: Main-process RSS (includes native heaps) }
+        llmRssMb: { type: number, description: Resident-LLM incremental footprint since host start (0 when none) }
+        embeddingSessionRssMb: { type: number, description: Embedding-session thread counters (0 when not measurable) }
+        rerankerSessionRssMb: { type: number, description: Reranker-worker thread counters (0 when not measurable) }
+        sqliteRssMb: { type: number, description: SQLite driver heap (0 when no store is open) }
+        systemFreeMb: { type: number, description: os.freemem() in MB }
+        systemTotalMb: { type: number, description: os.totalmem() in MB }
+    DowngradeState:
+      type: object
+      description: Sustained-pressure downgrade state (B8 S6; AC3 hysteresis documented in ADR-0008).
+      required: [effectiveProfile, downgraded]
+      properties:
+        effectiveProfile:
+          type: string
+          enum: [quality, fast]
+        downgraded:
+          type: boolean
+    TelemetryMemoryResponse:
+      type: object
+      required: [snapshot, downgrade]
+      properties:
+        snapshot:
+          $ref: "#/components/schemas/MemorySnapshot"
+        downgrade:
+          $ref: "#/components/schemas/DowngradeState"
 security:
   - {}
   - bearerAuth: []

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -304,9 +304,10 @@ Design decisions are frozen in ADR-0008 (`docs/adr/0008-memory-budget.md`).
   outside the mutex so a missing model still answers 503 immediately.
 - **Worker pools (S4)**: `TRAININGAPP_EMBEDDING_WORKER_POOL_SIZE` /
   `TRAININGAPP_RERANKER_WORKER_POOL_SIZE` (default 1, never
-  `os.cpus()`-derived). Values >1 are reported by the parser but REJECTED at
-  the host (logged + `memory:event`): B7's single-thread ORT ownership means
-  a second ONNX instance on another thread aborts the process.
+  `os.cpus()`-derived). Values >1 are reported by the parser but rejected at
+  the host — logged + `memory:event`, and the host CONTINUES with 1 (no
+  startup failure): B7's single-thread ORT ownership means a second ONNX
+  instance on another thread aborts the process.
 - **Idle unload (AC5)**: the retrieval worker is terminated after
   `memory.idleUnloadMs` idle and transparently rebuilt on the next
   score/embed; the measured reload latency is recorded. The resident LLM is

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -269,3 +269,47 @@ main/event-loop thread) -> the calibrated relevance floor (ADR-0007) -> topK.
   host attaches no retrieval surface and engines keep the B3 deterministic
   behavior; attaching/detaching is the `attachRetrievalSurface` seam,
   mirroring B6's document surface.
+
+## Runtime memory and concurrency budget (B8, issue #66)
+
+Design decisions are frozen in ADR-0008 (`docs/adr/0008-memory-budget.md`).
+
+- **Telemetry**: the host samples per-component memory every
+  `memory.telemetryIntervalMs` and serves `GET /telemetry/memory`
+  (`{snapshot, downgrade}`; `contracts/api.openapi.yaml` v2.4.0) —
+  token-guarded like every route (it reveals process memory). Component
+  attribution semantics (main-process RSS, baseline-relative LLM delta,
+  worker thread counters, better-sqlite3 heap) are documented in the ADR.
+  Unwired hosts answer 503 — the path is known, never 404.
+- **Memory env keys** (invalid values fall back per-key):
+  `TRAININGAPP_MEMORY_TELEMETRY_INTERVAL_MS` (5000),
+  `TRAININGAPP_MEMORY_MAX_TOTAL_GB` (16 — the v3 floor from
+  `.swarm/spec-snapshot.md`), `TRAININGAPP_MEMORY_PRESSURE_THRESHOLD_GB`
+  (6 — the SAME constant as `inference.profileThresholdGb`, imported not
+  restated), `TRAININGAPP_MEMORY_PRESSURE_SUSTAINED_MS` (10000),
+  `TRAININGAPP_MEMORY_RECOVERY_SUSTAINED_MS` (60000),
+  `TRAININGAPP_MEMORY_IDLE_UNLOAD_MS` (300000).
+- **Downgrade (AC2/AC3)**: free RAM strictly below the threshold for the
+  sustained window latches the effective profile to Fast (the user's
+  `inference.profile` setting is never mutated), logs the observed free-RAM
+  value, and emits `memory:event {type:'downgrade', effectiveProfile,
+  freeMemMb}`. There is NO silent auto-upgrade: after a sustained recovery
+  window the host clears the override only between generations (scheduler
+  fully drained), emitting `recovery-eligible` first. Renderer consumption
+  of `memory:event` lands with B9 (#67).
+- **Serialization (AC4)**: `/ask` + `/ask/stream` run under a FIFO generation
+  mutex (`concurrency.maxConcurrentGenerations`, default 1; excess requests
+  queue, never 503). The B6 embed phase pauses while a generation runs
+  (`coordination.waitForGenerationEnd()`). The stream preflight stays
+  outside the mutex so a missing model still answers 503 immediately.
+- **Worker pools (S4)**: `TRAININGAPP_EMBEDDING_WORKER_POOL_SIZE` /
+  `TRAININGAPP_RERANKER_WORKER_POOL_SIZE` (default 1, never
+  `os.cpus()`-derived). Values >1 are reported by the parser but REJECTED at
+  the host (logged + `memory:event`): B7's single-thread ORT ownership means
+  a second ONNX instance on another thread aborts the process.
+- **Idle unload (AC5)**: the retrieval worker is terminated after
+  `memory.idleUnloadMs` idle and transparently rebuilt on the next
+  score/embed; the measured reload latency is recorded. The resident LLM is
+  deliberately not unloaded (B4's resident-model contract).
+- **Soak harness**: `desktop/test/soak/memory-soak.mjs` (+ README) — the
+  AC1 reference-laptop procedure lives in `desktop/test/soak/README.md`.

--- a/desktop/main/backend/index.ts
+++ b/desktop/main/backend/index.ts
@@ -180,6 +180,11 @@ export class NodeBackendHost implements BackendHost {
       this.downgradeLatched = false;
       this.recoveryEmitted = false;
       engineOverride.setProfileOverride?.(null);
+      // Acknowledge the upgrade on the monitor: without this the never-reset
+      // `downgraded` latch re-latched 'fast' on the very next tick (fast/
+      // quality oscillation + event spam; PR-review finding PRR-F1, pinned by
+      // b8-host-loop.test.ts).
+      monitor.resetAfterUpgrade();
       this.config.onMemoryEvent?.({
         type: 'telemetry',
         effectiveProfile: 'quality',
@@ -385,8 +390,15 @@ export class NodeBackendHost implements BackendHost {
       }
       // B8 (issue #66): the sampler loop — observe/evaluate/downgrade at
       // memory.telemetryIntervalMs. unref'd so a headless host can still exit.
+      // The tick's rejection is consumed here (log + keep the sampler alive):
+      // an unhandled rejection from a raced worker disposal must not take the
+      // host down in plain-node entries (PRR-F2).
       this.telemetryTimer = setInterval(() => {
-        void this.memoryTick();
+        void this.memoryTick().catch((err: unknown) => {
+          console.error(
+            `[trainingapp-backend] memory tick failed (sampler continues): ${err instanceof Error ? err.message : String(err)}`,
+          );
+        });
       }, memoryConfig.telemetryIntervalMs);
       this.telemetryTimer.unref?.();
       return this.handle;

--- a/desktop/main/backend/index.ts
+++ b/desktop/main/backend/index.ts
@@ -11,6 +11,7 @@
 // Electron-free: safe to import from the headless dev-server entry and CI.
 import net from 'node:net';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { createLoopbackGuard } from '../security/loopback-guard.js';
 import { resolveNodeEngine } from './inference/llama-engine.js';
@@ -24,7 +25,25 @@ import { OnnxEmbedder, resolveEmbedder, type EmbeddingSurface } from './ingest/e
 import { resolveIngestConfig, resolveIngestLimits } from './ingest/config.js';
 import { createRetrievalSurface, type RetrievalSurface } from './retrieval/hybrid.js';
 import { resolveRetrievalConfig } from './retrieval/config.js';
-import { resolveRerankerModelDir, WorkerEmbedder, WorkerReranker, type RerankerSurface } from './retrieval/reranker.js';
+import {
+  resolveRerankerModelDir,
+  ResumableReranker,
+  WorkerEmbedder,
+  WorkerReranker,
+  type RerankerSurface,
+  type WorkerMemoryReport,
+} from './retrieval/reranker.js';
+import {
+  createPressureMonitor,
+  resolveConcurrencyConfig,
+  resolveMemoryConfig,
+  resolveWorkerPoolConfig,
+  type MemoryComponent,
+  type PressureMonitor,
+} from './memory/budget.js';
+import { createMemoryTelemetry, type MemoryTelemetry } from './memory/telemetry.js';
+import { ConcurrencyScheduler } from './memory/scheduler.js';
+import { IdleUnloadController } from './memory/idle-unload.js';
 import {
   resolveBackendMode,
   type BackendHandle,
@@ -73,6 +92,101 @@ export class NodeBackendHost implements BackendHost {
   private reranker: RerankerSurface | null = null;
   /** The embedder resolved for ingest — B7 reuses the SAME instance for query embedding. */
   private embedder: EmbeddingSurface | null = null;
+  // ---- B8 memory/concurrency governance (issue #66). All new members are
+  // INSTANCE FIELDS, deliberately never prototype methods: the b3 duck-type
+  // pin requires both host prototypes to expose exactly start/stop.
+  private scheduler: ConcurrencyScheduler | null = null;
+  private telemetry: MemoryTelemetry | null = null;
+  private monitor: PressureMonitor | null = null;
+  private idle: IdleUnloadController | null = null;
+  private resumable: ResumableReranker | null = null;
+  private telemetryTimer: ReturnType<typeof setInterval> | null = null;
+  private workerMemory: WorkerMemoryReport | null = null;
+  private embedsViaWorker = false;
+  private rssBaselineBytes = 0;
+  private downgradeLatched = false;
+  private recoveryEmitted = false;
+
+  /** Per-component RSS provider for the telemetry snapshot (bytes). */
+  private rssFor = (component: MemoryComponent): number => {
+    if (component === 'chromium') return process.memoryUsage().rss;
+    if (component === 'llm') {
+      // Baseline-relative increment: dominated by the resident llama model
+      // (native heap inside the main process; attribution documented in
+      // docs/adr/0008-memory-budget.md).
+      return Math.max(0, process.memoryUsage().rss - this.rssBaselineBytes);
+    }
+    if (component === 'rerankerSession') {
+      return this.workerMemory === null ? 0 : this.workerMemory.external + this.workerMemory.arrayBuffers;
+    }
+    if (component === 'embeddingSession') {
+      // The embed session shares the SAME single ORT thread when ingest
+      // embeddings are worker-proxied (B7 WorkerEmbedder); 0 otherwise
+      // (hash embedder or main-thread fixture — nothing measurable to own).
+      return this.embedsViaWorker && this.workerMemory !== null
+        ? this.workerMemory.external + this.workerMemory.arrayBuffers
+        : 0;
+    }
+    if (component === 'sqlite') {
+      const store = this.store;
+      if (store === null) return 0;
+      const db = store.db as unknown as { memoryUsed?: () => number };
+      return typeof db.memoryUsed === 'function' ? db.memoryUsed() : 0;
+    }
+    return 0;
+  };
+
+  /** One sampler tick: refresh worker memory, sample, observe, decide. */
+  private memoryTick = async (): Promise<void> => {
+    const monitor = this.monitor;
+    const scheduler = this.scheduler;
+    if (monitor === null || scheduler === null) return;
+    this.workerMemory = this.resumable !== null ? await this.resumable.reportMemory() : null;
+    const snapshot = this.telemetry?.sample() ?? null;
+    monitor.observe(os.freemem(), Date.now());
+    const status = monitor.evaluate();
+    const engineOverride = this.engine as { setProfileOverride?: (profile: 'quality' | 'fast' | null) => void };
+    if (status.downgraded && !this.downgradeLatched) {
+      this.downgradeLatched = true;
+      engineOverride.setProfileOverride?.('fast');
+      const freeMemMb = snapshot?.systemFreeMb ?? 0;
+      console.error(
+        `[trainingapp-backend] memory pressure: free RAM ${freeMemMb.toFixed(0)} MB sustained below threshold; downgrading inference profile to fast`,
+      );
+      this.config.onMemoryEvent?.({
+        type: 'downgrade',
+        effectiveProfile: 'fast',
+        freeMemMb,
+        detail: 'sustained free-RAM pressure below memory.pressureThresholdGb',
+      });
+    }
+    if (status.recoveryEligible && !this.recoveryEmitted) {
+      this.recoveryEmitted = true;
+      this.config.onMemoryEvent?.({
+        type: 'recovery-eligible',
+        detail: 'free RAM recovered above the threshold for the sustained recovery window',
+      });
+    }
+    // AC3 (issue #66): the ONLY upgrade path — the override clears when the
+    // recovery is eligible AND no generation is running or queued (checked
+    // between generations; bounded staleness = one telemetry interval).
+    if (
+      this.downgradeLatched &&
+      status.recoveryEligible &&
+      scheduler.generationInFlight === false &&
+      scheduler.queueDepth === 0 &&
+      scheduler.activeGenerations === 0
+    ) {
+      this.downgradeLatched = false;
+      this.recoveryEmitted = false;
+      engineOverride.setProfileOverride?.(null);
+      this.config.onMemoryEvent?.({
+        type: 'telemetry',
+        effectiveProfile: 'quality',
+        detail: 'profile override cleared between generations (recovery sustained)',
+      });
+    }
+  };
 
   /**
    * B6 (issue #64): snapshot the open store into <backupsDir>/<timestamp>/
@@ -100,6 +214,31 @@ export class NodeBackendHost implements BackendHost {
 
   async start(): Promise<BackendHandle> {
     if (this.handle) return this.handle;
+    // B8 (issue #66): resolve the memory/concurrency budget and build the
+    // governance stack BEFORE the listener exists, so /telemetry/memory and
+    // the generation mutex are live from the first request.
+    const env = this.config.env ?? process.env;
+    const memoryConfig = resolveMemoryConfig(env);
+    const concurrency = resolveConcurrencyConfig(env);
+    const poolConfig = resolveWorkerPoolConfig(env);
+    this.scheduler = new ConcurrencyScheduler({ maxConcurrentGenerations: concurrency.maxConcurrentGenerations });
+    this.rssBaselineBytes = process.memoryUsage().rss;
+    this.telemetry = createMemoryTelemetry({ rssProvider: this.rssFor });
+    this.monitor = createPressureMonitor({
+      pressureThresholdGb: memoryConfig.pressureThresholdGb,
+      pressureSustainedMs: memoryConfig.pressureSustainedMs,
+      recoverySustainedMs: memoryConfig.recoverySustainedMs,
+    });
+    if (poolConfig.rerankerWorkerPoolSize > 1 || poolConfig.embeddingWorkerPoolSize > 1) {
+      // Honest-config policy: the parser reports values as configured; the
+      // CONSUMPTION site rejects >1 because onnxruntime-node aborts the whole
+      // process when one ORT module instance is used from two threads (the
+      // B7 single-ORT-owner probe, backend start block below).
+      const detail =
+        'worker pool sizes > 1 rejected (B7 single-thread ORT ownership: a second ONNX instance on another thread aborts the process); continuing with 1';
+      console.error(`[trainingapp-backend] ${detail}`);
+      this.config.onMemoryEvent?.({ type: 'telemetry', detail });
+    }
     const server = createBackendServer({
       guard: createLoopbackGuard({
         token: this.config.token,
@@ -109,6 +248,23 @@ export class NodeBackendHost implements BackendHost {
       tokenHeaderName: this.config.tokenHeaderName,
       allowedOrigins: this.config.allowedOrigins,
       engine: this.engine,
+      scheduler: this.scheduler,
+      telemetry: () => {
+        // The payload's effectiveProfile reflects the ENGINE's actual profile
+        // (settings + pressure override) when the engine exposes it — the
+        // monitor alone cannot see an explicit inference.profile setting.
+        // downgraded remains the pressure-latch state (S6/AC3).
+        const status = this.monitor?.evaluate() ?? { downgraded: false };
+        const engineProfile = (this.engine as { effectiveProfile?: () => 'quality' | 'fast' })
+          .effectiveProfile?.();
+        return {
+          snapshot: this.telemetry?.snapshot() ?? {},
+          downgrade: {
+            effectiveProfile: engineProfile ?? 'quality',
+            downgraded: status.downgraded,
+          },
+        };
+      },
     });
     try {
       const port = await listenOnRandomPort(server);
@@ -168,17 +324,40 @@ export class NodeBackendHost implements BackendHost {
               retrievalConfig.rerank &&
               rerankerModelDir !== null
             ) {
-              this.reranker = new WorkerReranker({
+              // B8 (issue #66): the worker is RESUMABLE — the idle-unload
+              // controller may terminate it after memory.idleUnloadMs idle;
+              // the next score/embed transparently rebuilds it (reload
+              // latency recorded for AC5). onUse re-arms the idle window on
+              // every job start (score/embed/ingest embeds alike).
+              const resumable = new ResumableReranker({
                 modelDir: rerankerModelDir,
                 embedModelDir: this.embedder.weightsDir,
+                onUse: () => {
+                  this.idle?.touch();
+                },
+                onReload: (ms) => {
+                  this.idle?.recordReload(ms);
+                },
               });
-              this.embedder = new WorkerEmbedder(this.reranker as WorkerReranker, this.embedder.modelId);
+              this.idle = new IdleUnloadController({
+                idleUnloadMs: memoryConfig.idleUnloadMs,
+                unload: () => resumable.unload(),
+              });
+              this.resumable = resumable;
+              this.reranker = resumable;
+              this.embedder = new WorkerEmbedder(resumable, this.embedder.modelId);
+              this.embedsViaWorker = true;
             }
           } catch (err) {
             // Reranker unavailable: degrade to fused-ordering retrieval with
             // the embedder as-is (no worker exists, so main-thread ORT stays
-            // single-threaded). Never fail host start.
+            // single-threaded). Never fail host start. B8: the resumable
+            // wrapper and its idle controller are torn down with it.
             this.reranker = null;
+            this.resumable = null;
+            this.idle?.dispose();
+            this.idle = null;
+            this.embedsViaWorker = false;
             console.error(
               `[trainingapp-backend] reranker unavailable (retrieval degrades to fused ordering): ${err instanceof Error ? err.message : String(err)}`,
             );
@@ -188,7 +367,7 @@ export class NodeBackendHost implements BackendHost {
             set: (handle: StoreHandle | null) => {
               this.store = handle;
             },
-          });
+          }, this.scheduler);
           if (this.embedder !== null) {
             // B7: attach the hybrid retrieval surface AFTER the document
             // surface, reusing the same (possibly worker-proxied) embedder.
@@ -204,6 +383,12 @@ export class NodeBackendHost implements BackendHost {
           }
         }
       }
+      // B8 (issue #66): the sampler loop — observe/evaluate/downgrade at
+      // memory.telemetryIntervalMs. unref'd so a headless host can still exit.
+      this.telemetryTimer = setInterval(() => {
+        void this.memoryTick();
+      }, memoryConfig.telemetryIntervalMs);
+      this.telemetryTimer.unref?.();
       return this.handle;
     } catch (err) {
       // Partial-init cleanup: a failed bind must not leak the listener into
@@ -216,6 +401,24 @@ export class NodeBackendHost implements BackendHost {
 
 
   async stop(): Promise<void> {
+    // B8 (issue #66) governance teardown FIRST: no sampler fires mid-shutdown,
+    // the idle controller never fires after dispose, and queued (not yet
+    // started) generations fail fast instead of running after close.
+    if (this.telemetryTimer !== null) {
+      clearInterval(this.telemetryTimer);
+      this.telemetryTimer = null;
+    }
+    this.idle?.dispose();
+    this.idle = null;
+    this.scheduler?.rejectQueued(new Error('backend host is stopping'));
+    this.scheduler = null;
+    this.telemetry = null;
+    this.monitor = null;
+    this.workerMemory = null;
+    this.embedsViaWorker = false;
+    this.downgradeLatched = false;
+    this.recoveryEmitted = false;
+    this.resumable = null;
     const server = this.server;
     this.server = null;
     this.handle = null;
@@ -377,6 +580,7 @@ function attachStoreSurface(
   store: StoreHandle,
   embedder: EmbeddingSurface | null,
   accessors: StoreAccessors,
+  coordination: ConcurrencyScheduler | null,
 ): void {
   if (embedder === null) {
     // No usable embedder (weights not staged, bad env): the document surface
@@ -393,6 +597,8 @@ function attachStoreSurface(
     config: resolveIngestConfig(env),
     limits: resolveIngestLimits(env),
     onProgress: config.onIngestProgress,
+    // B8 (issue #66, S3): the embed phase pauses while a generation runs.
+    ...(coordination !== null ? { coordination } : {}),
   });
   if (typeof (engine as { attachDocumentSurface?: unknown }).attachDocumentSurface === 'function') {
     engine.attachDocumentSurface?.(surface);

--- a/desktop/main/backend/inference/llama-engine.ts
+++ b/desktop/main/backend/inference/llama-engine.ts
@@ -276,6 +276,14 @@ export class LlamaEngine implements EngineSurface {
   private resident: ResidentEntry | null = null;
   private loads = 0;
   private queue: Promise<unknown> = Promise.resolve();
+  /**
+   * B8 (issue #66) downgrade actuator: when latched ('fast' under sustained
+   * memory pressure), it shadows the user's inference.profile setting until
+   * the host clears it. The SETTING is never mutated, so the user's choice
+   * resumes automatically once the host clears the override (AC3: the only
+   * profile upgrade path is explicit host policy between generations).
+   */
+  private profileOverride: InferenceProfileName | null = null;
 
   constructor(options: LlamaEngineOptions = {}) {
     this.freeMemBytes = options.freeMemBytes ?? (() => os.freemem());
@@ -299,8 +307,25 @@ export class LlamaEngine implements EngineSurface {
     return path.join(os.homedir(), '.trainingapp', 'models');
   }
 
-  private effectiveProfile(): InferenceProfileName {
+  /**
+   * The effective inference profile for the NEXT query: the B8 pressure
+   * override wins when latched, else B4's selectProfile semantics
+   * (explicit setting beats auto-by-free-RAM; inclusive 6 GiB boundary).
+   * Public so the host (backend/index.ts) can observe it for telemetry.
+   */
+  effectiveProfile(): InferenceProfileName {
+    if (this.profileOverride !== null) return this.profileOverride;
     return selectProfile(this.profileSetting, this.freeMemBytes(), this.thresholdGb);
+  }
+
+  /**
+   * B8 (issue #66): the host latches 'fast' under sustained memory pressure
+   * and clears with null on recovery (between generations only). Passing the
+   * same value twice is a no-op; an unknown value is ignored.
+   */
+  setProfileOverride(profile: InferenceProfileName | null): void {
+    if (profile !== null && profile !== 'quality' && profile !== 'fast') return;
+    this.profileOverride = profile;
   }
 
   private effectiveThreads(): number {

--- a/desktop/main/backend/ingest/pipeline.ts
+++ b/desktop/main/backend/ingest/pipeline.ts
@@ -62,6 +62,15 @@ export interface IngestPipelineOptions {
   /** Extraction resource caps; omit for none (direct test constructions). */
   limits?: IngestLimits;
   onProgress?: (event: IngestProgress) => void;
+  /**
+   * B8 (issue #66, S3): the generation/ingestion coordination seam. When
+   * present, the embed phase awaits coordination.waitForGenerationEnd()
+   * before EVERY embed call — ingestion pauses while a generation runs
+   * (ConcurrencyScheduler satisfies this structurally; AC4).
+   */
+  coordination?: {
+    waitForGenerationEnd(): Promise<void>;
+  };
 }
 
 /** Byte-matches run_interop.py's normalized(): CRLF->LF, trailing space strip. */
@@ -252,6 +261,9 @@ export class IngestPipeline {
     }
 
     this.emit(docId, 'embed', 55);
+    // B8 (issue #66, AC4): pause before embed-heavy work while a generation
+    // is in flight — the awaited seam resolves the moment no generation runs.
+    await this.opts.coordination?.waitForGenerationEnd();
     let vectors: number[][];
     try {
       vectors = await this.opts.embedder.embed(chunks.map((c) => c.text));

--- a/desktop/main/backend/memory/budget.ts
+++ b/desktop/main/backend/memory/budget.ts
@@ -21,7 +21,9 @@ export type MemoryComponent = 'chromium' | 'llm' | 'embeddingSession' | 'reranke
 export interface MemoryBudgetConfig {
   /** memory.telemetryIntervalMs — host sampler cadence (default 5000). */
   telemetryIntervalMs: number;
-  /** memory.maxTotalGb — the enforced peak-RSS ceiling (default 16, the v3 floor). */
+  /** memory.maxTotalGb — the ACCOUNTING ceiling: the component table (ADR-0008 /
+ *  bench/RESULTS.md) must sum under it with headroom. It is enforced
+ *  procedurally (ADR accounting + soak evidence), not as a runtime kill-switch. */
   maxTotalGb: number;
   /** memory.pressureThresholdGb — B4's inference.profileThresholdGb (default 6). */
   pressureThresholdGb: number;
@@ -33,11 +35,16 @@ export interface MemoryBudgetConfig {
   idleUnloadMs: number;
 }
 
-/** Explicit positive integers only; junk/zero/negative fall back to the default. */
+/** Explicit positive integers only, bounded to the 32-bit timer range: junk or
+ *  out-of-range values fall back to the default. Values above 2^31-1 reaching
+ *  setInterval/setTimeout get silently CLAMPED TO 1ms by Node
+ *  (TimeoutOverflowWarning) — a hot loop (PRR-F3). */
+const MAX_TIMER_MS = 2147483647;
+
 function positiveInt(raw: string | undefined, fallback: number): number {
   if (raw === undefined || raw === '' || !/^\d+$/.test(raw)) return fallback;
   const value = Number.parseInt(raw, 10);
-  return Number.isFinite(value) && value > 0 ? value : fallback;
+  return Number.isFinite(value) && value > 0 && value <= MAX_TIMER_MS ? value : fallback;
 }
 
 export function resolveMemoryConfig(env: Record<string, string | undefined> = process.env): MemoryBudgetConfig {
@@ -78,6 +85,15 @@ export interface PressureStatus {
 export interface PressureMonitor {
   observe(freeBytes: number, atMs?: number): void;
   evaluate(atMs?: number): PressureStatus;
+  /**
+   * Host acknowledgement after it clears a latched downgrade override (the
+   * monitor's only upgrade path is the host's; PRR-F1). Clears the downgrade
+   * latch and recovery state so the NEXT downgrade requires a NEW sustained
+   * pressure episode — without this, `downgraded` stays true forever and the
+   * host re-latches the override on the next tick (level-vs-edge bug:
+   * oscillating fast/quality flips + event spam).
+   */
+  resetAfterUpgrade(): void;
 }
 
 /**
@@ -131,6 +147,12 @@ export function createPressureMonitor(options: PressureMonitorOptions = {}): Pre
         effectiveProfile: downgradedLatch ? 'fast' : 'quality',
         recoveryEligible: recoveryEligibleLatch,
       };
+    },
+    resetAfterUpgrade() {
+      downgradedLatch = false;
+      recoveryEligibleLatch = false;
+      pressureStreakStartMs = null;
+      recoveryStreakStartMs = null;
     },
   };
 }

--- a/desktop/main/backend/memory/budget.ts
+++ b/desktop/main/backend/memory/budget.ts
@@ -1,0 +1,170 @@
+// memory/budget.ts — the 16 GB runtime memory budget (issue #66, S2/S6).
+//
+// Pure configuration + decision logic: the resolve* helpers follow the
+// established per-subsystem pattern (explicit positive integers only; any
+// invalid value falls back to that key's default — exactly like
+// ingest/config.ts and inference/llama-engine.ts's env ingress), and the
+// pressure monitor is a synchronous state machine the host feeds samples
+// into (no polling loop lives here; the host owns the timer).
+//
+// Cross-reference contract (b8-wiring C9 pins it): pressureThresholdGb is
+// IMPORTED from inference/profile-select.js — B4's inference.profileThresholdGb
+// and B8's memory.pressureThresholdGb are the SAME threshold by construction,
+// so the two knobs cannot drift apart.
+import { DEFAULT_PROFILE_THRESHOLD_GB } from '../inference/profile-select.js';
+
+const GIB = 1024 ** 3;
+
+/** The measurable memory components (the MemorySnapshot budget lines, S1). */
+export type MemoryComponent = 'chromium' | 'llm' | 'embeddingSession' | 'rerankerSession' | 'sqlite';
+
+export interface MemoryBudgetConfig {
+  /** memory.telemetryIntervalMs — host sampler cadence (default 5000). */
+  telemetryIntervalMs: number;
+  /** memory.maxTotalGb — the enforced peak-RSS ceiling (default 16, the v3 floor). */
+  maxTotalGb: number;
+  /** memory.pressureThresholdGb — B4's inference.profileThresholdGb (default 6). */
+  pressureThresholdGb: number;
+  /** memory.pressureSustainedMs — sub-threshold streak that latches the downgrade (default 10000). */
+  pressureSustainedMs: number;
+  /** memory.recoverySustainedMs — above-threshold streak before upgrade ELIGIBILITY (default 60000). */
+  recoverySustainedMs: number;
+  /** memory.idleUnloadMs — idle window before ONNX sessions unload (default 300000). */
+  idleUnloadMs: number;
+}
+
+/** Explicit positive integers only; junk/zero/negative fall back to the default. */
+function positiveInt(raw: string | undefined, fallback: number): number {
+  if (raw === undefined || raw === '' || !/^\d+$/.test(raw)) return fallback;
+  const value = Number.parseInt(raw, 10);
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+export function resolveMemoryConfig(env: Record<string, string | undefined> = process.env): MemoryBudgetConfig {
+  return {
+    telemetryIntervalMs: positiveInt(env.TRAININGAPP_MEMORY_TELEMETRY_INTERVAL_MS, 5000),
+    maxTotalGb: positiveInt(env.TRAININGAPP_MEMORY_MAX_TOTAL_GB, 16),
+    pressureThresholdGb: positiveInt(env.TRAININGAPP_MEMORY_PRESSURE_THRESHOLD_GB, DEFAULT_PROFILE_THRESHOLD_GB),
+    pressureSustainedMs: positiveInt(env.TRAININGAPP_MEMORY_PRESSURE_SUSTAINED_MS, 10000),
+    recoverySustainedMs: positiveInt(env.TRAININGAPP_MEMORY_RECOVERY_SUSTAINED_MS, 60000),
+    idleUnloadMs: positiveInt(env.TRAININGAPP_MEMORY_IDLE_UNLOAD_MS, 300000),
+  };
+}
+
+// ---- pressure monitor (the downgrade decision, S6) -------------------------
+
+export interface PressureMonitorOptions {
+  /** Default from resolveMemoryConfig (DEFAULT_PROFILE_THRESHOLD_GB). */
+  pressureThresholdGb?: number;
+  /** Default from resolveMemoryConfig. */
+  pressureSustainedMs?: number;
+  /** Default: pressureSustainedMs. */
+  recoverySustainedMs?: number;
+  /** Clock seam, default Date.now. */
+  nowMs?: () => number;
+}
+
+export interface PressureStatus {
+  /** True once sub-threshold free RAM has been sustained >= pressureSustainedMs. */
+  downgraded: boolean;
+  /** 'fast' iff downgraded — NO silent auto-upgrade (AC3). */
+  effectiveProfile: 'quality' | 'fast';
+  /** True once above-threshold free RAM has been sustained >= recoverySustainedMs
+   *  AFTER the downgrade. Eligibility ONLY: the upgrade transition is host policy
+   *  between generations (the host clears its override; the monitor never does). */
+  recoveryEligible: boolean;
+}
+
+export interface PressureMonitor {
+  observe(freeBytes: number, atMs?: number): void;
+  evaluate(atMs?: number): PressureStatus;
+}
+
+/**
+ * Pure hysteresis state machine:
+ *   - the pressure boundary is INCLUSIVE like B4 selectProfile: freeBytes
+ *     >= pressureThresholdGb GiB is NOT pressure; strictly below is;
+ *   - a pressure streak broken by an above-threshold sample never matures;
+ *   - once downgraded, effectiveProfile stays 'fast' until the host upgrades;
+ *     sustained recovery only flips recoveryEligible, and a return to pressure
+ *     revokes eligibility (a fresh recovery window is required again).
+ */
+export function createPressureMonitor(options: PressureMonitorOptions = {}): PressureMonitor {
+  const defaults = resolveMemoryConfig();
+  const thresholdBytes = (options.pressureThresholdGb ?? defaults.pressureThresholdGb) * GIB;
+  const pressureSustainedMs = options.pressureSustainedMs ?? defaults.pressureSustainedMs;
+  const recoverySustainedMs = options.recoverySustainedMs ?? pressureSustainedMs;
+  const nowMs = options.nowMs ?? Date.now;
+
+  let pressureStreakStartMs: number | null = null;
+  let recoveryStreakStartMs: number | null = null;
+  let downgradedLatch = false;
+  let recoveryEligibleLatch = false;
+
+  return {
+    observe(freeBytes, atMs) {
+      const stamp = atMs ?? nowMs();
+      if (freeBytes < thresholdBytes) {
+        recoveryStreakStartMs = null;
+        recoveryEligibleLatch = false;
+        if (pressureStreakStartMs === null) pressureStreakStartMs = stamp;
+      } else {
+        pressureStreakStartMs = null;
+        if (downgradedLatch && recoveryStreakStartMs === null) recoveryStreakStartMs = stamp;
+      }
+    },
+    evaluate(atMs) {
+      const stamp = atMs ?? nowMs();
+      if (!downgradedLatch && pressureStreakStartMs !== null && stamp - pressureStreakStartMs >= pressureSustainedMs) {
+        downgradedLatch = true;
+      }
+      if (
+        downgradedLatch &&
+        !recoveryEligibleLatch &&
+        recoveryStreakStartMs !== null &&
+        stamp - recoveryStreakStartMs >= recoverySustainedMs
+      ) {
+        recoveryEligibleLatch = true;
+      }
+      return {
+        downgraded: downgradedLatch,
+        effectiveProfile: downgradedLatch ? 'fast' : 'quality',
+        recoveryEligible: recoveryEligibleLatch,
+      };
+    },
+  };
+}
+
+// ---- concurrency + worker-pool sizing (S3/S4) ------------------------------
+
+export interface ConcurrencyConfig {
+  /** concurrency.maxConcurrentGenerations (default 1, S3). */
+  maxConcurrentGenerations: number;
+}
+
+export function resolveConcurrencyConfig(env: Record<string, string | undefined> = process.env): ConcurrencyConfig {
+  return {
+    maxConcurrentGenerations: positiveInt(env.TRAININGAPP_CONCURRENCY_MAX_CONCURRENT_GENERATIONS, 1),
+  };
+}
+
+export interface WorkerPoolConfig {
+  /** embedding.workerPoolSize (default 1) — explicit, never os.cpus()-derived. */
+  embeddingWorkerPoolSize: number;
+  /** reranker.workerPoolSize (default 1) — explicit, never os.cpus()-derived. */
+  rerankerWorkerPoolSize: number;
+}
+
+/**
+ * The resolver is HONEST: it reports the configured value (e.g. 3). The >1
+ * REJECTION is deliberately at the host consumption site, where the B7
+ * single-thread ORT ownership constraint applies (onnxruntime-node aborts the
+ * process when one module instance is used from two threads — see
+ * backend/index.ts). Parsing and policy must not be conflated.
+ */
+export function resolveWorkerPoolConfig(env: Record<string, string | undefined> = process.env): WorkerPoolConfig {
+  return {
+    embeddingWorkerPoolSize: positiveInt(env.TRAININGAPP_EMBEDDING_WORKER_POOL_SIZE, 1),
+    rerankerWorkerPoolSize: positiveInt(env.TRAININGAPP_RERANKER_WORKER_POOL_SIZE, 1),
+  };
+}

--- a/desktop/main/backend/memory/idle-unload.ts
+++ b/desktop/main/backend/memory/idle-unload.ts
@@ -1,0 +1,77 @@
+// memory/idle-unload.ts — idle ONNX-session unloading (issue #66, S5).
+//
+// The controller owns ONLY the idle-window policy: construction does not arm
+// a window (nothing loaded -> nothing to unload); touch() (re)arms it; after
+// idleUnloadMs with no touch, unload fires EXACTLY ONCE for that window; a
+// later touch starts a fresh window (the reload-then-idle-again lifecycle).
+// Reload itself is lazy at the consumption site (retrieval/reranker.ts
+// ResumableReranker): the next request rebuilds the session and reports the
+// measured reload latency via recordReload (AC5).
+export interface IdleUnloadOptions {
+  /** The idle window (memory.idleUnloadMs, S5). */
+  idleUnloadMs: number;
+  /** Invoked ONCE per elapsed idle window; may be async (fire-and-forget). */
+  unload: () => void | Promise<void>;
+  /** Clock seam reserved for injected-time tests; the window itself runs on a
+   *  real one-shot timer so worker teardown cannot be faked. */
+  nowMs?: () => number;
+}
+
+export class IdleUnloadController {
+  private readonly idleUnloadMs: number;
+  private readonly unload: () => void | Promise<void>;
+  private readonly nowMs: () => number;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private fires = 0;
+  private reloadMs: number | null = null;
+  private disposed = false;
+
+  constructor(options: IdleUnloadOptions) {
+    this.idleUnloadMs = options.idleUnloadMs;
+    this.unload = options.unload;
+    this.nowMs = options.nowMs ?? Date.now;
+    void this.nowMs;
+  }
+
+  /** Marks use; (re)arms the idle window from NOW. */
+  touch(): void {
+    if (this.disposed) return;
+    if (this.timer !== null) clearTimeout(this.timer);
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      this.fires += 1;
+      try {
+        void Promise.resolve(this.unload()).catch(() => {
+          // The controller owns the policy, not the teardown's failure:
+          // an unload error is consumed here (the next use rebuilds anyway).
+        });
+      } catch {
+        // synchronous throw guard — same policy
+      }
+    }, this.idleUnloadMs);
+  }
+
+  /** Stops the timer; unload NEVER fires afterwards; touch() becomes inert. */
+  dispose(): void {
+    this.disposed = true;
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /** How many times unload has fired (>= 0). */
+  get unloadCount(): number {
+    return this.fires;
+  }
+
+  /** The host records a measured reload latency (AC5). */
+  recordReload(ms: number): void {
+    this.reloadMs = ms;
+  }
+
+  /** null until the first recordReload. */
+  get lastReloadMs(): number | null {
+    return this.reloadMs;
+  }
+}

--- a/desktop/main/backend/memory/scheduler.ts
+++ b/desktop/main/backend/memory/scheduler.ts
@@ -24,7 +24,7 @@ interface QueuedJob {
 export class ConcurrencyScheduler {
   private readonly max: number;
   private queue: QueuedJob[] = [];
-  private waiters: Array<() => void> = [];
+  private waiters: Array<{ resolve: () => void; reject: (err: Error) => void }> = [];
   private active = 0;
 
   constructor(options: ConcurrencySchedulerOptions = {}) {
@@ -55,8 +55,8 @@ export class ConcurrencyScheduler {
    */
   waitForGenerationEnd(): Promise<void> {
     if (!this.generationInFlight) return Promise.resolve();
-    return new Promise<void>((resolve) => {
-      this.waiters.push(resolve);
+    return new Promise<void>((resolve, reject) => {
+      this.waiters.push({ resolve, reject });
     });
   }
 
@@ -75,10 +75,17 @@ export class ConcurrencyScheduler {
     return this.active;
   }
 
-  /** Host shutdown: reject every QUEUED (not yet started) generation. */
+  /**
+   * Host shutdown: reject every QUEUED (not yet started) generation AND every
+   * pending waitForGenerationEnd() waiter, so an ingest paused on the seam
+   * fails fast instead of awaiting a scheduler that no longer exists
+   * (PRR-F4).
+   */
   rejectQueued(err: Error): void {
     const queued = this.queue.splice(0, this.queue.length);
     for (const job of queued) job.reject(err);
+    const waiters = this.waiters.splice(0, this.waiters.length);
+    for (const waiter of waiters) waiter.reject(err);
   }
 
   private pump(): void {
@@ -96,7 +103,7 @@ export class ConcurrencyScheduler {
           this.active -= 1;
           if (this.active === 0) {
             const waiters = this.waiters.splice(0, this.waiters.length);
-            for (const waiter of waiters) waiter();
+            for (const waiter of waiters) waiter.resolve();
           }
           this.pump();
         })

--- a/desktop/main/backend/memory/scheduler.ts
+++ b/desktop/main/backend/memory/scheduler.ts
@@ -1,0 +1,106 @@
+// memory/scheduler.ts — generation/ingestion serialization (issue #66, S3).
+//
+// ConcurrencyScheduler formalizes what B4 left implicit: a FIFO mutex around
+// LLM generation with observability, PLUS the ingestion-pause seam the B6
+// embed phase awaits. Excess generations queue (never 503) — the same
+// semantics as the per-engine queue in inference/llama-engine.ts, but
+// engine-independent (it holds for the CI StubEngine too) and observable.
+//
+// Observability contract (b8-wiring C9 pins the exact values): with one
+// generation running and one queued, (generationInFlight, queueDepth,
+// activeGenerations) reads (true, 1, 1); drained it reads (false, 0, 0).
+// The host checks the drained triple before clearing a pressure override.
+export interface ConcurrencySchedulerOptions {
+  /** Default 1 (concurrency.maxConcurrentGenerations, S3). */
+  maxConcurrentGenerations?: number;
+}
+
+interface QueuedJob {
+  fn: () => Promise<unknown>;
+  resolve: (value: unknown) => void;
+  reject: (err: unknown) => void;
+}
+
+export class ConcurrencyScheduler {
+  private readonly max: number;
+  private queue: QueuedJob[] = [];
+  private waiters: Array<() => void> = [];
+  private active = 0;
+
+  constructor(options: ConcurrencySchedulerOptions = {}) {
+    const requested = options.maxConcurrentGenerations ?? 1;
+    this.max = Number.isInteger(requested) && requested >= 1 ? requested : 1;
+  }
+
+  /**
+   * Serialized execution: at most maxConcurrentGenerations fn()s run at once;
+   * excess generations queue FIFO. Resolves with fn's value, rejects with
+   * fn's error — one failing generation never breaks the queue.
+   */
+  runGeneration<T>(fn: () => Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      this.queue.push({
+        fn: fn as () => Promise<unknown>,
+        resolve: resolve as (value: unknown) => void,
+        reject,
+      });
+      this.pump();
+    });
+  }
+
+  /**
+   * Resolves the next time the scheduler has NO generation in flight
+   * (immediately when idle). The ingestion-pause seam: the B6 embed phase
+   * awaits this before embed-heavy work (AC4).
+   */
+  waitForGenerationEnd(): Promise<void> {
+    if (!this.generationInFlight) return Promise.resolve();
+    return new Promise<void>((resolve) => {
+      this.waiters.push(resolve);
+    });
+  }
+
+  /** True while a generation executes. */
+  get generationInFlight(): boolean {
+    return this.active > 0;
+  }
+
+  /** Generations waiting to START. */
+  get queueDepth(): number {
+    return this.queue.length;
+  }
+
+  /** Currently executing generations (0..max). */
+  get activeGenerations(): number {
+    return this.active;
+  }
+
+  /** Host shutdown: reject every QUEUED (not yet started) generation. */
+  rejectQueued(err: Error): void {
+    const queued = this.queue.splice(0, this.queue.length);
+    for (const job of queued) job.reject(err);
+  }
+
+  private pump(): void {
+    while (this.active < this.max && this.queue.length > 0) {
+      const job = this.queue.shift();
+      if (job === undefined) break;
+      this.active += 1;
+      void job
+        .fn()
+        .finally(() => {
+          // Cleanup BEFORE the consumer's promise settles: after `await
+          // runGeneration(...)` returns, generationInFlight must already be
+          // false (the frozen C3 spec reads it synchronously right after the
+          // await) and a queued next generation must already have started.
+          this.active -= 1;
+          if (this.active === 0) {
+            const waiters = this.waiters.splice(0, this.waiters.length);
+            for (const waiter of waiters) waiter();
+          }
+          this.pump();
+        })
+        .then(job.resolve, job.reject);
+    }
+  }
+}

--- a/desktop/main/backend/memory/telemetry.ts
+++ b/desktop/main/backend/memory/telemetry.ts
@@ -1,0 +1,82 @@
+// memory/telemetry.ts — per-component memory sampling (issue #66, S1).
+//
+// Maps injectable seams onto the documented MemorySnapshot (MB fields,
+// 1 MB = 1024 * 1024 bytes). Pure sampling: the polling cadence is host
+// policy (a setInterval on memory.telemetryIntervalMs); this module never
+// runs a timer.
+//
+// In-process attribution semantics (the backend is Node in-process; ADR-0003
+// is open — see docs/adr/0008-memory-budget.md):
+//   - chromium  = main-process RSS (process.memoryUsage().rss; includes the
+//                 native heaps: llama.cpp, main-thread ORT if any, sqlite);
+//   - llm       = host-injected (resident-model incremental footprint;
+//                 0 when no model is resident);
+//   - embeddingSession / rerankerSession = host-injected (worker-reported
+//                 external+arrayBuffers when the retrieval worker exists —
+//                 the ONNX sessions live on that single ORT thread);
+//   - sqlite    = host-injected (better-sqlite3's own heap counter);
+//   - systemFreeMb / systemTotalMb = os.freemem()/os.totalmem().
+// Uninjectable components degrade to 0 — the snapshot shape never changes.
+import os from 'node:os';
+import type { MemoryComponent } from './budget.js';
+import { resolveMemoryConfig } from './budget.js';
+
+const MIB = 1024 * 1024;
+
+export interface MemorySnapshot {
+  chromiumRssMb: number;
+  llmRssMb: number;
+  embeddingSessionRssMb: number;
+  rerankerSessionRssMb: number;
+  sqliteRssMb: number;
+  systemFreeMb: number;
+  systemTotalMb: number;
+}
+
+export interface MemoryTelemetryOptions {
+  /** Default os.freemem(). */
+  freeMemBytes?: () => number;
+  /** Default os.totalmem(). */
+  totalMemBytes?: () => number;
+  /** Per-component RSS provider; returns BYTES; default: 0 for every component. */
+  rssProvider?: (component: MemoryComponent) => number;
+  /** Declared cadence (memory.telemetryIntervalMs); informational here — the
+   *  host owns the actual timer. Default resolveMemoryConfig().telemetryIntervalMs. */
+  intervalMs?: number;
+}
+
+export interface MemoryTelemetry {
+  /** Takes a fresh sample through the seams and records it. */
+  sample(): MemorySnapshot;
+  /** Returns the latest sample WITHOUT re-sampling (lazily takes one if none exists yet). */
+  snapshot(): MemorySnapshot;
+}
+
+export function createMemoryTelemetry(options: MemoryTelemetryOptions = {}): MemoryTelemetry {
+  const freeMemBytes = options.freeMemBytes ?? (() => os.freemem());
+  const totalMemBytes = options.totalMemBytes ?? (() => os.totalmem());
+  const rssProvider = options.rssProvider ?? (() => 0);
+  void (options.intervalMs ?? resolveMemoryConfig().telemetryIntervalMs);
+
+  let latest: MemorySnapshot | null = null;
+  const take = (): MemorySnapshot => ({
+    chromiumRssMb: rssProvider('chromium') / MIB,
+    llmRssMb: rssProvider('llm') / MIB,
+    embeddingSessionRssMb: rssProvider('embeddingSession') / MIB,
+    rerankerSessionRssMb: rssProvider('rerankerSession') / MIB,
+    sqliteRssMb: rssProvider('sqlite') / MIB,
+    systemFreeMb: freeMemBytes() / MIB,
+    systemTotalMb: totalMemBytes() / MIB,
+  });
+
+  return {
+    sample: () => {
+      latest = take();
+      return latest;
+    },
+    snapshot: () => {
+      if (latest === null) latest = take();
+      return latest;
+    },
+  };
+}

--- a/desktop/main/backend/retrieval/rerank-worker.ts
+++ b/desktop/main/backend/retrieval/rerank-worker.ts
@@ -9,13 +9,16 @@
 // The host therefore never calls ORT on the main thread when this worker
 // exists (WorkerEmbedder proxies query/ingest embeddings here).
 //
-// Message protocol (rerank half pinned by C4):
+// Message protocol (rerank half pinned by C4; memory half pinned by C9):
 //   main  -> worker: { kind: 'rerank', jobId, query, candidates }
 //                  | { kind: 'embed',  jobId, texts }
+//                  | { kind: 'memory', jobId }
 //   worker -> main:  { kind: 'rerank:result', jobId, scores }
 //                or  { kind: 'rerank:error',   jobId, message }
 //                or  { kind: 'embed:result',   jobId, vectors }
 //                or  { kind: 'embed:error',    jobId, message }
+//                or  { kind: 'memory:result',  jobId,
+//                      memory: { rss, external, arrayBuffers } }
 //
 // Models: ettin-reranker-32m-v1 (the web_ui baseline reranker,
 // web_ui/src/lib/models/model-manifest.ts:72-76) and bge-small-en-v1.5
@@ -125,12 +128,28 @@ async function scoreBatch(
   return scores;
 }
 
+type WorkerMessage =
+  | WorkerJob
+  | { kind: 'memory'; jobId: number };
+
 const port = parentPort;
 if (port !== null) {
   port.on('message', (raw: unknown) => {
     void (async () => {
-      const message = raw as WorkerJob;
-      if (!message || (message.kind !== 'rerank' && message.kind !== 'embed')) return;
+      const message = raw as WorkerMessage;
+      if (!message || typeof message.jobId !== 'number') return;
+      // B8 (issue #66): memory probe — thread-local counters for the
+      // telemetry snapshot (the ONNX sessions live on THIS thread).
+      if (message.kind === 'memory') {
+        const memory = process.memoryUsage();
+        port.postMessage({
+          kind: 'memory:result',
+          jobId: message.jobId,
+          memory: { rss: memory.rss, external: memory.external, arrayBuffers: memory.arrayBuffers },
+        });
+        return;
+      }
+      if (message.kind !== 'rerank' && message.kind !== 'embed') return;
       const dirs = ((workerData ?? {}) as { modelDir?: string | null; embedModelDir?: string | null });
       try {
         if (message.kind === 'rerank') {

--- a/desktop/main/backend/retrieval/reranker.ts
+++ b/desktop/main/backend/retrieval/reranker.ts
@@ -39,11 +39,23 @@ type WorkerResponse =
   | { kind: 'rerank:result'; jobId: number; scores: number[] }
   | { kind: 'rerank:error'; jobId: number; message: string }
   | { kind: 'embed:result'; jobId: number; vectors: number[][] }
-  | { kind: 'embed:error'; jobId: number; message: string };
+  | { kind: 'embed:error'; jobId: number; message: string }
+  | {
+      kind: 'memory:result';
+      jobId: number;
+      memory: { rss: number; external: number; arrayBuffers: number };
+    };
 
 interface PendingJob {
-  resolve: (payload: number[] | number[][]) => void;
+  resolve: (payload: number[] | number[][] | WorkerMemoryReport) => void;
   reject: (err: Error) => void;
+}
+
+/** Thread-local memory counters reported by the retrieval worker (B8, C9). */
+export interface WorkerMemoryReport {
+  rss: number;
+  external: number;
+  arrayBuffers: number;
 }
 
 /** A real reranker weight file is ~127MB; a Git-LFS pointer is ~134 bytes. */
@@ -143,6 +155,8 @@ export class WorkerReranker {
           job.resolve(message.scores);
         } else if (message.kind === 'embed:result' && Array.isArray(message.vectors)) {
           job.resolve(message.vectors);
+        } else if (message.kind === 'memory:result' && typeof message.memory === 'object' && message.memory !== null) {
+          job.resolve(message.memory);
         } else if ((message.kind === 'rerank:error' || message.kind === 'embed:error')) {
           job.reject(new Error(message.message));
         } else {
@@ -208,6 +222,27 @@ export class WorkerReranker {
     });
   }
 
+  /**
+   * B8 (issue #66, C9): the worker's thread-local memory counters for the
+   * telemetry snapshot. Resolves null when the worker was never started —
+   * it must NOT spawn a thread just to ask. Wire protocol: `{ kind: 'memory',
+   * jobId }` -> `{ kind: 'memory:result', jobId, memory: {...} }` (unwrapped
+   * here), served on the same pending-job machinery as score/embed.
+   */
+  async reportMemory(): Promise<WorkerMemoryReport | null> {
+    if (this.worker === null) return null;
+    const worker = this.worker;
+    const jobId = this.nextJobId;
+    this.nextJobId += 1;
+    return new Promise<WorkerMemoryReport>((resolve, reject) => {
+      this.pending.set(jobId, {
+        resolve: (payload) => resolve(payload as WorkerMemoryReport),
+        reject,
+      });
+      worker.postMessage({ kind: 'memory', jobId });
+    });
+  }
+
   /** Terminate the worker, reject in-flight jobs, idempotent. */
   async dispose(): Promise<void> {
     this.disposed = true;
@@ -233,15 +268,105 @@ export class WorkerReranker {
 }
 
 /**
+ * B8 (issue #66, S5/AC5): an unload-then-rebuild retrieval surface. The
+ * idle-unload host policy terminates the worker WITHOUT poisoning this
+ * instance; the NEXT score()/embed() transparently rebuilds a fresh
+ * WorkerReranker from the retained options and reports the measured
+ * construct-to-first-answer latency via onReload. dispose() is permanent
+ * (a disposed WorkerReranker is single-shot by construction, so "unload"
+ * vs "dispose" differ exactly in whether this instance may rebuild).
+ *
+ * Satisfies the RerankerSurface + WorkerEmbedder-embedder seams structurally,
+ * so the host can wrap the production worker without touching B7's surface.
+ */
+export class ResumableReranker {
+  private readonly runnerOptions: RerankerRunnerOptions;
+  private readonly onReload: ((ms: number) => void) | undefined;
+  private readonly onUse: (() => void) | undefined;
+  private runner: WorkerReranker | null = null;
+  private disposed = false;
+
+  constructor(
+    options: RerankerRunnerOptions & { onReload?: (ms: number) => void; onUse?: () => void } = {},
+  ) {
+    const { onReload, onUse, ...runnerOptions } = options;
+    this.runnerOptions = runnerOptions;
+    this.onReload = onReload;
+    this.onUse = onUse;
+  }
+
+  private ensureRunner(): WorkerReranker {
+    if (this.disposed) {
+      throw new Error('ResumableReranker has been disposed');
+    }
+    if (this.runner === null) {
+      this.runner = new WorkerReranker(this.runnerOptions);
+    }
+    return this.runner;
+  }
+
+  private async runWithReloadTiming<T>(run: (runner: WorkerReranker) => Promise<T>): Promise<T> {
+    // onUse fires on EVERY job start (the B8 idle-unload controller re-arms
+    // here), including during a rebuild.
+    this.onUse?.();
+    const rebuilt = this.runner === null;
+    const startedAt = performance.now();
+    const result = await run(this.ensureRunner());
+    if (rebuilt) {
+      // performance.now(): sub-ms precision, so even an instant fixture
+      // rebuild reports a finite, positive latency (C9's assertion).
+      const reloadMs = performance.now() - startedAt;
+      if (reloadMs > 0) this.onReload?.(reloadMs);
+    }
+    return result;
+  }
+
+  /** Score candidates against the query; rebuilds the worker after unload(). */
+  score(query: string, candidates: string[]): Promise<number[]> {
+    return this.runWithReloadTiming((runner) => runner.score(query, candidates));
+  }
+
+  /** Embed texts through the worker's bge pipeline; rebuilds after unload(). */
+  embed(texts: string[]): Promise<number[][]> {
+    if (texts.length === 0) return Promise.resolve([]);
+    return this.runWithReloadTiming((runner) => runner.embed(texts));
+  }
+
+  /**
+   * Idle unload: terminate the worker (in-flight jobs reject) and forget the
+   * instance. The NEXT score()/embed() transparently rebuilds a fresh one.
+   */
+  async unload(): Promise<void> {
+    const runner = this.runner;
+    this.runner = null;
+    if (runner !== null) await runner.dispose();
+  }
+
+  /** B8: worker memory counters, or null while unloaded (never rebuilds). */
+  async reportMemory(): Promise<WorkerMemoryReport | null> {
+    return this.runner !== null ? this.runner.reportMemory() : null;
+  }
+
+  /** Permanent teardown; idempotent; safe after unload(). */
+  async dispose(): Promise<void> {
+    this.disposed = true;
+    const runner = this.runner;
+    this.runner = null;
+    if (runner !== null) await runner.dispose();
+  }
+}
+
+/**
  * Main-thread proxy that routes embeddings through the retrieval worker so
  * onnxruntime stays on a SINGLE thread of this process (cross-thread ort
  * aborts the process; see rerank-worker.ts header). Satisfies the same
- * EmbeddingSurface contract as ingest/embedder.ts.
+ * EmbeddingSurface contract as ingest/embedder.ts. Structural embedder seam:
+ * accepts the raw WorkerReranker OR the B8 ResumableReranker wrapper.
  */
 export class WorkerEmbedder {
   readonly modelId: string;
   constructor(
-    private readonly worker: WorkerReranker,
+    private readonly worker: { embed(texts: string[]): Promise<number[][]> },
     modelId: string,
   ) {
     this.modelId = modelId;

--- a/desktop/main/backend/retrieval/reranker.ts
+++ b/desktop/main/backend/retrieval/reranker.ts
@@ -311,14 +311,28 @@ export class ResumableReranker {
     this.onUse?.();
     const rebuilt = this.runner === null;
     const startedAt = performance.now();
-    const result = await run(this.ensureRunner());
-    if (rebuilt) {
-      // performance.now(): sub-ms precision, so even an instant fixture
-      // rebuild reports a finite, positive latency (C9's assertion).
-      const reloadMs = performance.now() - startedAt;
-      if (reloadMs > 0) this.onReload?.(reloadMs);
+    try {
+      const result = await run(this.ensureRunner());
+      if (rebuilt) {
+        // performance.now(): sub-ms precision, so even an instant fixture
+        // rebuild reports a finite, positive latency (C9's assertion).
+        const reloadMs = performance.now() - startedAt;
+        if (reloadMs > 0) this.onReload?.(reloadMs);
+      }
+      return result;
+    } catch (err) {
+      // A DEAD runner must not be reused: worker-exit/dispose rejections
+      // would be replayed for every later job while the idle-unload
+      // controller never sees a usable session (PRR-F5). Drop it so the next
+      // call transparently rebuilds a fresh worker.
+      const message = err instanceof Error ? err.message : String(err);
+      if (/exited|disposed|terminated/i.test(message)) {
+        const dead = this.runner;
+        this.runner = null;
+        if (dead !== null) void dead.dispose().catch(() => {});
+      }
+      throw err;
     }
-    return result;
   }
 
   /** Score candidates against the query; rebuilds the worker after unload(). */

--- a/desktop/main/backend/server.ts
+++ b/desktop/main/backend/server.ts
@@ -32,11 +32,31 @@ export interface BackendServerOptions {
   engine?: EngineSurface;
   /** Sidecar mode: forward every request to this loopback upstream port. */
   upstreamPort?: number;
+  /**
+   * B8 (issue #66): generation/ingestion serialization. When wired, /ask and
+   * /ask/stream execute under the scheduler's FIFO mutex (max
+   * maxConcurrentGenerations) and its observability feeds the host's
+   * upgrade predicate. Optional: old constructions keep working unwired.
+   */
+  scheduler?: {
+    runGeneration<T>(fn: () => Promise<T>): Promise<T>;
+  };
+  /**
+   * B8 (issue #66): the telemetry snapshot provider for GET /telemetry/memory.
+   * Provider FUNCTION shape (host wires `() => ({ snapshot, downgrade })`).
+   * When absent the known route degrades to a contract-safe 503 — never 404.
+   */
+  telemetry?: () => {
+    snapshot: Record<string, number>;
+    downgrade: { effectiveProfile: 'quality' | 'fast'; downgraded: boolean };
+  };
 }
 
-// The 14 contract operations (contracts/api.openapi.yaml). Unknown paths get
+// The 15 contract operations (contracts/api.openapi.yaml). Unknown paths get
 // 404, known paths with a wrong method get 405 — the route TABLE is the
-// conformance surface.
+// conformance surface. (/telemetry/memory arrives with B8, issue #66: it is
+// token-guarded like every route — it reveals process memory — and degrades
+// to a contract-safe 503 when no telemetry provider is wired.)
 const CONTRACT_ROUTES: ReadonlyMap<string, ReadonlySet<string>> = new Map([
   ['/health', new Set(['GET'])],
   ['/auth/status', new Set(['GET'])],
@@ -50,6 +70,7 @@ const CONTRACT_ROUTES: ReadonlyMap<string, ReadonlySet<string>> = new Map([
   ['/search', new Set(['POST'])],
   ['/settings', new Set(['GET', 'PUT'])],
   ['/stats', new Set(['GET'])],
+  ['/telemetry/memory', new Set(['GET'])],
 ]);
 
 function sendJson(res: ServerResponse, status: number, body: unknown, cors?: CorsContext): void {
@@ -350,6 +371,13 @@ export function createBackendServer(opts: BackendServerOptions): http.Server {
       sendJson(res, 500, { detail: 'Backend host misconfigured: neither engine nor upstream' }, cors);
       return;
     }
+    // B8 (issue #66): when the host wired the scheduler, /ask + /ask/stream
+    // execute under the FIFO generation mutex. Unwired constructions keep the
+    // old unwrapped semantics (the transport cannot serialize what it was
+    // never handed).
+    const runGeneration = opts.scheduler
+      ? <T,>(fn: () => Promise<T>): Promise<T> => opts.scheduler!.runGeneration(fn)
+      : <T,>(fn: () => Promise<T>): Promise<T> => fn();
     const path = (req.url ?? '/').split('?')[0] ?? '/';
     const methods = CONTRACT_ROUTES.get(path);
     if (methods === undefined) {
@@ -396,10 +424,12 @@ export function createBackendServer(opts: BackendServerOptions): http.Server {
             if (path === '/ask') {
               let result;
               try {
-                result = await engine.query(parsed.value.question, {
-                  nResults: parsed.value.n_results,
-                  history: parsed.value.history,
-                });
+                result = await runGeneration(() =>
+                  engine.query(parsed.value.question, {
+                    nResults: parsed.value.n_results,
+                    history: parsed.value.history,
+                  }),
+                );
               } catch (err) {
                 // B4 (issue #62): no staged model is the contract's 503
                 // "engine not initialized" response with a load diagnostic.
@@ -422,9 +452,10 @@ export function createBackendServer(opts: BackendServerOptions): http.Server {
                 cors,
               );
             } else {
-              // B4 (issue #62): preflight BEFORE runAskStream writes any
-              // header, so a missing model still answers 503 JSON instead of
-              // a mid-stream error event after `200 text/event-stream`.
+              // B8 (issue #66): preflight stays OUTSIDE the generation mutex —
+              // a missing model must answer its 503 immediately, never queue
+              // behind an in-flight generation. Only the actual
+              // generation-carrying stream runs under the scheduler.
               try {
                 await engine.preflight?.();
               } catch (err) {
@@ -434,10 +465,12 @@ export function createBackendServer(opts: BackendServerOptions): http.Server {
                 }
                 throw err;
               }
-              await runAskStream(res, engine, parsed.value.question, {
-                n_results: parsed.value.n_results,
-                history: parsed.value.history,
-              }, cors);
+              await runGeneration(() =>
+                runAskStream(res, engine, parsed.value.question, {
+                  n_results: parsed.value.n_results,
+                  history: parsed.value.history,
+                }, cors),
+              );
             }
             return;
           }
@@ -584,6 +617,18 @@ export function createBackendServer(opts: BackendServerOptions): http.Server {
           case 'GET /stats':
             sendJson(res, 200, await engine.getStats(), cors);
             return;
+          case 'GET /telemetry/memory': {
+            // B8 (issue #66): token-guarded above (every route traverses the
+            // guard), so this reveals process memory only to the host's own
+            // renderer. Unwired hosts degrade to a contract-safe 503 — the
+            // path is KNOWN (405 semantics apply), never silently 404.
+            if (!opts.telemetry) {
+              sendJson(res, 503, { detail: 'Memory telemetry is not wired on this host' }, cors);
+              return;
+            }
+            sendJson(res, 200, opts.telemetry(), cors);
+            return;
+          }
           default:
             sendJson(res, 404, { detail: 'Not found' }, cors);
             return;

--- a/desktop/main/backend/store/document-surface.ts
+++ b/desktop/main/backend/store/document-surface.ts
@@ -47,6 +47,12 @@ export interface StoreDocumentSurfaceOptions {
   /** Schema root for re-initialization; discovered when omitted. */
   repoRoot?: string;
   onProgress?: (event: IngestProgress) => void;
+  /** B8 (issue #66, S3): forwarded to the pipeline — the embed phase awaits
+   *  this before embed-heavy work while a generation runs (ConcurrencyScheduler
+   *  satisfies it structurally). */
+  coordination?: {
+    waitForGenerationEnd(): Promise<void>;
+  };
 }
 
 export class StoreDocumentSurface implements DocumentSurface {
@@ -66,6 +72,7 @@ export class StoreDocumentSurface implements DocumentSurface {
         config: this.opts.config,
         ...(this.opts.limits ? { limits: this.opts.limits } : {}),
         onProgress: this.opts.onProgress,
+        ...(this.opts.coordination ? { coordination: this.opts.coordination } : {}),
       });
     }
     return this.pipeline;

--- a/desktop/main/backend/types.ts
+++ b/desktop/main/backend/types.ts
@@ -90,6 +90,20 @@ export interface IngestProgressEvent {
   percent: number;
 }
 
+/**
+ * Memory telemetry event shape (B8, issue #66): `memory:event` for B9.
+ * `downgrade` fires once when sustained pressure latches the Quality->Fast
+ * switch (carrying the observed free-RAM value); `recovery-eligible` fires
+ * once when the recovery window matures; `telemetry` carries informational
+ * budget notices (e.g. a worker-pool size >1 rejected by the ORT guardrail).
+ */
+export interface MemoryEvent {
+  type: 'downgrade' | 'recovery-eligible' | 'telemetry';
+  effectiveProfile?: 'quality' | 'fast';
+  freeMemMb?: number;
+  detail?: string;
+}
+
 export interface BackendHostConfig {
   mode?: BackendMode;
   /** Per-launch transport token (from security/token.ts, or a test token). */
@@ -121,6 +135,10 @@ export interface BackendHostConfig {
   /** Node mode only (B6): ingest progress sink. The Electron bootstrap
    *  forwards these to the renderer as `ingest:progress` IPC events. */
   onIngestProgress?: (event: IngestProgressEvent) => void;
+  /** Node mode only (B8, issue #66): memory telemetry/downgrade event sink.
+   *  The Electron bootstrap forwards these to the renderer as `memory:event`
+   *  IPC events (B9 owns the UI). */
+  onMemoryEvent?: (event: MemoryEvent) => void;
   /** Node mode only (B6): corruption prompt seam. When the store file fails
    *  the startup integrity check, the host asks the embedder of this callback
    *  whether to restore from the latest backup or start fresh; when unset,

--- a/desktop/main/index.ts
+++ b/desktop/main/index.ts
@@ -212,6 +212,14 @@ export function bootstrap(): void {
             win.webContents.send('ingest:progress', event);
           }
         },
+        // B8 (issue #66): forward memory telemetry/downgrade events to the
+        // renderer as `memory:event` (B9 owns the UI; the channel name is the
+        // B9 contract, documented in docs/adr/0008-memory-budget.md).
+        onMemoryEvent: (event) => {
+          for (const win of BrowserWindow.getAllWindows()) {
+            win.webContents.send('memory:event', event);
+          }
+        },
         // B6: corruption prompt — modal by design (ADR-0006): a store failing
         // integrity cannot be served, so startup blocks on the user's choice.
         onStoreCorruption: async (info) => {

--- a/desktop/src/__tests__/b8-host-loop.test.ts
+++ b/desktop/src/__tests__/b8-host-loop.test.ts
@@ -1,0 +1,130 @@
+// b8-host-loop.test.ts — PR-review regression pin (PRR-F1/PRR-F6, issue #66
+// PR #104 review round). ADDITIVE spec: not part of the frozen checkpoint
+// set; it exists because the frozen b8 specs exercise the memory units and
+// the frozen route/scheduler seams but never the REAL NodeBackendHost
+// memoryTick loop across ticks — the exact seam where the downgrade/upgrade
+// oscillation (fast/quality re-latch every ~2 ticks after one pressure
+// episode) shipped and passed CI.
+//
+// What this pins, end to end through the REAL host loop (real
+// NodeBackendHost + real LlamaEngine + real PressureMonitor + real sampler
+// interval; only os.freemem() is mocked so the pressure episodes are
+// deterministic):
+//   1. sustained sub-threshold os.freemem() latches the override
+//      (effectiveProfile 'fast' even though the ENGINE sees ample RAM — the
+//      override, not auto-selection, must be the cause) + downgrade event;
+//   2. sustained recovery + drained scheduler clears the override
+//      (effectiveProfile back to 'quality') + recovery-eligible and
+//      override-cleared events;
+//   3. THE REGRESSION: ticks after the upgrade produce NO further events and
+//      the profile STAYS quality (the monitor ack resets the latch — no
+//      fast/quality oscillation).
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import os from 'node:os';
+import { NodeBackendHost } from '../../main/backend/index.js';
+import { LlamaEngine } from '../../main/backend/inference/llama-engine.js';
+import type { MemoryEvent } from '../../main/backend/types.js';
+
+const GIB = 1024 ** 3;
+
+// freemem() is the HOST-side pressure signal (index.ts monitor.observe); the
+// ENGINE's own free-RAM seam is injected separately and kept HIGH so any
+// 'fast' observed in phase A can only come from the pressure override.
+const hostFree = vi.hoisted(() => ({ bytes: 10 * 1024 ** 3 }));
+
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>();
+  const mocked = {
+    ...actual,
+    freemem: () => hostFree.bytes,
+  };
+  return {
+    ...actual,
+    default: mocked,
+    freemem: mocked.freemem,
+  };
+});
+
+const ENV = {
+  TRAININGAPP_MEMORY_TELEMETRY_INTERVAL_MS: '25',
+  TRAININGAPP_MEMORY_PRESSURE_SUSTAINED_MS: '80',
+  TRAININGAPP_MEMORY_RECOVERY_SUSTAINED_MS: '80',
+} as const;
+
+describe('b8 host loop (PRR-F1 regression pin): real memoryTick across ticks', () => {
+  let host: NodeBackendHost | null = null;
+  let events: MemoryEvent[] = [];
+  let engine: LlamaEngine;
+
+  const drain = async (ms: number): Promise<void> => {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+  };
+
+  afterEach(async () => {
+    if (host !== null) {
+      await host.stop().catch(() => {});
+      host = null;
+    }
+  });
+
+  it(
+    'downgrade latches once, upgrade clears the override, and post-upgrade ticks do NOT re-downgrade (no oscillation)',
+    async () => {
+      let engineFree = 10 * GIB; // engine auto-selection would say 'quality'
+      engine = new LlamaEngine({ freeMemBytes: () => engineFree, modelDir: 'Z:/b8-host-loop-none' });
+      events = [];
+      host = new NodeBackendHost({
+        token: 'b8-host-loop-token',
+        env: { ...ENV },
+        engine,
+        onMemoryEvent: (event) => events.push(event),
+      });
+      await host.start();
+
+      // Phase A: sustained sub-threshold HOST free RAM -> override latches.
+      hostFree.bytes = 1 * GIB;
+      await drain(500);
+      const afterPressure = engine.effectiveProfile();
+      expect(
+        afterPressure,
+        'sustained host-level pressure must downgrade the effective profile',
+      ).toBe('fast');
+      expect(events.some((e) => e.type === 'downgrade'), 'a downgrade event fired').toBe(true);
+      const eventsAfterPressure = events.length;
+
+      // Phase B: sustained recovery -> eligibility -> override cleared.
+      hostFree.bytes = 12 * GIB;
+      await drain(700);
+      expect(
+        engine.effectiveProfile(),
+        'sustained recovery must clear the override (back to auto quality)',
+      ).toBe('quality');
+      expect(events.some((e) => e.type === 'recovery-eligible'), 'recovery-eligible fired').toBe(
+        true,
+      );
+      expect(
+        events.some((e) => e.type === 'telemetry'),
+        'the override-cleared telemetry event fired',
+      ).toBe(true);
+
+      // Phase C (THE PIN): healthy ticks after the upgrade must be quiet —
+      // no re-downgrade, no event spam, profile stable at quality. Before the
+      // PRR-F1 fix this phase re-latched 'fast' every other tick.
+      const eventsBeforeQuiet = events.length;
+      await drain(900); // ~36 ticks at the 25 ms interval
+      expect(engine.effectiveProfile(), 'profile must STAY quality after the upgrade').toBe(
+        'quality',
+      );
+      expect(
+        events.length,
+        `no events may fire after the upgrade (had ${eventsBeforeQuiet}, got ${events.length}: ${JSON.stringify(events.slice(eventsBeforeQuiet))})`,
+      ).toBe(eventsBeforeQuiet);
+      expect(eventsAfterPressure).toBeGreaterThan(0);
+
+      // Teardown exercises the B8 stop() path as well.
+      await host.stop();
+      host = null;
+    },
+    20_000,
+  );
+});

--- a/desktop/src/__tests__/b8-idle-unload.test.ts
+++ b/desktop/src/__tests__/b8-idle-unload.test.ts
@@ -1,0 +1,217 @@
+// b8-idle-unload.test.ts — FROZEN ACCEPTANCE SPEC (issue #66 trace, AC5 / S5, check C4).
+//
+// NEW-SURFACE: statically imports desktop/main/backend/memory/idle-unload.js,
+// which does not exist at the base revision — the whole file fails collection
+// with a module-not-found error, which IS the acceptance evidence for the
+// missing idle-session-unload surface.
+//
+// FROZEN PRODUCTION CONTRACT — module desktop/main/backend/memory/idle-unload.ts:
+//
+//   export interface IdleUnloadOptions {
+//     idleUnloadMs: number;                 // the idle window (memory.idleUnloadMs, S5)
+//     unload: () => void | Promise<void>;   // invoked ONCE per elapsed idle window
+//     nowMs?: () => number;                 // clock seam, default Date.now
+//   }
+//   export class IdleUnloadController {
+//     constructor(options: IdleUnloadOptions);
+//     touch(): void;                 // marks use; (re-)arms the idle window.
+//                                    // The idle window runs from the LAST touch();
+//                                    // construction alone does not arm a window
+//                                    // (nothing loaded -> nothing to unload).
+//     dispose(): void;               // stops the timer; unload NEVER fires after.
+//     readonly unloadCount: number;  // how many times unload has fired (>= 0).
+//     recordReload(ms: number): void;       // host records a measured reload latency (AC5)
+//     readonly lastReloadMs: number | null; // null until the first recordReload.
+//   }
+//
+//   Idle semantics pinned below: after idleUnloadMs with NO use, unload fires
+//   EXACTLY ONCE for that window (never repeatedly); a touch() during a window
+//   re-arms it (the pending unload does NOT fire); a touch() after an unload
+//   re-arms a FRESH window which may fire again (the reload-then-idle-again
+//   lifecycle); dispose() cancels a pending window outright.
+//
+// FROZEN HOST-LEVEL RELOAD CONTRACT (AC5, exercised in the last test with the
+// REAL WorkerReranker and a fixture worker — NO ONNX weights needed):
+//   - unload  = await runner.dispose()            (WorkerReranker.dispose terminates the worker);
+//   - reload  = lazily constructing a FRESH WorkerReranker on the next use
+//     (a disposed instance is single-shot by construction — reranker.ts
+//     throws after dispose — so reload means a new instance);
+//   - the measured reload latency = time from reload start until the FIRST
+//     post-reload request resolves, recorded via controller.recordReload(ms)
+//     and surfaced as controller.lastReloadMs.
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { IdleUnloadController } from '../../main/backend/memory/idle-unload.js';
+import { WorkerReranker } from '../../main/backend/retrieval/reranker.js';
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Fixture worker: answers rerank jobs IMMEDIATELY with deterministic
+ * descending scores (n-i)/n (the b7 message protocol, no busy sleep — the
+ * reload-latency measurement here must not be dominated by fake work).
+ * Written to a temp dir AT RUNTIME so the spec stays self-contained and
+ * weight-free.
+ */
+const FIXTURE_WORKER_SOURCE = [
+  "import { parentPort } from 'node:worker_threads';",
+  "parentPort.on('message', (msg) => {",
+  "  if (!msg || msg.kind !== 'rerank') return;",
+  '  const scores = msg.candidates.map((_, i) => (msg.candidates.length - i) / msg.candidates.length);',
+  "  parentPort.postMessage({ kind: 'rerank:result', jobId: msg.jobId, scores });",
+  '});',
+  '',
+].join('\n');
+
+function writeFixtureWorker(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'b8-c4-fixture-'));
+  const file = path.join(dir, 'fixture-rerank-worker.mjs');
+  fs.writeFileSync(file, FIXTURE_WORKER_SOURCE, 'utf8');
+  return file;
+}
+
+/** Remove the fixture's temp dir (best effort). */
+function cleanupFixture(workerPath: string): void {
+  try {
+    fs.rmSync(path.dirname(workerPath), { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+}
+
+// Real-timer windows kept tiny (< 500 ms per wait) with wide margins against
+// Windows timer coarsening (~15.6 ms quantum): checks at 70-80 ms against a
+// 150 ms window can never flake.
+const WINDOW_MS = 150;
+
+describe('b8 C4 (S5): IdleUnloadController idle semantics', () => {
+  it(
+    'fires unload EXACTLY ONCE after the idle window elapses with no use',
+    async () => {
+      const times: number[] = [];
+      const controller = new IdleUnloadController({
+        idleUnloadMs: WINDOW_MS,
+        unload: () => {
+          times.push(Date.now());
+        },
+      });
+      controller.touch();
+      await sleep(70); // inside the 150 ms window
+      expect(controller.unloadCount, 'not fired before the idle window elapses').toBe(0);
+      await sleep(300); // well past the window
+      expect(controller.unloadCount, 'unload fired exactly once for the window').toBe(1);
+      expect(times).toHaveLength(1);
+      await sleep(150); // idle continues; it must NOT fire again for the same window
+      expect(controller.unloadCount, 'unload never repeats within one idle period').toBe(1);
+    },
+    20_000,
+  );
+
+  it(
+    'a touch() mid-window re-arms it, and a touch() after an unload starts a fresh window that fires again',
+    async () => {
+      let calls = 0;
+      const controller = new IdleUnloadController({
+        idleUnloadMs: WINDOW_MS,
+        unload: () => {
+          calls += 1;
+        },
+      });
+      controller.touch();
+      await sleep(80);
+      controller.touch(); // use during the window resets the idle timer
+      await sleep(80); // 160 ms since the FIRST touch, but only 80 ms since the last
+      expect(controller.unloadCount, 'a re-armed window must not fire on the stale schedule').toBe(0);
+      await sleep(300);
+      expect(controller.unloadCount, 'the re-armed window fires once when IT elapses').toBe(1);
+
+      controller.touch(); // post-unload use (the reload path) re-arms a fresh window
+      await sleep(500);
+      expect(controller.unloadCount, 'a second idle period after re-arm fires again (reload-then-idle lifecycle)').toBe(2);
+      expect(calls).toBe(2);
+    },
+    20_000,
+  );
+
+  it(
+    'dispose() cancels the pending idle window; unload never fires afterwards',
+    async () => {
+      const controller = new IdleUnloadController({
+        idleUnloadMs: WINDOW_MS,
+        unload: () => {
+          throw new Error('unload must never fire after dispose');
+        },
+      });
+      controller.touch();
+      controller.dispose();
+      await sleep(400);
+      expect(controller.unloadCount, 'dispose stops the timer without firing unload').toBe(0);
+    },
+    20_000,
+  );
+
+  it(
+    'AC5 reload-latency recording: lastReloadMs starts null and records the measured value',
+    () => {
+      const controller = new IdleUnloadController({ idleUnloadMs: 60_000, unload: () => {} });
+      expect(controller.lastReloadMs, 'no reload has happened yet').toBe(null);
+      controller.recordReload(1234);
+      expect(controller.lastReloadMs).toBe(1234);
+      // The latest measurement wins.
+      controller.recordReload(5678);
+      expect(controller.lastReloadMs).toBe(5678);
+    },
+    20_000,
+  );
+});
+
+describe('b8 C4 (AC5): unload-then-reload with the REAL WorkerReranker (fixture worker, no weights)', () => {
+  it(
+    'unload disposes the runner; the documented reload path (fresh runner + first request) succeeds and its latency is recorded',
+    async () => {
+      const fixturePath = writeFixtureWorker();
+      try {
+        // Session alive: first use spawns the fixture worker lazily (real spawn).
+        const first = new WorkerReranker({ workerPath: fixturePath });
+        const before = await first.score('unload me', ['alpha', 'beta', 'gamma', 'delta']);
+        expect(before).toEqual([1, 0.75, 0.5, 0.25]);
+
+        // Idle unload fires once and disposes the runner (the frozen host
+        // contract: unload = await runner.dispose()).
+        let unloaded = false;
+        const controller = new IdleUnloadController({
+          idleUnloadMs: WINDOW_MS,
+          unload: async () => {
+            unloaded = true;
+            await first.dispose();
+          },
+        });
+        controller.touch();
+        await sleep(400);
+        expect(controller.unloadCount).toBe(1);
+        expect(unloaded, 'the unload callback ran and disposed the real runner').toBe(true);
+
+        // Reload (the frozen host contract): a FRESH runner on next use; the
+        // measured construct-to-first-answer latency is recorded (AC5).
+        const reloadStartedAt = Date.now();
+        const second = new WorkerReranker({ workerPath: fixturePath });
+        const after = await second.score('reload me', ['alpha', 'beta']);
+        const reloadMs = Date.now() - reloadStartedAt;
+
+        expect(after, 'the next request after unload succeeds through the fresh runner').toEqual([1, 0.5]);
+        expect(reloadMs, 'a real, positive reload latency was measured').toBeGreaterThan(0);
+        controller.recordReload(reloadMs);
+        expect(controller.lastReloadMs, 'the measured reload latency is recorded').toBe(reloadMs);
+
+        await second.dispose();
+      } finally {
+        cleanupFixture(fixturePath);
+      }
+    },
+    20_000,
+  );
+});

--- a/desktop/src/__tests__/b8-pressure-downgrade.test.ts
+++ b/desktop/src/__tests__/b8-pressure-downgrade.test.ts
@@ -1,0 +1,266 @@
+// b8-pressure-downgrade.test.ts — FROZEN ACCEPTANCE SPEC (issue #66 trace, AC2 + AC3 support, checks S1/S2/S6, check C2).
+//
+// NEW-SURFACE: statically imports desktop/main/backend/memory/budget.js and
+// desktop/main/backend/memory/telemetry.js, neither of which exists at the
+// base revision — the whole file fails collection with a module-not-found
+// error, which IS the acceptance evidence for the missing memory subsystem.
+//
+// FROZEN PRODUCTION CONTRACT #1 — module desktop/main/backend/memory/budget.ts:
+//
+//   export interface MemoryBudgetConfig {
+//     telemetryIntervalMs: number;   // default 5000   (memory.telemetryIntervalMs)
+//     maxTotalGb: number;            // default 16     (memory.maxTotalGb)
+//     pressureThresholdGb: number;   // default 6      (memory.pressureThresholdGb, cross-referenced
+//                                    //                 with B4 inference.profileThresholdGb)
+//     pressureSustainedMs: number;   // default 10000  (memory.pressureSustainedMs)
+//     idleUnloadMs: number;          // default 300000 (memory.idleUnloadMs)
+//   }
+//   export function resolveMemoryConfig(
+//     env?: Record<string, string | undefined>,   // default process.env
+//   ): MemoryBudgetConfig;
+//
+//   Env overrides follow the established per-subsystem pattern (explicit
+//   positive integers only; any invalid value falls back to that key's
+//   default — exactly like ingest/config.ts):
+//     TRAININGAPP_MEMORY_TELEMETRY_INTERVAL_MS
+//     TRAININGAPP_MEMORY_MAX_TOTAL_GB
+//     TRAININGAPP_MEMORY_PRESSURE_THRESHOLD_GB
+//     TRAININGAPP_MEMORY_PRESSURE_SUSTAINED_MS
+//     TRAININGAPP_MEMORY_IDLE_UNLOAD_MS
+//
+//   Downgrade decision — a PURE, synchronously testable state machine (no
+//   polling loop inside the monitor; the host feeds it samples):
+//
+//   export type MemoryComponent = 'chromium' | 'llm' | 'embeddingSession' | 'rerankerSession' | 'sqlite';
+//   export interface PressureMonitorOptions {
+//     pressureThresholdGb?: number;   // default from resolveMemoryConfig
+//     pressureSustainedMs?: number;   // default from resolveMemoryConfig
+//     recoverySustainedMs?: number;   // default: pressureSustainedMs
+//     nowMs?: () => number;           // clock seam, default Date.now
+//   }
+//   export interface PressureStatus {
+//     downgraded: boolean;            // true once sub-threshold free RAM sustained >= pressureSustainedMs
+//     effectiveProfile: 'quality' | 'fast';  // 'fast' iff downgraded (NO silent auto-upgrade)
+//     recoveryEligible: boolean;      // true once above-threshold free RAM sustained >= recoverySustainedMs
+//   }                                 //   — eligibility ONLY; the upgrade transition is host
+//                                     //   policy between generations (AC3, no thrash)
+//   export interface PressureMonitor {
+//     observe(freeBytes: number, atMs?: number): void;
+//     evaluate(atMs?: number): PressureStatus;
+//   }
+//   export function createPressureMonitor(options?: PressureMonitorOptions): PressureMonitor;
+//
+//   Semantics pinned below:
+//     - pressure boundary is INCLUSIVE like B4 selectProfile: freeBytes
+//       >= pressureThresholdGb GiB is NOT pressure; strictly below is;
+//     - a pressure streak broken by an above-threshold sample never matures;
+//     - once downgraded, effectiveProfile stays 'fast' until the host upgrades
+//       it; sustained recovery only flips recoveryEligible.
+//
+// FROZEN PRODUCTION CONTRACT #2 — module desktop/main/backend/memory/telemetry.ts:
+//
+//   export interface MemorySnapshot {   // MB fields, 1 MB = 1024 * 1024 bytes
+//     chromiumRssMb: number;
+//     llmRssMb: number;
+//     embeddingSessionRssMb: number;
+//     rerankerSessionRssMb: number;
+//     sqliteRssMb: number;
+//     systemFreeMb: number;
+//     systemTotalMb: number;
+//   }
+//   export interface MemoryTelemetryOptions {
+//     freeMemBytes?: () => number;    // default os.freemem()
+//     totalMemBytes?: () => number;   // default os.totalmem()
+//     rssProvider?: (component: MemoryComponent) => number;  // returns BYTES
+//     intervalMs?: number;            // default resolveMemoryConfig().telemetryIntervalMs
+//   }
+//   export interface MemoryTelemetry {
+//     sample(): MemorySnapshot;       // takes a fresh sample through the seams and records it
+//     snapshot(): MemorySnapshot;     // returns the latest sample WITHOUT re-sampling
+//                                     // (lazily takes one if none exists yet)
+//   }
+//   export function createMemoryTelemetry(options?: MemoryTelemetryOptions): MemoryTelemetry;
+import { describe, expect, it } from 'vitest';
+import { resolveMemoryConfig, createPressureMonitor } from '../../main/backend/memory/budget.js';
+import { createMemoryTelemetry } from '../../main/backend/memory/telemetry.js';
+
+const GIB = 1024 ** 3;
+const MIB = 1024 ** 2;
+
+const ENV = {
+  telemetryIntervalMs: 'TRAININGAPP_MEMORY_TELEMETRY_INTERVAL_MS',
+  maxTotalGb: 'TRAININGAPP_MEMORY_MAX_TOTAL_GB',
+  pressureThresholdGb: 'TRAININGAPP_MEMORY_PRESSURE_THRESHOLD_GB',
+  pressureSustainedMs: 'TRAININGAPP_MEMORY_PRESSURE_SUSTAINED_MS',
+  idleUnloadMs: 'TRAININGAPP_MEMORY_IDLE_UNLOAD_MS',
+} as const;
+
+/** Structural local types: the implementer's exports must be assignable to these. */
+interface PressureStatus {
+  downgraded: boolean;
+  effectiveProfile: string;
+  recoveryEligible: boolean;
+}
+interface PressureMonitor {
+  observe(freeBytes: number, atMs?: number): unknown;
+  evaluate(atMs?: number): PressureStatus;
+}
+interface MemorySnapshot {
+  chromiumRssMb: number;
+  llmRssMb: number;
+  embeddingSessionRssMb: number;
+  rerankerSessionRssMb: number;
+  sqliteRssMb: number;
+  systemFreeMb: number;
+  systemTotalMb: number;
+}
+interface MemoryTelemetry {
+  sample(): MemorySnapshot;
+  snapshot(): MemorySnapshot;
+}
+
+/** Monitor with short windows and explicit timestamps: pure, ~0 ms wall time. */
+function monitor(pressureSustainedMs = 200, recoverySustainedMs = 200): PressureMonitor {
+  return createPressureMonitor({ pressureThresholdGb: 6, pressureSustainedMs, recoverySustainedMs });
+}
+
+describe('b8 C2 (S2): resolveMemoryConfig defaults + env overrides', () => {
+  it('defaults are the documented 16 GB runtime budget', () => {
+    const config = resolveMemoryConfig({});
+    expect(config.telemetryIntervalMs).toBe(5000);
+    expect(config.maxTotalGb).toBe(16);
+    expect(config.pressureThresholdGb).toBe(6);
+    expect(config.pressureSustainedMs).toBe(10000);
+    expect(config.idleUnloadMs).toBe(300000);
+  });
+
+  it('explicit positive env values override; invalid values fall back to defaults', () => {
+    const overridden = resolveMemoryConfig({
+      [ENV.telemetryIntervalMs]: '1000',
+      [ENV.maxTotalGb]: '8',
+      [ENV.pressureThresholdGb]: '4',
+      [ENV.pressureSustainedMs]: '2500',
+      [ENV.idleUnloadMs]: '60000',
+    });
+    expect(overridden.telemetryIntervalMs).toBe(1000);
+    expect(overridden.maxTotalGb).toBe(8);
+    expect(overridden.pressureThresholdGb).toBe(4);
+    expect(overridden.pressureSustainedMs).toBe(2500);
+    expect(overridden.idleUnloadMs).toBe(60000);
+
+    const notANumber = resolveMemoryConfig({ [ENV.maxTotalGb]: 'not-a-number' });
+    expect(notANumber.maxTotalGb).toBe(16);
+    // Explicit positive integers only: zero is invalid and falls back.
+    const zero = resolveMemoryConfig({ [ENV.pressureSustainedMs]: '0' });
+    expect(zero.pressureSustainedMs).toBe(10000);
+  });
+});
+
+describe('b8 C2 (AC2): sustained memory pressure flips the effective profile quality -> fast', () => {
+  it('a sub-threshold free-RAM streak flips to fast only once it is SUSTAINED', () => {
+    const m = monitor(); // pressureSustainedMs = 200
+    m.observe(4 * GIB, 0); // below 6 GiB from t=0
+    expect(m.evaluate(100), '100ms of pressure (< 200ms) must not downgrade yet').toMatchObject({
+      downgraded: false,
+      effectiveProfile: 'quality',
+      recoveryEligible: false,
+    });
+    expect(m.evaluate(200), '>= 200ms of sustained pressure downgrades (AC2)').toMatchObject({
+      downgraded: true,
+      effectiveProfile: 'fast',
+      recoveryEligible: false,
+    });
+  });
+
+  it('a pressure streak broken by an above-threshold sample never matures', () => {
+    const broken = monitor();
+    broken.observe(4 * GIB, 0);
+    broken.observe(7 * GIB, 50); // streak broken long before it could mature
+    expect(broken.evaluate(400).downgraded).toBe(false);
+    expect(broken.evaluate(400).effectiveProfile).toBe('quality');
+  });
+
+  it('the pressure boundary is inclusive: exactly pressureThresholdGb GiB free is NOT pressure', () => {
+    // Cross-references B4 selectProfile: quality when freeBytes >= threshold * GIB.
+    const boundary = monitor();
+    boundary.observe(6 * GIB, 0);
+    expect(boundary.evaluate(400).downgraded).toBe(false);
+  });
+});
+
+describe('b8 C2 (AC3): recovery hysteresis — eligibility only, never a silent auto-upgrade', () => {
+  it('does NOT flip back mid-recovery-window, and sustained recovery only reports eligibility', () => {
+    const m = monitor(); // pressureSustainedMs = 200, recoverySustainedMs = 200
+    m.observe(4 * GIB, 0);
+    expect(m.evaluate(200).effectiveProfile, 'precondition: downgraded to fast').toBe('fast');
+
+    m.observe(8 * GIB, 300); // free RAM back above threshold: recovery streak starts
+    const mid = m.evaluate(400); // 100ms into recovery (< 200ms window)
+    expect(mid.effectiveProfile, 'no flip back mid-recovery-window').toBe('fast');
+    expect(mid.recoveryEligible).toBe(false);
+
+    const mature = m.evaluate(500); // 200ms into recovery (>= recoverySustainedMs)
+    expect(mature.recoveryEligible, 'sustained recovery reports upgrade eligibility').toBe(true);
+    expect(
+      mature.effectiveProfile,
+      'NO silent auto-upgrade: eligibility only — the upgrade transition is host policy between generations',
+    ).toBe('fast');
+  });
+});
+
+describe('b8 C2 (S1): MemoryTelemetry maps injectable seams onto the documented snapshot', () => {
+  it('sample() converts seam BYTES to MB (1 MB = 1024*1024) for all seven fields', () => {
+    const rssTable: Record<string, number> = {
+      chromium: 512 * MIB,
+      llm: 2 * GIB,
+      embeddingSession: 256 * MIB,
+      rerankerSession: 128 * MIB,
+      sqlite: 64 * MIB,
+    };
+    let freeCalls = 0;
+    const telemetry: MemoryTelemetry = createMemoryTelemetry({
+      freeMemBytes: () => {
+        freeCalls += 1;
+        return 2 * GIB;
+      },
+      totalMemBytes: () => 8 * GIB,
+      rssProvider: (component: string) => rssTable[component],
+    });
+
+    const snap = telemetry.sample();
+    expect(snap.systemFreeMb).toBe(2048);
+    expect(snap.systemTotalMb).toBe(8192);
+    expect(snap.chromiumRssMb).toBe(512);
+    expect(snap.llmRssMb).toBe(2048);
+    expect(snap.embeddingSessionRssMb).toBe(256);
+    expect(snap.rerankerSessionRssMb).toBe(128);
+    expect(snap.sqliteRssMb).toBe(64);
+  });
+
+  it('snapshot() returns the LATEST sample without re-sampling, and lazily samples when none exists', () => {
+    let freeCalls = 0;
+    const telemetry: MemoryTelemetry = createMemoryTelemetry({
+      freeMemBytes: () => {
+        freeCalls += 1;
+        return 2 * GIB;
+      },
+      totalMemBytes: () => 8 * GIB,
+      rssProvider: () => 0,
+    });
+
+    // Lazy: snapshot() before any sample() takes exactly one sample.
+    const first = telemetry.snapshot();
+    expect(first.systemFreeMb).toBe(2048);
+    expect(freeCalls).toBe(1);
+
+    // snapshot() afterwards returns the same latest sample with NO new sampling.
+    const again = telemetry.snapshot();
+    expect(freeCalls).toBe(1);
+    expect(again).toEqual(first);
+
+    // sample() takes a fresh one through the seams.
+    const fresh = telemetry.sample();
+    expect(freeCalls).toBe(2);
+    expect(fresh.systemFreeMb).toBe(2048);
+  });
+});

--- a/desktop/src/__tests__/b8-scheduler-serialization.test.ts
+++ b/desktop/src/__tests__/b8-scheduler-serialization.test.ts
@@ -1,0 +1,267 @@
+// b8-scheduler-serialization.test.ts — FROZEN ACCEPTANCE SPEC (issue #66 trace, AC4 / S3, check C3).
+//
+// NEW-SURFACE: statically imports desktop/main/backend/memory/scheduler.js,
+// which does not exist at the base revision — the whole file fails collection
+// with a module-not-found error, which IS the acceptance evidence for the
+// missing generation/ingestion serialization. The pipeline-seam test below
+// additionally pins HOW the pause must be wired into the EXISTING
+// desktop/main/backend/ingest/pipeline.ts (an additive optional option).
+//
+// FROZEN PRODUCTION CONTRACT #1 — module desktop/main/backend/memory/scheduler.ts:
+//
+//   export interface ConcurrencySchedulerOptions {
+//     maxConcurrentGenerations?: number;   // default 1 (concurrency.maxConcurrentGenerations, S3)
+//   }
+//   export class ConcurrencyScheduler {
+//     constructor(options?: ConcurrencySchedulerOptions);
+//     runGeneration<T>(fn: () => Promise<T>): Promise<T>;
+//       // Serialized: at most maxConcurrentGenerations fn()s execute at once;
+//       // excess generations queue FIFO (matches B4 per-engine queue semantics);
+//       // resolves with fn's value, rejects with fn's error.
+//     readonly generationInFlight: boolean;  // true while a generation executes
+//     readonly queueDepth: number;           // generations waiting to START
+//     readonly activeGenerations: number;    // currently executing (0..max)
+//     waitForGenerationEnd(): Promise<void>;
+//       // resolves the next time the scheduler has NO generation in flight
+//       // (i.e. when generationInFlight becomes false); resolves immediately
+//       // when called while idle. This is the ingestion-pause seam (S3).
+//   }
+//
+// FROZEN PRODUCTION CONTRACT #2 — additive option on the EXISTING
+// IngestPipelineOptions (desktop/main/backend/ingest/pipeline.ts):
+//
+//   coordination?: { waitForGenerationEnd(): Promise<void> };
+//     // ConcurrencyScheduler satisfies this structurally. When present, the
+//     // embed phase awaits coordination.waitForGenerationEnd() BEFORE calling
+//     // embedder.embed(...) for EVERY document (the AC4 ingestion pause).
+//
+// AC4 timestamp ordering: the embed phase of an ingest started mid-generation
+// must not BEGIN until the in-flight generation ENDS, proven by Date.now()
+// ordering (embedStarted >= generationEnded), not by implementation details.
+import { afterEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { ConcurrencyScheduler } from '../../main/backend/memory/scheduler.js';
+import { IngestPipeline } from '../../main/backend/ingest/pipeline.js';
+import { openStore, type StoreHandle } from '../../main/backend/store/sqlite-store.js';
+
+const THIS_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+/** Repo-root discovery via the established contracts marker (b4/b6 convention). */
+function findRepoRoot(dir: string): string {
+  let current = dir;
+  for (let i = 0; i < 32; i += 1) {
+    if (fs.existsSync(path.join(current, 'contracts', 'api.openapi.yaml'))) return current;
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  throw new Error('could not locate the repo root (marker contracts/api.openapi.yaml not found)');
+}
+
+const REPO_ROOT = findRepoRoot(THIS_DIR);
+const NATIVE_DEPS_PRESENT = fs.existsSync(path.join(REPO_ROOT, 'desktop', 'node_modules', 'better-sqlite3'));
+const itReal = NATIVE_DEPS_PRESENT ? it : it.skip;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function deferred<T = void>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+/** Deterministic filler: n short unique words joined by single spaces (b6 convention). */
+function words(n: number, prefix = 'w'): string {
+  return Array.from({ length: n }, (_, i) => `${prefix}${i}`).join(' ');
+}
+
+const tempDirs: string[] = [];
+const openStores: StoreHandle[] = [];
+
+afterEach(() => {
+  while (openStores.length > 0) {
+    const store = openStores.pop();
+    try {
+      store?.close();
+    } catch {
+      /* best effort */
+    }
+  }
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    try {
+      fs.rmSync(dir as string, { recursive: true, force: true });
+    } catch {
+      /* best effort */
+    }
+  }
+});
+
+describe('b8 C3 (S3): ConcurrencyScheduler generation serialization', () => {
+  it(
+    'default maxConcurrentGenerations is 1: a second generation queues FIFO with observable queueDepth',
+    async () => {
+      const scheduler = new ConcurrencyScheduler(); // no options -> default max 1
+      const events: string[] = [];
+      const held1 = deferred();
+      const held2 = deferred();
+
+      const first = scheduler.runGeneration(async () => {
+        events.push('g1-start');
+        await held1.promise;
+        events.push('g1-end');
+        return 1;
+      });
+      await sleep(50);
+      expect(scheduler.generationInFlight, 'first generation is in flight').toBe(true);
+      expect(scheduler.activeGenerations).toBe(1);
+
+      const second = scheduler.runGeneration(async () => {
+        events.push('g2-start');
+        await held2.promise;
+        events.push('g2-end');
+        return 2;
+      });
+      await sleep(50);
+      // FIFO queue: the second fn has NOT started while the first holds.
+      expect(events, 'the queued generation must not start').toEqual(['g1-start']);
+      expect(scheduler.queueDepth, 'one generation is waiting to start').toBe(1);
+      expect(scheduler.activeGenerations).toBe(1);
+
+      held1.resolve();
+      expect(await first, 'runGeneration resolves with fn value').toBe(1);
+      await sleep(50);
+      expect(events, 'the second generation starts only after the first ends').toEqual([
+        'g1-start',
+        'g1-end',
+        'g2-start',
+      ]);
+      expect(scheduler.queueDepth).toBe(0);
+
+      held2.resolve();
+      expect(await second).toBe(2);
+      expect(scheduler.generationInFlight).toBe(false);
+      expect(scheduler.activeGenerations).toBe(0);
+    },
+    20_000,
+  );
+
+  it(
+    'AC4 timestamp ordering: an ingest-style embed that awaits waitForGenerationEnd() starts only AFTER the generation ends',
+    async () => {
+      const scheduler = new ConcurrencyScheduler({ maxConcurrentGenerations: 1 });
+      const held = deferred();
+
+      let generationStartedAt = 0;
+      let generationEndedAt = 0;
+      const generation = scheduler.runGeneration(async () => {
+        generationStartedAt = Date.now();
+        await held.promise; // fake slow generation, released by a real timer below
+        generationEndedAt = Date.now();
+        return 'gen-result';
+      });
+      await sleep(50); // let the generation actually begin executing
+      expect(scheduler.generationInFlight).toBe(true);
+
+      // The ingest side starts MID-GENERATION and must block on the seam.
+      const embedRequestedAt = Date.now();
+      let embedStartedAt = 0;
+      const embed = scheduler.waitForGenerationEnd().then(() => {
+        embedStartedAt = Date.now();
+      });
+
+      await sleep(50); // still mid-generation: the embed work must not have begun
+      expect(embedStartedAt, 'embed work must not start while the generation is in flight').toBe(0);
+      expect(scheduler.generationInFlight).toBe(true);
+
+      held.resolve(); // release the held generation with a REAL event-loop tick
+      expect(await generation).toBe('gen-result');
+      await embed;
+
+      const timestamps = `timestamps ms — embedRequested=${embedRequestedAt} generationStarted=${generationStartedAt} generationEnded=${generationEndedAt} embedStarted=${embedStartedAt}`;
+      // The AC4 ordering proof: the embed phase waited for the generation.
+      expect(embedStartedAt, `embedStarted must be >= generationEnded (${timestamps})`).toBeGreaterThanOrEqual(
+        generationEndedAt,
+      );
+      expect(generationStartedAt, `generationStart must precede generationEnd (${timestamps})`).toBeLessThan(
+        generationEndedAt,
+      );
+      expect(embedRequestedAt, `the ingest request began mid-generation (${timestamps})`).toBeLessThan(
+        generationEndedAt,
+      );
+      expect(scheduler.generationInFlight).toBe(false);
+      expect(scheduler.queueDepth, 'the coordinated embed is not itself a queued generation').toBe(0);
+    },
+    20_000,
+  );
+});
+
+describe('b8 C3 (AC4): IngestPipeline embed phase awaits the coordination seam', () => {
+  itReal(
+    'an ingest started mid-generation does not call embedder.embed until the generation ends',
+    async () => {
+      const scheduler = new ConcurrencyScheduler({ maxConcurrentGenerations: 1 });
+      const held = deferred();
+      let generationStartedAt = 0;
+      let generationEndedAt = 0;
+      const generation = scheduler.runGeneration(async () => {
+        generationStartedAt = Date.now();
+        await held.promise;
+        generationEndedAt = Date.now();
+        return 'gen-result';
+      });
+      await sleep(50);
+      expect(scheduler.generationInFlight).toBe(true);
+
+      const storeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'b8-c3-store-'));
+      tempDirs.push(storeDir);
+      const store = openStore({ dbPath: path.join(storeDir, 'b8-c3.db') });
+      openStores.push(store);
+
+      let embedCalls = 0;
+      let embedStartedAt = 0;
+      const dims = store.dims;
+      const unitVector = new Array<number>(dims).fill(1 / Math.sqrt(dims));
+      const embedder = {
+        modelId: 'b8-c3-embedder',
+        embed: async (texts: string[]): Promise<number[][]> => {
+          embedCalls += 1;
+          if (embedStartedAt === 0) embedStartedAt = Date.now();
+          return texts.map(() => unitVector);
+        },
+      };
+
+      const pipeline = new IngestPipeline({
+        store,
+        embedder,
+        config: { maxConcurrentFiles: 2, chunkWordCount: 256, chunkOverlapWords: 100 },
+        coordination: scheduler, // the frozen pipeline seam: ConcurrencyScheduler satisfies it structurally
+      });
+
+      const embedRequestedAt = Date.now();
+      const ingest = pipeline.ingestFile({ name: 'b8-pause.txt', data: Buffer.from(words(300)) });
+
+      await sleep(150); // extraction + chunking complete instantly; the embed phase must be PAUSED
+      expect(embedCalls, 'the embed phase must be observably paused during the generation (AC4)').toBe(0);
+
+      held.resolve(); // release the generation; the embed phase may now proceed
+      const [ingestResult] = await Promise.all([ingest, generation]);
+
+      const timestamps = `timestamps ms — embedRequested=${embedRequestedAt} generationStarted=${generationStartedAt} generationEnded=${generationEndedAt} embedStarted=${embedStartedAt}`;
+      expect(ingestResult.success, 'the paused ingest completes after the generation').toBe(true);
+      expect(ingestResult.chunks_added, 'the embed phase really ran').toBeGreaterThan(0);
+      expect(embedCalls).toBe(1);
+      expect(embedStartedAt, `embedStarted must be >= generationEnded (${timestamps})`).toBeGreaterThanOrEqual(
+        generationEndedAt,
+      );
+    },
+    20_000,
+  );
+});

--- a/desktop/src/__tests__/b8-telemetry-route.test.ts
+++ b/desktop/src/__tests__/b8-telemetry-route.test.ts
@@ -1,0 +1,163 @@
+// b8-telemetry-route.test.ts — FROZEN ACCEPTANCE SPEC (issue #66 trace, AC7 / S7, check C1).
+//
+// Pins GET /telemetry/memory on the REAL guarded server booted exactly like
+// the b3 spec boots it (createBackendServer + createLoopbackGuard + StubEngine,
+// node mode). RED AT BASE: the route is absent from CONTRACT_ROUTES
+// (desktop/main/backend/server.ts) and from contracts/api.openapi.yaml, so the
+// guarded request answers 404 and the first assertion below fails with a
+// 404-vs-200 reason. That failure IS the acceptance evidence for the missing
+// observability surface.
+//
+// This file deliberately imports ONLY modules that already exist at the base
+// revision (server / engine / loopback-guard). It must NEVER import a
+// desktop/main/backend/memory/* module — it has to RUN (and fail with the 404
+// evidence) on the pre-fix tree.
+//
+// FROZEN ROUTE CONTRACT the implementer must add (server.ts CONTRACT_ROUTES +
+// contracts/api.openapi.yaml version bump, token-guarded like every route —
+// it reveals process memory, so NOT /health-style unauthenticated):
+//
+//   GET /telemetry/memory
+//     -> 200, content-type application/json, body:
+//     {
+//       "snapshot": {
+//         "chromiumRssMb":         number,  // >= 0, finite
+//         "llmRssMb":              number,  // >= 0, finite
+//         "embeddingSessionRssMb": number,  // >= 0, finite
+//         "rerankerSessionRssMb":  number,  // >= 0, finite
+//         "sqliteRssMb":           number,  // >= 0, finite
+//         "systemFreeMb":          number,  // >= 0, finite; systemTotalMb >= systemFreeMb
+//         "systemTotalMb":         number   // >= 0, finite
+//       },
+//       "downgrade": {
+//         "effectiveProfile": "quality" | "fast",   // B4 profile vocabulary
+//         "downgraded":       boolean
+//       }
+//     }
+//   - no transport token -> 401 (the B3 guard stays in front of the route);
+//   - a non-GET method on the known path -> 405 (route-table semantics).
+//
+// The snapshot numbers are MB (1 MB = 1024 * 1024 bytes) and come from the
+// memory/telemetry.ts MemorySnapshot (issue S1); the downgrade state comes
+// from the memory/budget.ts pressure monitor (issue S2/S6).
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import http from 'node:http';
+import { createBackendServer, listenOnRandomPort } from '../../main/backend/server.js';
+import { StubEngine } from '../../main/backend/engine.js';
+import { createLoopbackGuard } from '../../main/security/loopback-guard.js';
+
+const TOKEN = 'b8-telemetry-spec-token';
+const TOKEN_HEADER = 'x-desktop-token';
+
+let server: http.Server;
+let port = 0;
+
+function url(path: string): string {
+  return `http://127.0.0.1:${port}${path}`;
+}
+
+beforeAll(async () => {
+  // The telemetry option is an INLINE STRUCTURAL STUB (a plain provider
+  // function returning the C1 response shape; zero new imports): it decouples
+  // this file's TRANSPORT conformance pin (route exists -> 200, guard -> 401,
+  // non-GET -> 405; red at base with the exact 404-vs-200 assertion) from the
+  // PROVIDER shape, which b8-wiring.test.ts item 9 pins against the real
+  // createMemoryTelemetry. Keeping the stub inline keeps the file
+  // BASE-RUNNABLE (C1 is the only DISCRIMINATING row) and lets C9's
+  // no-telemetry 503 arm coexist: no provider wired -> 503, provider wired ->
+  // 200, regardless of who built the provider.
+  server = createBackendServer({
+    guard: createLoopbackGuard({ token: TOKEN }),
+    tokenHeaderName: 'X-Desktop-Token',
+    engine: new StubEngine(),
+    telemetry: () => ({
+      snapshot: {
+        chromiumRssMb: 0,
+        llmRssMb: 0,
+        embeddingSessionRssMb: 0,
+        rerankerSessionRssMb: 0,
+        sqliteRssMb: 0,
+        systemFreeMb: 0,
+        systemTotalMb: 0,
+      },
+      downgrade: { effectiveProfile: 'quality', downgraded: false },
+    }),
+  });
+  port = await listenOnRandomPort(server);
+}, 20_000);
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+const SNAPSHOT_NUMERIC_FIELDS = [
+  'chromiumRssMb',
+  'llmRssMb',
+  'embeddingSessionRssMb',
+  'rerankerSessionRssMb',
+  'sqliteRssMb',
+  'systemFreeMb',
+  'systemTotalMb',
+] as const;
+
+interface TelemetryMemoryBody {
+  snapshot?: Record<string, unknown>;
+  downgrade?: { effectiveProfile?: unknown; downgraded?: unknown };
+}
+
+describe('b8 C1 (AC7/S7): GET /telemetry/memory on the guarded server', () => {
+  it(
+    'answers 200 with the documented snapshot + downgrade state (RED at base: the route 404s)',
+    async () => {
+      const response = await fetch(url('/telemetry/memory'), { headers: { [TOKEN_HEADER]: TOKEN } });
+      // RED AT BASE: /telemetry/memory is not in CONTRACT_ROUTES, so this
+      // fails as "expected ... to be 200" with received 404 until S7 lands.
+      expect(response.status, 'GET /telemetry/memory must exist on the guarded contract surface').toBe(200);
+      expect(response.headers.get('content-type')).toBe('application/json');
+
+      const body = (await response.json()) as TelemetryMemoryBody;
+      expect(body, 'route body must be a JSON object').toBeTypeOf('object');
+
+      // The current snapshot under exactly one documented key: "snapshot".
+      expect(body.snapshot, 'body.snapshot must exist (the current MemorySnapshot, S1)').toBeTypeOf('object');
+      for (const field of SNAPSHOT_NUMERIC_FIELDS) {
+        const value = body.snapshot?.[field];
+        expect(value, `snapshot.${field} must be a number`).toBeTypeOf('number');
+        expect(Number.isFinite(value as number), `snapshot.${field} must be finite`).toBe(true);
+        expect(value as number, `snapshot.${field} must be non-negative`).toBeGreaterThanOrEqual(0);
+      }
+      expect(
+        body.snapshot?.systemTotalMb as number,
+        'systemTotalMb must be >= systemFreeMb',
+      ).toBeGreaterThanOrEqual(body.snapshot?.systemFreeMb as number);
+
+      // The downgrade state under exactly one documented key: "downgrade",
+      // naming the effective inference profile with B4's vocabulary.
+      expect(body.downgrade, 'body.downgrade must exist (the pressure/downgrade state, S2/S6)').toBeTypeOf('object');
+      expect(body.downgrade?.effectiveProfile, 'downgrade.effectiveProfile must be a string').toBeTypeOf('string');
+      expect(
+        ['quality', 'fast'],
+        'downgrade.effectiveProfile must be one of the B4 profile names',
+      ).toContain(body.downgrade?.effectiveProfile);
+      expect(body.downgrade?.downgraded, 'downgrade.downgraded must be a boolean').toBeTypeOf('boolean');
+    },
+    20_000,
+  );
+
+  it(
+    'stays behind the loopback guard (no token -> 401) and a non-GET method gets 405',
+    async () => {
+      // The guard runs before routing, so this half already passes at base —
+      // the route must never weaken the B3 guardrail when it is added.
+      const unauthorized = await fetch(url('/telemetry/memory'));
+      expect(unauthorized.status).toBe(401);
+      // Known path + wrong method is route-table semantics (CONTRACT_ROUTES).
+      const wrongMethod = await fetch(url('/telemetry/memory'), {
+        method: 'POST',
+        headers: { [TOKEN_HEADER]: TOKEN },
+      });
+      expect(wrongMethod.status).toBe(405);
+    },
+    20_000,
+  );
+});

--- a/desktop/src/__tests__/b8-wiring.test.ts
+++ b/desktop/src/__tests__/b8-wiring.test.ts
@@ -1,0 +1,475 @@
+// b8-wiring.test.ts — FROZEN ACCEPTANCE SPEC (issue #66 trace, host-integration layer, check C9).
+//
+// NEW-SURFACE: statically imports desktop/main/backend/memory/{budget,telemetry,
+// scheduler,idle-unload}.js — none exist at the base revision — so the whole
+// file fails collection with a module-not-found error, which IS the acceptance
+// evidence. Where a round-1 spec pinned the UNIT contracts, this file pins how
+// the HOST composes them (NodeBackendHost wiring) plus the additive engine/
+// retrieval surfaces the composition requires.
+//
+// FROZEN CONTRACTS PINNED HERE (the implementer builds to these exactly):
+//
+// 1. memory/budget.ts MUST import DEFAULT_PROFILE_THRESHOLD_GB from
+//    ../inference/profile-select.js (single source of truth, not a restated 6):
+//    resolveMemoryConfig({}).pressureThresholdGb === DEFAULT_PROFILE_THRESHOLD_GB.
+//
+// 2. MemoryBudgetConfig gains recoverySustainedMs: default 60000, env
+//    TRAININGAPP_MEMORY_RECOVERY_SUSTAINED_MS overrides (positive ints only;
+//    junk/zero fall back).
+//
+// 3. BackendServerOptions gains telemetry?: MemoryTelemetry. WITHOUT it, the
+//    route GET /telemetry/memory is a KNOWN path that answers 503 (JSON body
+//    with a non-empty `detail` string) — degraded, never 404-absent; WITH it
+//    the route answers 200 with the C1 shape. (Known-path 405 for non-GET
+//    applies either way.)
+//
+// 4. LlamaEngine additive override (the downgrade actuator):
+//      setProfileOverride(profile: 'quality' | 'fast' | null): void
+//      effectiveProfile(): 'quality' | 'fast'   // becomes PUBLIC (today private)
+//    Precedence: override > explicit inference.profile setting > auto-by-free-RAM
+//    (selectProfile semantics unchanged when the override is null, the default).
+//
+// 5. ConcurrencyScheduler observability triple — the host's upgrade predicate:
+//    (generationInFlight, queueDepth, activeGenerations) reads (true,1,1)
+//    while one generation runs and one queues, and (false,0,0) when drained.
+//
+// 6. retrieval/reranker.ts gains ResumableReranker — same options as
+//    WorkerReranker plus onReload?: (ms: number) => void:
+//      score(query, candidates): Promise<number[]>   // spawns/rebuilds transparently
+//      embed(texts): Promise<number[][]>
+//      unload(): Promise<void>      // terminates the worker WITHOUT disposing;
+//                                    // the NEXT score()/embed() rebuilds it and
+//                                    // reports the measured reload latency via
+//                                    // onReload (finite, > 0)
+//      dispose(): Promise<void>     // permanent; idempotent; safe after unload()
+//
+// 7. WorkerReranker.reportMemory(): Promise<{ rss: number; external: number;
+//    arrayBuffers: number } | null> — resolves the worker's memory numbers, or
+//    null when the worker was never started (it must NOT spawn just to ask).
+//    Wire protocol: main -> worker { kind: 'memory', jobId }
+//                   worker -> main { kind: 'memory:result', jobId,
+//                                     memory: { rss, external, arrayBuffers } }
+//
+// 8. Host downgrade wiring: createMemoryTelemetry (seams) -> sample() ->
+//    createPressureMonitor.observe(systemFreeMb MB, atMs) -> evaluate():
+//    sustained sub-threshold => { downgraded: true, effectiveProfile: 'fast' };
+//    then sustained above-threshold => recoveryEligible true while
+//    effectiveProfile STAYS 'fast' (no silent auto-upgrade; AC3 hysteresis).
+//
+// 9. createMemoryTelemetry with DEFAULT providers (no seams) still yields all
+//    seven numeric non-negative finite fields; with an rssProvider the
+//    bytes -> MB conversion is exact (bytes / 1024 / 1024).
+//
+// 10. memory/budget.ts gains the worker-pool resolver (S4 — explicit, never
+//     os.cpus()-derived):
+//       export interface WorkerPoolConfig { embeddingWorkerPoolSize: number; rerankerWorkerPoolSize: number; }
+//       export function resolveWorkerPoolConfig(env?): WorkerPoolConfig;
+//     Env: TRAININGAPP_EMBEDDING_WORKER_POOL_SIZE / TRAININGAPP_RERANKER_WORKER_POOL_SIZE
+//     (integers >= 1 only; junk/zero fall back to the default 1). The resolver
+//     is HONEST — it reports the configured value (e.g. 3); the >1 REJECTION
+//     (B7 single ORT-owner guardrail) happens at the CONSUMPTION site in the
+//     host, deliberately not in the parser.
+//
+// 11. contracts/api.openapi.yaml drift: the frozen contract doc must contain
+//     the path '/telemetry/memory:' and the schema names MemorySnapshot and
+//     DowngradeState, and must not still carry info.version 2.3.0 (A6: adding
+//     the route bumps the version).
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { resolveMemoryConfig, resolveWorkerPoolConfig, createPressureMonitor } from '../../main/backend/memory/budget.js';
+import { createMemoryTelemetry } from '../../main/backend/memory/telemetry.js';
+import { ConcurrencyScheduler } from '../../main/backend/memory/scheduler.js';
+import { IdleUnloadController } from '../../main/backend/memory/idle-unload.js';
+import { createBackendServer, listenOnRandomPort } from '../../main/backend/server.js';
+import { StubEngine } from '../../main/backend/engine.js';
+import { createLoopbackGuard } from '../../main/security/loopback-guard.js';
+import { WorkerReranker, ResumableReranker, WorkerEmbedder } from '../../main/backend/retrieval/reranker.js';
+import { DEFAULT_PROFILE_THRESHOLD_GB } from '../../main/backend/inference/profile-select.js';
+import { LlamaEngine } from '../../main/backend/inference/llama-engine.js';
+
+const GIB = 1024 ** 3;
+const MIB = 1024 ** 2;
+
+const THIS_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+/** Repo-root discovery via the established contracts marker (b4/b6 convention). */
+function findRepoRoot(dir: string): string {
+  let current = dir;
+  for (let i = 0; i < 32; i += 1) {
+    if (fs.existsSync(path.join(current, 'contracts', 'api.openapi.yaml'))) return current;
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  throw new Error('could not locate the repo root (marker contracts/api.openapi.yaml not found)');
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function deferred<T = void>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+/**
+ * Fixture worker speaking the b7 protocol for all three job kinds — rerank
+ * (immediate descending (n-i)/n scores), embed (fixed [0.25, 0.75] vector per
+ * text), and memory (fixed rss/external/arrayBuffers) — so every C9 surface is
+ * exercised with NO ONNX weights. Written to a temp dir AT RUNTIME.
+ */
+const FIXTURE_WORKER_SOURCE = [
+  "import { parentPort } from 'node:worker_threads';",
+  "parentPort.on('message', (msg) => {",
+  "  if (!msg || typeof msg.jobId !== 'number') return;",
+  "  if (msg.kind === 'rerank') {",
+  '    const scores = msg.candidates.map((_, i) => (msg.candidates.length - i) / msg.candidates.length);',
+  "    parentPort.postMessage({ kind: 'rerank:result', jobId: msg.jobId, scores });",
+  '    return;',
+  '  }',
+  "  if (msg.kind === 'embed') {",
+  '    const vectors = msg.texts.map(() => [0.25, 0.75]);',
+  "    parentPort.postMessage({ kind: 'embed:result', jobId: msg.jobId, vectors });",
+  '    return;',
+  '  }',
+  "  if (msg.kind === 'memory') {",
+  "    parentPort.postMessage({ kind: 'memory:result', jobId: msg.jobId, memory: { rss: 111, external: 222, arrayBuffers: 333 } });",
+  '  }',
+  '});',
+  '',
+].join('\n');
+
+function writeFixtureWorker(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'b8-c9-fixture-'));
+  const file = path.join(dir, 'fixture-rerank-worker.mjs');
+  fs.writeFileSync(file, FIXTURE_WORKER_SOURCE, 'utf8');
+  return file;
+}
+
+const fixtureCleanups: Array<() => void> = [];
+
+afterEach(() => {
+  while (fixtureCleanups.length > 0) {
+    const cleanup = fixtureCleanups.pop();
+    try {
+      cleanup?.();
+    } catch {
+      /* best effort */
+    }
+  }
+});
+
+describe('b8 C9: budget config cross-references (threshold + recovery window + pools)', () => {
+  it(
+    'pressureThresholdGb is B4\'s DEFAULT_PROFILE_THRESHOLD_GB (imported, not restated)',
+    () => {
+      expect(resolveMemoryConfig({}).pressureThresholdGb).toBe(DEFAULT_PROFILE_THRESHOLD_GB);
+    },
+    20_000,
+  );
+
+  it(
+    'recoverySustainedMs defaults to 60000; TRAININGAPP_MEMORY_RECOVERY_SUSTAINED_MS overrides; junk/zero fall back',
+    () => {
+      expect(resolveMemoryConfig({}).recoverySustainedMs).toBe(60000);
+      const overridden = resolveMemoryConfig({ TRAININGAPP_MEMORY_RECOVERY_SUSTAINED_MS: '1500' });
+      expect(overridden.recoverySustainedMs).toBe(1500);
+      expect(resolveMemoryConfig({ TRAININGAPP_MEMORY_RECOVERY_SUSTAINED_MS: 'junk' }).recoverySustainedMs).toBe(60000);
+      expect(resolveMemoryConfig({ TRAININGAPP_MEMORY_RECOVERY_SUSTAINED_MS: '0' }).recoverySustainedMs).toBe(60000);
+    },
+    20_000,
+  );
+
+  it(
+    'resolveWorkerPoolConfig is HONEST: explicit ints >= 1 reported, defaults 1, junk/zero -> default (rejection is host-side)',
+    () => {
+      expect(resolveWorkerPoolConfig({})).toMatchObject({ embeddingWorkerPoolSize: 1, rerankerWorkerPoolSize: 1 });
+      expect(
+        resolveWorkerPoolConfig({ TRAININGAPP_RERANKER_WORKER_POOL_SIZE: '3' }),
+        'the resolver reports the configured value; >1 rejection happens at the host consumption site',
+      ).toMatchObject({ embeddingWorkerPoolSize: 1, rerankerWorkerPoolSize: 3 });
+      expect(resolveWorkerPoolConfig({ TRAININGAPP_EMBEDDING_WORKER_POOL_SIZE: '2' })).toMatchObject({
+        embeddingWorkerPoolSize: 2,
+        rerankerWorkerPoolSize: 1,
+      });
+      expect(resolveWorkerPoolConfig({ TRAININGAPP_RERANKER_WORKER_POOL_SIZE: 'many' }).rerankerWorkerPoolSize).toBe(1);
+      expect(resolveWorkerPoolConfig({ TRAININGAPP_EMBEDDING_WORKER_POOL_SIZE: '0' }).embeddingWorkerPoolSize).toBe(1);
+    },
+    20_000,
+  );
+});
+
+describe('b8 C9: /telemetry/memory without host wiring (503 fallback) + contract doc drift', () => {
+  let server: http.Server;
+  let port = 0;
+
+  beforeAll(async () => {
+    server = createBackendServer({
+      guard: createLoopbackGuard({ token: 'b8-c9-503-token' }),
+      tokenHeaderName: 'X-Desktop-Token',
+      engine: new StubEngine(),
+      // deliberately NO telemetry option: the route degrades to 503
+    });
+    port = await listenOnRandomPort(server);
+  }, 20_000);
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it(
+    'unwired server answers 503 with a JSON detail — the route is a KNOWN path, not 404-absent',
+    async () => {
+      const response = await fetch(`http://127.0.0.1:${port}/telemetry/memory`, {
+        headers: { 'x-desktop-token': 'b8-c9-503-token' },
+      });
+      expect(response.status, 'no-telemetry-option degrades to 503 (503, never 404: the path is known)').toBe(503);
+      expect(response.headers.get('content-type')).toBe('application/json');
+      const body = (await response.json()) as { detail?: unknown };
+      expect(body.detail, 'the 503 carries a human-readable detail string').toBeTypeOf('string');
+      expect((body.detail as string).length).toBeGreaterThan(0);
+    },
+    20_000,
+  );
+
+  it(
+    "contracts/api.openapi.yaml declares the route and both schemas, and the info version is bumped",
+    () => {
+      const yaml = fs.readFileSync(path.join(findRepoRoot(THIS_DIR), 'contracts', 'api.openapi.yaml'), 'utf8');
+      expect(yaml, 'the OpenAPI spec must declare /telemetry/memory:').toContain('/telemetry/memory:');
+      expect(yaml, 'the OpenAPI spec must declare the MemorySnapshot schema').toContain('MemorySnapshot');
+      expect(yaml, 'the OpenAPI spec must declare the DowngradeState schema').toContain('DowngradeState');
+      expect(yaml, 'adding the route requires an info.version bump (was 2.3.0)').not.toContain('version: 2.3.0');
+    },
+    20_000,
+  );
+});
+
+describe('b8 C9: LlamaEngine profile override precedence (the downgrade actuator)', () => {
+  it(
+    "setProfileOverride beats an explicit inference.profile setting; null restores selectProfile semantics",
+    () => {
+      let freeBytes = 10 * GIB; // high free RAM
+      const engine = new LlamaEngine({ freeMemBytes: () => freeBytes });
+
+      // Baseline (override defaults to null): explicit 'quality' + high RAM -> quality.
+      expect(engine.applySettingsPatch({ 'inference.profile': 'quality' }).ok).toBe(true);
+      expect(engine.effectiveProfile(), 'explicit quality + high free RAM -> quality').toBe('quality');
+
+      // selectProfile semantics unchanged: 'auto' + low RAM -> fast.
+      freeBytes = 1 * GIB;
+      expect(engine.applySettingsPatch({ 'inference.profile': 'auto' }).ok).toBe(true);
+      expect(engine.effectiveProfile(), 'auto + low free RAM -> fast (B4 semantics unchanged)').toBe('fast');
+
+      // The override WINS even against an explicit setting + high free RAM.
+      freeBytes = 10 * GIB;
+      expect(engine.applySettingsPatch({ 'inference.profile': 'quality' }).ok).toBe(true);
+      engine.setProfileOverride('fast');
+      expect(engine.effectiveProfile(), "override 'fast' beats settings-applied 'quality' + high free RAM").toBe('fast');
+
+      // Clearing the override restores the pre-override answer.
+      engine.setProfileOverride(null);
+      expect(engine.effectiveProfile(), 'null override restores explicit quality + high free RAM -> quality').toBe(
+        'quality',
+      );
+    },
+    20_000,
+  );
+});
+
+describe('b8 C9: scheduler observability triple (the host upgrade predicate)', () => {
+  it(
+    'reads (inFlight=true, queueDepth=1, active=1) with one running + one queued, then (false,0,0) drained',
+    async () => {
+      const scheduler = new ConcurrencyScheduler(); // default maxConcurrentGenerations 1
+      const held1 = deferred();
+      const held2 = deferred();
+      const first = scheduler.runGeneration(() => held1.promise);
+      await sleep(50);
+      const second = scheduler.runGeneration(() => held2.promise);
+      await sleep(50);
+      expect(
+        [scheduler.generationInFlight, scheduler.queueDepth, scheduler.activeGenerations],
+        'the exact predicate the host checks before clearing a profile override',
+      ).toEqual([true, 1, 1]);
+
+      held1.resolve();
+      held2.resolve();
+      await Promise.all([first, second]);
+      expect([scheduler.generationInFlight, scheduler.queueDepth, scheduler.activeGenerations]).toEqual([false, 0, 0]);
+    },
+    20_000,
+  );
+});
+
+describe('b8 C9: ResumableReranker lifecycle (AC5 reload at the retrieval surface)', () => {
+  it(
+    'score -> unload -> score rebuilds transparently with a measured onReload latency; embed rebuilds too; dispose is idempotent after unload',
+    async () => {
+      const fixturePath = writeFixtureWorker();
+      fixtureCleanups.push(() => fs.rmSync(path.dirname(fixturePath), { recursive: true, force: true }));
+      const reloadLatencies: number[] = [];
+      const resumable = new ResumableReranker({ workerPath: fixturePath, onReload: (ms) => reloadLatencies.push(ms) });
+
+      // Session alive.
+      const before = await resumable.score('first', ['a', 'b', 'c', 'd']);
+      expect(before).toEqual([1, 0.75, 0.5, 0.25]);
+
+      // Idle unload terminates the worker without disposing the instance.
+      await resumable.unload();
+
+      // Transparent rebuild on next use + measured reload latency.
+      const afterUnload = await resumable.score('second', ['a', 'b']);
+      expect(afterUnload, 'score() works after unload (transparent rebuild)').toEqual([1, 0.5]);
+      expect(reloadLatencies.length, 'the rebuild reported its latency via onReload').toBeGreaterThanOrEqual(1);
+      expect(reloadLatencies[0], 'the reload latency is a finite positive number of ms').toBeGreaterThan(0);
+      expect(Number.isFinite(reloadLatencies[0])).toBe(true);
+
+      // embed() rebuilds after a second unload (WorkerEmbedder wraps the same surface).
+      await resumable.unload();
+      const embedder = new WorkerEmbedder(resumable, 'b8-c9-embedder');
+      const vectors = await embedder.embed(['hello']);
+      expect(vectors, 'embed() works after unload (transparent rebuild)').toEqual([[0.25, 0.75]]);
+      expect(reloadLatencies.length, 'the embed rebuild also reported its latency').toBeGreaterThanOrEqual(2);
+
+      // dispose() after unload does not throw and is idempotent.
+      await resumable.dispose();
+      await resumable.dispose();
+    },
+    20_000,
+  );
+});
+
+describe('b8 C9: WorkerReranker.reportMemory (per-worker RSS for the snapshot)', () => {
+  it(
+    "resolves null before the worker ever starts, then the worker's rss/external/arrayBuffers numbers",
+    async () => {
+      const fixturePath = writeFixtureWorker();
+      fixtureCleanups.push(() => fs.rmSync(path.dirname(fixturePath), { recursive: true, force: true }));
+      const runner = new WorkerReranker({ workerPath: fixturePath });
+
+      // Never started: reportMemory must NOT spawn a worker just to ask.
+      await expect(runner.reportMemory(), 'no worker yet -> null').resolves.toBeNull();
+
+      const scores = await runner.score('memory probe', ['a', 'b', 'c', 'd']);
+      expect(scores).toEqual([1, 0.75, 0.5, 0.25]);
+
+      const memory = await runner.reportMemory();
+      expect(memory, 'memory:result round-trips as numbers').toMatchObject({ rss: 111, external: 222, arrayBuffers: 333 });
+      expect(memory?.rss).toBeTypeOf('number');
+      expect(memory?.external).toBeTypeOf('number');
+      expect(memory?.arrayBuffers).toBeTypeOf('number');
+
+      await runner.dispose();
+    },
+    20_000,
+  );
+});
+
+describe('b8 C9: host downgrade wiring composition (telemetry -> monitor -> decision)', () => {
+  it(
+    'sustained sub-threshold samples downgrade to fast; sustained recovery reports eligibility WITHOUT auto-flipping back',
+    () => {
+      const config = resolveMemoryConfig({});
+      let freeBytes = 2 * GIB; // below the 6 GiB threshold
+      const telemetry = createMemoryTelemetry({
+        freeMemBytes: () => freeBytes,
+        totalMemBytes: () => 16 * GIB,
+        rssProvider: () => 0,
+      });
+      const monitor = createPressureMonitor({
+        pressureThresholdGb: config.pressureThresholdGb,
+        pressureSustainedMs: 200,
+        recoverySustainedMs: 200,
+      });
+
+      // The host loop (compressed): sample -> observe -> evaluate.
+      for (const t of [0, 100, 200, 300]) {
+        monitor.observe(telemetry.sample().systemFreeMb * MIB, t);
+      }
+      const downgraded = monitor.evaluate(300);
+      expect(downgraded, 'sustained sub-threshold free RAM downgrades the effective profile').toMatchObject({
+        downgraded: true,
+        effectiveProfile: 'fast',
+      });
+
+      // Recovery: free RAM back above threshold for the recovery window.
+      freeBytes = 10 * GIB;
+      for (const t of [400, 500, 600, 700]) {
+        monitor.observe(telemetry.sample().systemFreeMb * MIB, t);
+      }
+      const recovered = monitor.evaluate(700);
+      expect(recovered.recoveryEligible, 'sustained recovery reports upgrade eligibility').toBe(true);
+      expect(recovered.effectiveProfile, 'NO silent auto-upgrade — the flip is host policy between generations').toBe(
+        'fast',
+      );
+    },
+    20_000,
+  );
+
+  it(
+    'the idle-unload controller composes from the same resolved config (idleUnloadMs)',
+    () => {
+      const config = resolveMemoryConfig({});
+      const controller = new IdleUnloadController({ idleUnloadMs: config.idleUnloadMs, unload: () => {} });
+      controller.touch();
+      expect(controller.unloadCount, 'armed but not elapsed').toBe(0);
+      controller.dispose();
+      expect(controller.lastReloadMs).toBe(null);
+    },
+    20_000,
+  );
+
+  it(
+    'default telemetry providers yield all seven numeric non-negative fields; injected bytes map exactly to MB',
+    () => {
+      // Defaults (no seams at all): os.freemem/os.totalmem/process RSS paths.
+      const defaults = createMemoryTelemetry();
+      const snap = defaults.sample();
+      for (const field of [
+        'chromiumRssMb',
+        'llmRssMb',
+        'embeddingSessionRssMb',
+        'rerankerSessionRssMb',
+        'sqliteRssMb',
+        'systemFreeMb',
+        'systemTotalMb',
+      ] as const) {
+        expect(snap[field], `default snapshot.${field} is a number`).toBeTypeOf('number');
+        expect(Number.isFinite(snap[field]), `default snapshot.${field} is finite`).toBe(true);
+        expect(snap[field], `default snapshot.${field} is non-negative`).toBeGreaterThanOrEqual(0);
+      }
+
+      // Injected per-component bytes convert exactly (bytes / 1024 / 1024).
+      const table: Record<string, number> = {
+        chromium: 512 * MIB,
+        llm: 2 * GIB,
+        embeddingSession: 256 * MIB,
+        rerankerSession: 128 * MIB,
+        sqlite: 64 * MIB,
+      };
+      const injected = createMemoryTelemetry({
+        freeMemBytes: () => 2 * GIB,
+        totalMemBytes: () => 8 * GIB,
+        rssProvider: (component: string) => table[component],
+      });
+      const exact = injected.sample();
+      expect(exact.chromiumRssMb).toBe(512);
+      expect(exact.llmRssMb).toBe(2048);
+      expect(exact.embeddingSessionRssMb).toBe(256);
+      expect(exact.rerankerSessionRssMb).toBe(128);
+      expect(exact.sqliteRssMb).toBe(64);
+      expect(exact.systemFreeMb).toBe(2048);
+      expect(exact.systemTotalMb).toBe(8192);
+    },
+    20_000,
+  );
+});

--- a/desktop/test/soak/README.md
+++ b/desktop/test/soak/README.md
@@ -34,9 +34,11 @@ no CI run substitutes for it). Checklist:
    node desktop/test/soak/memory-soak.mjs --duration-s 1800 --target-free-gb 6 --report soak-16gb-i5.log
    ```
    (`--target-free-gb` ballast-allocates until free RAM is at/below the
-   target; it refuses to run on machines below `--min-total-gb` (default 12)
-   so it can never starve the target laptop itself. On a machine already at
-   ~6 GB free, omit the flag.)
+   target; on machines below `--min-total-gb` (default 12) it refuses to
+   BALLAST — logging a safety notice and continuing WITHOUT ballast — so it
+   can never starve the target laptop itself. On a machine already at
+   ~6 GB free, omit the flag. `--queries-per-cycle <n>` (default 1) controls
+   the concurrent /ask load per cycle.)
 4. While it runs: watch the telemetry lines — sustained sub-6 GiB free RAM
    must flip `profile:quality downgraded:false` to `downgraded:true` within
    ~10-20 s, and the host must keep serving ingest+query without OOM/crash.

--- a/desktop/test/soak/README.md
+++ b/desktop/test/soak/README.md
@@ -1,0 +1,67 @@
+# Desktop memory soak harness (B8, issue #66 / AC1)
+
+`memory-soak.mjs` boots the real desktop backend host (node mode — the same
+`NodeBackendHost` the Electron shell runs, including the B8 memory governance
+stack, real B4 inference when weights are staged, real B6/B7 ingest +
+retrieval) and runs a sustained ingest+query workload while sampling
+`GET /telemetry/memory` every cycle.
+
+It exits 0 when the host survived the whole workload with well-formed
+telemetry (the no-OOM/crash proof) and 1 otherwise. Whether the Quality->Fast
+downgrade TRIGGERED is reported, not asserted — triggering requires free RAM
+below `memory.pressureThresholdGb` (6 GiB) sustained for
+`memory.pressureSustainedMs` (10 s).
+
+## Reference-laptop procedure (the AC1 evidence the issue demands)
+
+The physical soak is run on the 16 GB i5 reference laptop ("needs-hardware";
+no CI run substitutes for it). Checklist:
+
+1. Machine state: 16 GB i5 laptop, AC power, lid open, no other heavy
+   applications; record the hardware tuple (CPU model, RAM, OS build,
+   inference-library version from `desktop/package.json`, ONNX Runtime
+   version, model SHA256 for both profiles via `sha256sum models/*/*/model.gguf`).
+2. Build and stage:
+   ```
+   npm --prefix desktop ci
+   npm --prefix desktop run compile
+   # stage models/gemma-4-e2b-it/ and models/lfm2.5-vl-450m/ (both profiles)
+   ```
+3. The reference laptop idles near ~8-12 GB free; to reach AC1's "~6 GB free"
+   condition, close background apps until `os.freemem()` is at/below 6 GiB,
+   or run from a machine with more headroom using the ballast flag:
+   ```
+   node desktop/test/soak/memory-soak.mjs --duration-s 1800 --target-free-gb 6 --report soak-16gb-i5.log
+   ```
+   (`--target-free-gb` ballast-allocates until free RAM is at/below the
+   target; it refuses to run on machines below `--min-total-gb` (default 12)
+   so it can never starve the target laptop itself. On a machine already at
+   ~6 GB free, omit the flag.)
+4. While it runs: watch the telemetry lines — sustained sub-6 GiB free RAM
+   must flip `profile:quality downgraded:false` to `downgraded:true` within
+   ~10-20 s, and the host must keep serving ingest+query without OOM/crash.
+5. Attach `soak-16gb-i5.log` (telemetry log + verdict JSON) to the issue and
+   mirror the final component table into `bench/RESULTS.md` +
+   `docs/adr/0008-memory-budget.md`. The soak is invalidated if B4/B7 change
+   their resource footprint (different reranker, larger KV cache) — re-run.
+
+## Quick smoke (any machine, seconds)
+
+```
+npm --prefix desktop run compile
+node desktop/test/soak/memory-soak.mjs --duration-s 20 --docs 6 --embedder hash
+```
+
+`--embedder hash` skips ONNX weights (deterministic fixture embedder) so the
+harness runs on CI-like machines; the LLM still loads if a GGUF is staged —
+add `--model-dir` pointing at an empty dir to skip native inference.
+
+## Devstation provisional runs
+
+Runs on non-reference machines (e.g. the 128 GB devstation) produce valid
+per-component RSS numbers but are NOT the AC1 evidence; record them in
+`bench/RESULTS.md` as machine-tagged provisional rows and keep the
+reference-laptop rows explicitly marked. Ballasting a 128 GB machine down to
+6 GB free is supported (`--target-free-gb 6`) and exercises the downgrade
+path, but the pressure numbers are only acceptance-grade on the reference
+hardware.

--- a/desktop/test/soak/memory-soak.mjs
+++ b/desktop/test/soak/memory-soak.mjs
@@ -1,0 +1,300 @@
+#!/usr/bin/env node
+// memory-soak.mjs — B8 soak/measurement harness (issue #66, S9 / AC1).
+//
+// Boots the REAL desktop backend host (node mode: NodeBackendHost with the
+// B8 memory governance stack, real B4 inference when weights are staged,
+// real B6/B7 ingest + retrieval otherwise) and runs a sustained
+// ingest+query workload while sampling GET /telemetry/memory every cycle.
+//
+// What it proves (exit code):
+//   0 — the host survived the whole sustained workload (no OOM/crash) and
+//       every telemetry sample had the documented shape;
+//   1 — the host crashed, an error path fired, or a sample was malformed.
+// Whether the pressure downgrade TRIGGERED is workload-dependent (it needs
+// free RAM below memory.pressureThresholdGb for memory.pressureSustainedMs)
+// and is REPORTED, not asserted — the harness reports what it observed.
+//
+// Memory constraint (AC1's "~6 GB free"): --target-free-gb ballast-allocates
+// anonymous buffers until os.freemem() is at/below the target so the
+// downgrade path can be exercised on machines with headroom. SAFETY: the
+// harness refuses to ballast when the machine's TOTAL RAM is below
+// --min-total-gb (default 12 GB), and never allocates on behalf of a machine
+// it might starve. Reference-laptop runs need no ballast at ~6 GB free.
+//
+// Usage (from the repo root; compile first):
+//   npm --prefix desktop run compile
+//   node desktop/test/soak/memory-soak.mjs [--duration-s 60] [--target-free-gb 6]
+//        [--model-dir <dir>] [--docs 12] [--queries-per-cycle 1] [--report <file>]
+//
+// Flags:
+//   --duration-s <n>        sustained workload seconds (default 60)
+//   --target-free-gb <gb>   ballast until os.freemem() <= this (0 = no ballast)
+//   --min-total-gb <gb>     refuse to ballast below this total RAM (default 12)
+//   --docs <n>              number of generated documents to ingest (default 12)
+//   --queries-per-cycle <n> concurrent /ask calls per cycle (default 1)
+//   --model-dir <dir>       TRAININGAPP_INFERENCE_MODEL_DIR override
+//   --embedder hash         force the deterministic hash embedder (no weights)
+//   --report <file>         write the telemetry log + verdict JSON here
+//
+// Reference-laptop procedure (AC1): see desktop/test/soak/README.md.
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import crypto from 'node:crypto';
+
+const REPO_ROOT = (() => {
+  let current = path.dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 32; i += 1) {
+    if (fs.existsSync(path.join(current, 'contracts', 'api.openapi.yaml'))) return current;
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  throw new Error('repo root not found (contracts/api.openapi.yaml marker missing)');
+})();
+
+function parseArgs(argv) {
+  const args = {
+    durationS: 60,
+    targetFreeGb: 0,
+    minTotalGb: 12,
+    docs: 12,
+    queriesPerCycle: 1,
+    modelDir: undefined,
+    embedderHash: false,
+    report: undefined,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const flag = argv[i];
+    const next = () => argv[++i];
+    if (flag === '--duration-s') args.durationS = Number(next());
+    else if (flag === '--target-free-gb') args.targetFreeGb = Number(next());
+    else if (flag === '--min-total-gb') args.minTotalGb = Number(next());
+    else if (flag === '--docs') args.docs = Number(next());
+    else if (flag === '--queries-per-cycle') args.queriesPerCycle = Number(next());
+    else if (flag === '--model-dir') args.modelDir = next();
+    else if (flag === '--embedder' && next() === 'hash') args.embedderHash = true;
+    else if (flag === '--report') args.report = next();
+    else throw new Error(`unknown flag: ${flag}`);
+  }
+  return args;
+}
+
+const logLines = [];
+function log(line) {
+  const stamped = `${new Date().toISOString()} ${line}`;
+  console.log(stamped);
+  logLines.push(stamped);
+}
+
+const GIB = 1024 ** 3;
+const ballast = [];
+
+function applyBallast(targetFreeBytes) {
+  let guard = 0;
+  while (os.freemem() > targetFreeBytes && guard < 4096) {
+    guard += 1;
+    // 256 MiB chunks: anonymous, untouched (never written) — the OS counts
+    // them against free RAM only as they are committed by touch-free
+    // reservation on Windows; write one byte per chunk to force commit.
+    const chunk = Buffer.alloc(256 * 1024 * 1024);
+    chunk[0] = 1;
+    ballast.push(chunk);
+    if (os.freemem() <= targetFreeBytes) break;
+  }
+  log(`ballast: ${ballast.length} chunks, free now ${(os.freemem() / GIB).toFixed(2)} GiB`);
+}
+
+function request(port, token, method, apiPath, body) {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        host: '127.0.0.1',
+        port,
+        path: apiPath,
+        method,
+        headers: {
+          'X-Desktop-Token': token,
+          ...(body !== undefined ? { 'content-type': 'application/json' } : {}),
+        },
+      },
+      (res) => {
+        let data = '';
+        res.on('data', (c) => (data += c));
+        res.on('end', () => resolve({ status: res.statusCode, body: data }));
+      },
+    );
+    req.on('error', reject);
+    req.setTimeout(300_000, () => {
+      req.destroy(new Error('request timed out after 300s'));
+    });
+    if (body !== undefined) req.write(JSON.stringify(body));
+    req.end();
+  });
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  log(`soak start: duration=${args.durationS}s docs=${args.docs} queriesPerCycle=${args.queriesPerCycle} targetFreeGb=${args.targetFreeGb}`);
+
+  // ---- memory constraint (AC1) ------------------------------------------
+  const totalGb = os.totalmem() / GIB;
+  if (args.targetFreeGb > 0) {
+    if (totalGb < args.minTotalGb) {
+      log(`SAFETY: total RAM ${totalGb.toFixed(1)} GB < min-total-gb ${args.minTotalGb}; refusing to ballast`);
+    } else {
+      applyBallast(args.targetFreeGb * GIB);
+    }
+  }
+
+  // ---- real host (node mode) --------------------------------------------
+  // Windows: absolute-path dynamic imports must be file:// URLs.
+  const dist = path.join(REPO_ROOT, 'desktop', 'dist', 'main', 'backend');
+  const { createBackendHost, resolveNodeEngine } = await import(
+    pathToFileURL(path.join(dist, 'index.js')).href
+  );
+
+  const token = crypto.randomBytes(24).toString('hex');
+  const storeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'b8-soak-store-'));
+  const events = [];
+  const env = { ...process.env };
+  if (args.embedderHash) env.TRAININGAPP_DESKTOP_EMBEDDER = 'hash';
+  if (args.modelDir !== undefined) env.TRAININGAPP_INFERENCE_MODEL_DIR = args.modelDir;
+
+  const host = createBackendHost({
+    token,
+    tokenHeaderName: 'X-Desktop-Token',
+    allowedOrigins: ['app://*'],
+    mode: 'node',
+    env,
+    engine: resolveNodeEngine(env),
+    storePath: path.join(storeDir, 'store.sqlite'),
+    onIngestProgress: () => {},
+    onMemoryEvent: (event) => {
+      events.push(event);
+      log(`memory event: ${JSON.stringify(event)}`);
+    },
+  });
+  const handle = await host.start();
+  log(`host up: mode=${handle.mode} port=${handle.port} (free RAM at boot ${(os.freemem() / GIB).toFixed(2)} GiB)`);
+
+  // Generated corpus: unique per-run content (content-hash identity would
+  // dedupe identical docs) with enough text for many chunks per doc.
+  const docsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'b8-soak-docs-'));
+  for (let d = 0; d < args.docs; d += 1) {
+    const words = [];
+    for (let w = 0; w < 4000; w += 1) {
+      words.push(`${crypto.randomBytes(4).toString('hex')}`);
+    }
+    fs.writeFileSync(path.join(docsDir, `soak-doc-${d}.txt`), words.join(' '), 'utf8');
+  }
+
+  let sawDowngrade = false;
+  let cycles = 0;
+  let errors = 0;
+  const startedAt = Date.now();
+  const deadline = startedAt + args.durationS * 1000;
+  let docIndex = 0;
+
+  try {
+    while (Date.now() < deadline) {
+      cycles += 1;
+      // Ingest: one fresh directory pass per few cycles (new content each
+      // pass keeps the embed-heavy work real instead of a dedupe no-op).
+      if (cycles % 3 === 1 && docIndex < args.docs * 2) {
+        const passDir = path.join(docsDir, `pass-${docIndex}`);
+        fs.mkdirSync(passDir, { recursive: true });
+        for (let k = 0; k < Math.min(4, args.docs); k += 1) {
+          const words = [];
+          for (let w = 0; w < 3000; w += 1) words.push(crypto.randomBytes(4).toString('hex'));
+          fs.writeFileSync(path.join(passDir, `doc-${docIndex}-${k}.txt`), words.join(' '), 'utf8');
+        }
+        docIndex += 1;
+        const ingestStart = Date.now();
+        const ingest = await request(handle.port, token, 'POST', '/ingest', { directory: passDir });
+        log(`cycle ${cycles}: ingest pass-${docIndex - 1} -> ${ingest.status} (${Date.now() - ingestStart} ms)`);
+        if (ingest.status !== 200) errors += 1;
+      }
+
+      // Queries: sustained generation load alongside ingestion.
+      const queryStart = Date.now();
+      const queries = Array.from({ length: args.queriesPerCycle }, (_, q) =>
+        request(handle.port, token, 'POST', '/ask', { question: `soak cycle ${cycles} query ${q}: summarize the ingested documents` })
+          .then((r) => {
+            if (r.status !== 200) log(`cycle ${cycles}: /ask -> ${r.status}: ${r.body.slice(0, 140)}`);
+            return r.status;
+          })
+          .catch((err) => {
+            errors += 1;
+            log(`cycle ${cycles}: /ask error: ${err.message}`);
+            return 0;
+          }),
+      );
+      await Promise.all(queries);
+      log(`cycle ${cycles}: queries done (${Date.now() - queryStart} ms)`);
+
+      // Telemetry sample: shape-assert every snapshot (the AC1 "no OOM +
+      // documented telemetry shape" evidence).
+      const telemetry = await request(handle.port, token, 'GET', '/telemetry/memory');
+      if (telemetry.status !== 200) {
+        errors += 1;
+        log(`cycle ${cycles}: TELEMETRY ERROR ${telemetry.status}`);
+      } else {
+        const body = JSON.parse(telemetry.body);
+        const s = body.snapshot ?? {};
+        const fields = [
+          'chromiumRssMb', 'llmRssMb', 'embeddingSessionRssMb',
+          'rerankerSessionRssMb', 'sqliteRssMb', 'systemFreeMb', 'systemTotalMb',
+        ];
+        const malformed = fields.some((f) => typeof s[f] !== 'number' || !Number.isFinite(s[f]) || s[f] < 0);
+        if (malformed || typeof body.downgrade?.downgraded !== 'boolean') {
+          errors += 1;
+          log(`cycle ${cycles}: MALFORMED TELEMETRY ${telemetry.body.slice(0, 200)}`);
+        } else {
+          log(
+            `cycle ${cycles}: telemetry rss {chromium:${s.chromiumRssMb.toFixed(0)} llm:${s.llmRssMb.toFixed(0)} ` +
+              `embed:${s.embeddingSessionRssMb.toFixed(1)} rerank:${s.rerankerSessionRssMb.toFixed(1)} ` +
+              `sqlite:${s.sqliteRssMb.toFixed(1)}} free:${s.systemFreeMb.toFixed(0)}MB ` +
+              `total:${s.systemTotalMb.toFixed(0)}MB profile:${body.downgrade.effectiveProfile} downgraded:${body.downgrade.downgraded}`,
+          );
+          if (body.downgrade.downgraded) sawDowngrade = true;
+        }
+      }
+    }
+  } finally {
+    const finalTelemetry = await request(handle.port, token, 'GET', '/telemetry/memory').catch(() => null);
+    if (finalTelemetry?.status === 200) {
+      log(`final telemetry: ${finalTelemetry.body}`);
+    }
+    await host.stop().catch((err) => log(`host.stop error: ${err.message}`));
+  }
+
+  const verdict = {
+    cycles,
+    errors,
+    sawDowngrade,
+    survived: errors === 0,
+    durationS: args.durationS,
+    freeRssAtEndMb: (os.freemem() / (1024 * 1024)).toFixed(0),
+    events,
+    machine: {
+      cpu: os.cpus()[0]?.model ?? 'unknown',
+      cores: os.cpus().length,
+      totalRamGb: +(os.totalmem() / GIB).toFixed(1),
+      platform: `${os.platform()} ${os.release()}`,
+    },
+  };
+  log(`soak end: cycles=${cycles} errors=${errors} sawDowngrade=${sawDowngrade} -> ${errors === 0 ? 'PASS' : 'FAIL'}`);
+  if (args.report !== undefined) {
+    fs.writeFileSync(args.report, `${logLines.join('\n')}\n\n${JSON.stringify(verdict, null, 2)}\n`, 'utf8');
+    log(`report written: ${args.report}`);
+  }
+  process.exitCode = errors === 0 ? 0 : 1;
+}
+
+main().catch((err) => {
+  log(`FATAL: ${err instanceof Error ? err.stack : String(err)}`);
+  process.exitCode = 1;
+});

--- a/docs/adr/0008-memory-budget.md
+++ b/docs/adr/0008-memory-budget.md
@@ -39,7 +39,7 @@ Electron has `os.freemem()`/`os.totalmem()`.
 | Component | Source | Semantics |
 |---|---|---|
 | `chromiumRssMb` | `process.memoryUsage().rss` (main) | Whole main-process RSS, INCLUDING the native heaps (llama.cpp mmap, main-thread ORT when the hash fixture is used, better-sqlite3). |
-| `llmRssMb` | baseline-relative delta | Main-RSS now minus main-RSS at host start; dominated by the resident llama model. 0 while no model is resident. Deliberately conservative: it is an increment, not a private counter (Node shares one process). |
+| `llmRssMb` | baseline-relative delta | Main-RSS now minus main-RSS at host start; dominated by the resident llama model once loaded. It is a delta of ALL post-start growth (not gated on model residency — treat it as an increment subsumed in `chromiumRssMb`, never a separate budget line), and reads 0 before any post-start growth. |
 | `embeddingSessionRssMb` / `rerankerSessionRssMb` | worker `process.memoryUsage()` (`external`+`arrayBuffers`) | Thread-local ONNX footprint from the single retrieval worker (B7 owns ALL ORT work on one thread). 0 while the worker is unloaded/absent. |
 | `sqliteRssMb` | better-sqlite3 `memoryUsed()` | The driver's own heap counter. 0 when no store is open. |
 
@@ -77,7 +77,11 @@ per-worker ORT isolation AND duplicated model memory — rejected until a future
 - **Recovery / no silent auto-upgrade:** after the downgrade, sustained above-threshold free RAM
   for `recoverySustainedMs` latches `recoveryEligible` (event `recovery-eligible` fires once). The
   override clears ONLY at a sampler tick where the scheduler is fully drained
-  (`generationInFlight === false && queueDepth === 0 && activeGenerations === 0`). Bounded
+  (`generationInFlight === false && queueDepth === 0 && activeGenerations === 0`). At that upgrade
+  the host ACKNOWLEDGES the monitor (`resetAfterUpgrade()`), which clears the monitor's downgrade
+  latch so the next downgrade requires a NEW sustained pressure episode — without the ack, the
+  never-reset latch re-latched 'fast' on the next tick (fast/quality oscillation + event spam;
+  PR-review finding PRR-F1, pinned by b8-host-loop.test.ts). Bounded
   staleness: at most one telemetry interval past predicate satisfaction. Rationale: flipping the
   resident model mid-session under oscillating pressure thrashes the resident sequence and KV
   cache; a drained-transition makes the flip atomic with respect to generation work.

--- a/docs/adr/0008-memory-budget.md
+++ b/docs/adr/0008-memory-budget.md
@@ -1,0 +1,110 @@
+# ADR-0008: Runtime memory budget, concurrency governance, and idle-session unloading
+
+- **Status:** Accepted (implementation in progress on issue #66, B8)
+- **Date:** 2026-09-10
+- **Deciders:** Workstream B (desktop backend), issue #66
+- **Supersedes:** none · **Related:** ADR-0005 (store), ADR-0006 (profile model), ADR-0007 (relevance floor)
+
+## Context
+
+The v3 hardware floor is a 12th-gen i5 with 16 GB RAM (`.swarm/spec-snapshot.md`). Before this ADR,
+no measured, enforced peak-RAM budget existed for the whole running system (Chromium + resident LLM
+weights/KV + embedding/reranker ONNX sessions + worker pools + SQLite). Each component carried its
+own siloed story: B4 picked Quality/Fast per query from a single `os.freemem()` reading, B7's
+retrieval worker lived until app exit, and B6 ingestion ran regardless of in-flight generations.
+The browser surface's `navigator.deviceMemory` heuristics are memory-blind by construction (they
+report total device RAM capped at 8 GB, never free RAM) and are explicitly NOT imported here —
+Electron has `os.freemem()`/`os.totalmem()`.
+
+## Decision
+
+### 1. Budget and telemetry (`desktop/main/backend/memory/`)
+
+- `memory.maxTotalGb` defaults to **16** (`TRAININGAPP_MEMORY_MAX_TOTAL_GB`); it is the accounting
+  ceiling the component table (below) must sum under with headroom.
+- `memory.pressureThresholdGb` defaults to **6** — the SAME constant as B4's
+  `inference.profileThresholdGb` (`DEFAULT_PROFILE_THRESHOLD_GB`, imported, not restated; pinned by
+  b8-wiring C9 so the two knobs cannot drift).
+- `memory.telemetryIntervalMs` (5000) drives the host sampler;
+  `memory.pressureSustainedMs` (10000), `memory.recoverySustainedMs` (60000) and
+  `memory.idleUnloadMs` (300000) are the hysteresis/idle windows. All are env-overridable with
+  strict positive-integer parsing (junk/zero fall back to defaults).
+- `GET /telemetry/memory` returns `{ snapshot: MemorySnapshot, downgrade: DowngradeState }`
+  (`contracts/api.openapi.yaml` v2.4.0). It is transport-token-guarded like every route (it reveals
+  process memory; never `/health`-style unauthenticated). A host without a telemetry provider
+  answers a contract-safe 503 — the path is known, never 404-absent.
+
+### 2. Component attribution semantics (in-process Node backend; ADR-0003 still open)
+
+| Component | Source | Semantics |
+|---|---|---|
+| `chromiumRssMb` | `process.memoryUsage().rss` (main) | Whole main-process RSS, INCLUDING the native heaps (llama.cpp mmap, main-thread ORT when the hash fixture is used, better-sqlite3). |
+| `llmRssMb` | baseline-relative delta | Main-RSS now minus main-RSS at host start; dominated by the resident llama model. 0 while no model is resident. Deliberately conservative: it is an increment, not a private counter (Node shares one process). |
+| `embeddingSessionRssMb` / `rerankerSessionRssMb` | worker `process.memoryUsage()` (`external`+`arrayBuffers`) | Thread-local ONNX footprint from the single retrieval worker (B7 owns ALL ORT work on one thread). 0 while the worker is unloaded/absent. |
+| `sqliteRssMb` | better-sqlite3 `memoryUsed()` | The driver's own heap counter. 0 when no store is open. |
+
+These are honest-but-approximate per-component attributions inside one process; the measured-sum
+evidence (AC6) therefore comes from the soak harness's process-level samples plus the reference
+bench rows, not from summing the snapshot fields alone.
+
+### 3. Concurrency governance (`memory/scheduler.ts`)
+
+- `concurrency.maxConcurrentGenerations` defaults to **1**: `/ask` and `/ask/stream` execute under
+  a FIFO mutex in the transport (`server.ts`), engine-independent (it holds for the CI StubEngine
+  too, which B4's per-engine private queue never covered). Excess generations queue; they never
+  503.
+- The `/ask/stream` preflight runs OUTSIDE the mutex — a missing-model 503 must never queue behind
+  an in-flight generation.
+- Ingestion pause: the B6 embed phase awaits `scheduler.waitForGenerationEnd()` before every embed
+  call (`IngestPipelineOptions.coordination`). Extract/chunk/write phases are unaffected; only
+  embed-heavy work yields to generation.
+
+### 4. Worker pools (S4)
+
+`embedding.workerPoolSize` and `reranker.workerPoolSize` are explicit configuration
+(`TRAININGAPP_{EMBEDDING,RERANKER}_WORKER_POOL_SIZE`, default **1**, never `os.cpus()`-derived).
+The parser is honest (it reports 3 if you configure 3); the CONSUMPTION site rejects >1: B7's
+empirical probe (backend start block; trace repro/mix-probe.mjs) showed onnxruntime-node aborts the
+whole process when one module instance is used from two threads, so a >1 reranker pool would need
+per-worker ORT isolation AND duplicated model memory — rejected until a future issue proves it.
+
+### 5. Downgrade and recovery (AC2/AC3 — the documented decision)
+
+- **Downgrade:** when free RAM stays strictly below `pressureThresholdGb` for
+  `pressureSustainedMs`, the host latches `engine.setProfileOverride('fast')` (the user's
+  `inference.profile` setting is NEVER mutated), logs the observed free-RAM value, and emits
+  `memory:event {type:'downgrade'}` to the renderer.
+- **Recovery / no silent auto-upgrade:** after the downgrade, sustained above-threshold free RAM
+  for `recoverySustainedMs` latches `recoveryEligible` (event `recovery-eligible` fires once). The
+  override clears ONLY at a sampler tick where the scheduler is fully drained
+  (`generationInFlight === false && queueDepth === 0 && activeGenerations === 0`). Bounded
+  staleness: at most one telemetry interval past predicate satisfaction. Rationale: flipping the
+  resident model mid-session under oscillating pressure thrashes the resident sequence and KV
+  cache; a drained-transition makes the flip atomic with respect to generation work.
+- Monitor hysteresis is a pure state machine (no timer inside the monitor); a return to pressure
+  revokes eligibility.
+
+### 6. Idle-session unloading (AC5)
+
+- `memory.idleUnloadMs` (300000): the retrieval worker (the single ONNX owner) is terminated after
+  the idle window with no rerank/embed/ingest-embed use; the NEXT request transparently rebuilds
+  it, and the measured construct-to-first-answer reload latency is recorded
+  (`IdleUnloadController.recordReload`) and reported via `onReload`.
+- The resident LLM is deliberately NOT unloaded on idle: B4's resident-model contract (load once,
+  reuse across requests) is the latency story of the product; S5 scopes idle-unload to the
+  embedding/reranker ONNX sessions.
+
+## Measured component budget (devstation, provisional)
+
+Measured 2026-09-11 via `desktop/test/soak/memory-soak.mjs` on the devstation (not the reference
+laptop — see `bench/RESULTS.md` "Desktop runtime memory (B8)"): values and the sum-vs-ceiling
+statement live there. Reference-laptop rows are **PENDING** the physical soak (AC1 waiver decision
+recorded in the issue-trace/PR); re-run and update this table if B4/B7 change their footprint.
+
+## Consequences
+
+- The renderer (B9) gains `memory:event` and `GET /telemetry/memory` for a live memory UI.
+- First-run validation (#85) and the low-RAM matrix (#86) consume the same thresholds.
+- A sidecar-mode host forwards `/telemetry/memory` to the child transparently; if ADR-0003 ever
+  selects a Python sidecar, its PID's RSS joins the snapshot through the documented provider seam.
+- Rollback: revert the PR; no schema or data migration.

--- a/tests/test_api_memory_telemetry_route.py
+++ b/tests/test_api_memory_telemetry_route.py
@@ -1,0 +1,55 @@
+"""
+Regression tests for the /telemetry/memory route on the Python API surface
+(issue #66, B8 CI round).
+
+The B8 telemetry subsystem lives on the Electron/Node desktop surface
+(desktop/main/backend/memory/). The shared contract (contracts/api.openapi.yaml
+v2.4.0) declares GET /telemetry/memory, so the Python host must declare the
+path too — but it never wires telemetry, so the route answers the documented
+unwired 503 forever. The contract-drift check
+(contracts/tests/run_conformance.py --asgi api_server:app) pins path-set
+equality; these tests pin the behavior.
+
+Tests:
+1. The route answers 503 (a KNOWN path — never 404-absent) with a JSON
+   {"detail": ...} body, matching the desktop unwired semantics.
+2. The app's OpenAPI schema declares the path (drift-guard at the unit level).
+3. The path requires auth like every other route (401 without credentials
+   when auth is enabled is the guard's domain; with auth disabled the route
+   is reachable and must still 503 — the 503 must never leak before the
+   guard).
+"""
+
+from fastapi.testclient import TestClient
+
+from api_server import app
+
+client = TestClient(app)
+
+
+class TestMemoryTelemetryRoute:
+    """The Python surface declares /telemetry/memory and answers the
+    documented unwired 503 (issue #66 CI round)."""
+
+    def test_route_answers_documented_unwired_503(self):
+        response = client.get("/telemetry/memory")
+        assert response.status_code == 503, (
+            "GET /telemetry/memory must answer the documented unwired 503 "
+            f"(known path, never 404); got {response.status_code}"
+        )
+        body = response.json()
+        assert isinstance(body.get("detail"), str) and len(body["detail"]) > 0
+
+    def test_route_declared_in_openapi_schema(self):
+        schema = app.openapi()
+        assert "/telemetry/memory" in schema.get("paths", {}), (
+            "the app's OpenAPI schema must declare /telemetry/memory so the "
+            "shared contract drift check stays green"
+        )
+        assert "get" in schema["paths"]["/telemetry/memory"]
+
+    def test_wrong_method_is_405_not_404(self):
+        response = client.post("/telemetry/memory")
+        assert (
+            response.status_code == 405
+        ), "a known path with a wrong method must 405 (route-table semantics)"


### PR DESCRIPTION
Closes #66

## Root Cause

No measured, enforced runtime memory or concurrency budget existed on the desktop surface: zero uses of `process.memoryUsage().rss`/`os.totalmem()` in `desktop/main|preload`, no `/telemetry` path in the contract route table (`desktop/main/backend/server.ts:40-53`) or `contracts/api.openapi.yaml`, a fire-and-complete ingest pipeline (`ingest/pipeline.ts`) with no coupling to in-flight generations, a retrieval worker that lived until app exit (`retrieval/reranker.ts`), and the only free-RAM signal consumed by per-query profile selection (`inference/llama-engine.ts:281,303`). The 16 GB v3 hardware floor (`.swarm/spec-snapshot.md:5`) was unmeasured and unenforced. Full analysis: `.agents/issue-traces/66-enforce-16gb-runtime-memory-concurrency-budget/` (04-root-cause.md).

## Fix

New cross-component governance subsystem wired at the host (`desktop/main/backend/index.ts`), per the approved plan (07-approved-plan.md):

- `memory/budget.ts` — `resolveMemoryConfig` (`memory.telemetryIntervalMs` 5000, `memory.maxTotalGb` 16, `memory.pressureThresholdGb` 6 **imported from B4's `DEFAULT_PROFILE_THRESHOLD_GB` so the knobs cannot drift**, sustained 10000 ms, recovery 60000 ms, idle-unload 300000 ms; env overrides with strict positive-int fallback), the pure hysteresis `PressureMonitor` (inclusive boundary, latch, eligibility-only recovery), and explicit `concurrency`/worker-pool resolvers (never `os.cpus()`-derived).
- `memory/telemetry.ts` — `MemorySnapshot` (chromium/llm/embedding/reranker/sqlite MB + system free/total) with injectable seams; unmeasurable components degrade to 0.
- `memory/scheduler.ts` — `ConcurrencyScheduler`: FIFO generation mutex (`concurrency.maxConcurrentGenerations` default 1; excess queue, never 503), observability triple, `waitForGenerationEnd()` pause seam.
- `memory/idle-unload.ts` — `IdleUnloadController` (touch-re-arm, one unload per window, reload-latency recording).
- `server.ts` — 13th contract route `GET /telemetry/memory` (token-guarded; 503 with JSON detail when unwired, never 404; 405 semantics) + `/ask`//`ask/stream` wrapped in the scheduler (stream preflight stays OUTSIDE the mutex so a missing model still 503s immediately).
- `ingest/pipeline.ts` + `store/document-surface.ts` — additive `coordination` seam: the embed phase awaits the generation end before every embed (AC4).
- `retrieval/reranker.ts` + `rerank-worker.ts` — `ResumableReranker` (idle unload terminates the worker; next use transparently rebuilds and records measured reload latency), worker memory reporting (`memory` -> `memory:result` protocol), `WorkerEmbedder` widened structurally.
- `inference/llama-engine.ts` — additive `setProfileOverride()` consulted before B4's `selectProfile`; the user's `inference.profile` setting is never mutated.
- Host wiring — sampler tick (`memory.telemetryIntervalMs`), downgrade latch (`setProfileOverride('fast')` + logged free-RAM value + `onMemoryEvent`), recovery eligibility event, override cleared ONLY at a tick where the scheduler is fully drained (AC3: no silent auto-upgrade; bounded staleness one interval), pool-size >1 rejected with a logged `memory:event` (B7 single-thread ORT ownership), full teardown in `stop()`.
- `desktop/main/index.ts` — `memory:event` IPC channel to the renderer (B9 consumes).
- `contracts/api.openapi.yaml` 2.3.0 -> **2.4.0** — `/telemetry/memory` + `MemorySnapshot`/`DowngradeState`/`TelemetryMemoryResponse`.
- `docs/adr/0008-memory-budget.md` (the issue's ADR-0007 slot was taken by ADR-0007-relevance-floor; next free number used), `desktop/test/soak/memory-soak.mjs` + README (AC1 reference-laptop harness + procedure), `bench/RESULTS.md` B8 section, `desktop/README.md` config/route docs.

## Recurrence Prevention (defect class)

- Defect class: memory/concurrency knobs sized from local heuristics or restated constants, without cross-component measurement or a single source of truth.
- Sweep result: 5 predicates (threshold constant, `os.cpus()`, browser `deviceMemory` heuristics, freemem/totalmem/memoryUsage consumers, pool-size knobs), 7 consolidated hits, all dispositioned (2 FIX = the new measurement layer, 4 OUT_OF_CLASS with evidence, 1 FALSE_POSITIVE) — `08a-recurrence-sweep.md`.
- Guardrail: CI pins — C9 asserts `resolveMemoryConfig({}).pressureThresholdGb === DEFAULT_PROFILE_THRESHOLD_GB` (import-not-restate) and C2 pins the absolute value; demonstrated to bite by mutating the shared constant 6 -> 7 (C2 spec RED) and restoring (GREEN). Lint/type-level rungs infeasible (no desktop TS lint surface; types cannot pin cross-module value equality) — recorded in 08a.

## Tests

- Regression test: `cd desktop && node node_modules/vitest/vitest.mjs run` -> PASS (49 files / 327 tests).
- Impacted suite: full suite re-run via `repro-check.sh run` C8 PRESERVING — base GREEN -> head GREEN.
- Lint/type/build/security checks: `npm --prefix desktop run compile` (tsc both tsconfigs) -> PASS; `node desktop/scripts/run-conformance-host.mjs` -> `CONFORMANCE: PASS 10/10 checks passed, 2 skipped` (log: repro/conformance.log); no new dependencies (node builtins only); the new route asserts 401 without a token (C1).
- Deferred-work scan: `scan-deferred.sh` -> `scan-deferred: clean (base=origin/master)`.

## Regression Protection

- Five new frozen acceptance specs (`desktop/src/__tests__/b8-*.test.ts`), authored by an independent check-author context, frozen at a red checkpoint (`repro-check.sh checkpoint`, 6 manifest rows incl. one sanctioned C1 AMEND/CHECK_WRONG), all flipped RED/ERROR -> GREEN at head and independently re-run by the implementation reviewer and final critic.
- Mutation probes: 4 implementer probes (budget boundary, scheduler max, idle re-arm, reranker rebuild) + 1 independent reviewer probe (idle re-arm) — every mutation sent its spec RED, restored GREEN; C1's base run IS the revert probe (RED at 7264c36 for the 404-vs-200 reason).
- Test drift review: `git diff 7264c36..HEAD --stat -- desktop/src/__tests__` shows only the five new b8 files; no pre-existing spec touched (C8 GREEN at both ends).

## Acceptance Criteria -> Evidence

| Acceptance criterion (from intake) | Evidence (command + output, or test name) |
|---|---|
| AC1 soak at ~6 GB free, no OOM (reference laptop) | Harness + procedure shipped (`desktop/test/soak/memory-soak.mjs`, README); devstation runs PASS (7667 cycles / 0 errors; 5 cycles / 0 errors with native inference; logs `repro/soak-devstation*.log`); **reference-laptop run PENDING hardware** (see Waivers) |
| AC2 downgrade triggers + renderer event | C2 GREEN (`b8-pressure-downgrade.test.ts`) + C9 override precedence; `memory:event` forward in `desktop/main/index.ts` |
| AC3 downgrade recovery behavior stated | `docs/adr/0008-memory-budget.md` §5 (no silent auto-upgrade; drained-tick predicate; bounded staleness); hysteresis pinned by C2 |
| AC4 generation/ingestion serialization, timestamp ordering | C3 GREEN (`b8-scheduler-serialization.test.ts`, scheduler + real IngestPipeline levels) |
| AC5 idle unload + measured reload latency | C4 GREEN (`b8-idle-unload.test.ts`, real fixture-worker reload, `lastReloadMs` recorded) |
| AC6 component RSS accounting under 16 GB | `bench/RESULTS.md` "Desktop runtime memory (B8)" — devstation provisional rows measured + anomaly note; **reference-i5 sum PENDING hardware** (see Waivers) |
| AC7 telemetry route + test | C1 GREEN (`b8-telemetry-route.test.ts`: 200 shape, 401, 405) + C9 503-no-provider arm + OpenAPI drift pin |

## Invariant Audit

The repo has no single invariant doc; the frozen contracts audited (per docs/security/desktop.md, contracts/, and the prior-issue specs):

- B2 loopback guard in front of EVERY route: not touched — C1 asserts 401 without token on the new route; guard call site unchanged (`server.ts` single guard before routing).
- B3 host prototype pin (start/stop only): not touched — new members are instance fields; `b3-backend-selector.test.ts` passes 3/3.
- B4 resident-model + per-engine queue + cancellation: not touched (additive `setProfileOverride` consulted before `selectProfile`); b4 suite GREEN.
- B5 store schema/recovery: not touched (no schema change).
- B6 content-hash identity, single-writer queue, write rules: not touched (additive coordination seam only); b6 suite GREEN.
- B7 single-thread ORT ownership: STRENGTHENED — idle unload/resumable rebuild keeps all ORT work on the one worker; pool-size >1 explicitly rejected; b7 suite GREEN.
- Frozen API contract: extended (route + schemas + version bump), conformance PASS; C9 pins the spec/route consistency.
- `contracts/store.schema.sql`: untouched.

## Risk and Rollback

- Risk level: medium (new route expands the contract surface — conformance-guarded; /ask gains one FIFO hop — semantics identical to the prior per-engine queue, now observable; idle unload default 5 min avoids thrash).
- Rollback: revert the single commit; no schema or data migration; route removal restores the 12-path contract.
- Residual risk: in-process per-component RSS attribution is approximate (workers share process RSS; LLM is baseline-relative) — documented in ADR-0008; process-level sums come from the soak/bench instead.

## Waivers (or none)

**Owner decision recorded (merge gate):** the interactive owner reviewed the pending-hardware disposition and explicitly instructed (verbatim, session 2026-09-11): "then drive CI to green and merge the PR. monitor until it merges" — i.e. AC1's physical soak and AC6's reference-laptop rows are WAIVED as merge-blocking evidence, with the obligation tracked below. AC1's physical soak and AC6's reference-laptop rows require the 16 GB i5 reference laptop (`needs-hardware`; the issue itself states "no CI unit-test substitutes for the physical-machine soak test"). This PR ships the harness, the documented procedure, CI-coverable logic tests (explicitly allowed by the issue), and clearly-labeled devstation provisional measurements; the reference-laptop rows are marked PENDING in `bench/RESULTS.md` and ADR-0008. Follow-up: run `desktop/test/soak/memory-soak.mjs` on the reference laptop per `desktop/test/soak/README.md` and attach the log to #66.

## Review pass (post-publication hardening, PRR-F1..F6)

A swarm-pr-review pass (6 base lanes + 8 attested micro risk families + independent reviewer + 2 critic passes, run pr104-20260911-080534) validated 6 functional findings and a doc-wording set; all resolved in the review-hardening commit: the merge-blocker was a downgrade/upgrade OSCILLATION (the host re-latched 'fast' every ~2 ticks after one pressure episode because the monitor's `downgraded` latch was never resettable) — fixed with a `PressureMonitor.resetAfterUpgrade()` host ack and pinned end-to-end by the new `b8-host-loop.test.ts` (real host loop; revert probe FAILs with 84+ oscillation events without the ack); plus sampler-tick rejection guard, 32-bit env clamp, scheduler waiter rejection on stop, dead-runner rebuild, and doc wording fixes. Independent reviewer + final critic both APPROVE on the shipped tree (tree-id b37511fb69952aaf276ca39b7e05af48cc593b7b).

## Merge status

Awaiting explicit user approval; not merged.

PR head: 712d6990218d247c0a060a74e3e157bd77884d76

## Issue Closure

Closes #66
