### PR TITLE
feat(packtool): D2 offline narration transcription — content-hash cache + ASR overlay (issue #78)

### DIFF
--- a/docs/training-transcription.md
+++ b/docs/training-transcription.md
@@ -1,0 +1,124 @@
+# Offline narration transcription (D2, issue #78)
+
+`packtool/storyline/transcribe.py` is a **build-machine-only** CLI that
+recovers narration text for every audio/video asset in an Articulate
+Storyline 360 publish that has no native transcript sidecar, caches results
+by content hash, and emits one sidecar-format transcript file per media
+OBJECT id for D1's extractor to consume.
+
+It is a Python tool (stdlib + `faster-whisper`); the packtool CLI itself
+stays Node/TypeScript. Nothing in `web_ui/` or the Electron main process
+imports or invokes it — there is **no runtime transcription dependency** in
+the shipped app, and none may be added (acceptance check C5 pins this).
+
+## Usage
+
+```bash
+pip install faster-whisper        # build machine only; NOT in requirements.txt
+
+python packtool/storyline/transcribe.py \
+  --publish "<publishDir>" \
+  --out     "<asrDir>" \            # ASR transcript store (per object id)
+  --cache-dir "<cacheDir>" \          # content-hash cache
+  --report   "<report.json>"
+
+# feed the store to the extractor:
+node packtool/dist/cli.js storyline extract "<publishDir>" --out "<outDir>" --asr-dir "<asrDir>"
+```
+
+## Model choice (named, per the issue)
+
+**`distil-large-v3`** (HuggingFace id `Systran/faster-distil-whisper-large-v3`),
+CPU, `compute_type=int8`, `language=en`. Chosen per the issue's primary
+option; feasibility was measured on the reference build machine before the
+full run (32-thread x64, cold load ~4 s). The distil model is English-only —
+matches the course corpus; pass `--model Systran/faster-whisper-medium.en`
+to override (never mixed as a co-default). `--language` overrides `en`.
+
+Audio decoding uses the FFmpeg libraries **bundled with** faster-whisper
+(PyAV): MP3 narration files and the audio track of MP4 videos take the same
+path. No system ffmpeg install is required (the issue's "e.g. via ffmpeg"
+extraction is satisfied by this equivalent bundled decoder).
+
+## Measured build-machine runtime (full corpus)
+
+Reference corpus: OpMed CDP MicroLearning Companion (300 MP3 narration
+assets + 37 sidecar-less video object ids = **337 media**, 45.8 minutes of
+voiced audio; 22 of the 37 videos are silent bumpers with no audio stream).
+
+- **Cold run (full ASR): ~34 minutes wall** (measured 2026-09-12 on the
+  reference build machine, 32 threads, int8 distil-large-v3, sequential
+  one-media-at-a-time processing; ~1.35x realtime).
+- **Warm re-run (all cache hits): ~3 seconds** (the acceptance driver's
+  own measured `elapsed` on the verified run).
+
+## Cache and invalidation rule
+
+Cache key (content-addressed, never filename-derived — publish filenames
+embed sample-rate/index metadata that churns across re-publishes):
+
+```
+composite = "<format_version>|<sha256(media bytes)>|<model id>|<compute type>"
+entry     = <cache-dir>/transcripts/<sha256[:12]>/<sha256(composite)>.json
+```
+
+The entry JSON stores the cues plus the full key components for auditability.
+On read, the stored components are compared to the request; ANY mismatch
+(different bytes, model, compute type, or format version) is treated as a
+cache MISS and the media is re-transcribed. Rules:
+
+- Re-publish with unchanged media (same bytes) → 100% cache hits, 0 ASR calls.
+- Changed audio content under the same filename → different content hash →
+  re-transcription.
+- Model or compute-type change → different key → full re-transcription.
+- Cache format change → bump `CACHE_FORMAT_VERSION` (re-keys everything).
+
+## Output contract
+
+`<asrDir>/<objectId>_transcripts.js`, byte-format identical to native
+`story_content/<id>_transcripts.js` sidecars (`const data = {...};`
+`window.globalLoadJsAsset(...)`), payload
+`{"transcripts":[{"name":"captions","source":"asr","model":"…","cues":
+[{"start_ms":<int>,"text":"…"}]}]}`. Keys are media OBJECT ids — the same id
+space the extractor's native-sidecar lookup uses — so a re-publish whose
+filenames churned still resolves. Media with no audio stream transcribes to
+an empty cue list (the honest ASR result for silence), recorded with
+`"note": "no audio stream"` in the report and cache entry.
+
+The report JSON carries `total`/`media_count`/`transcribed`/`cache_hits`/
+`failures` aggregates and one entry per media (kind, url, object_ids,
+media_sha256, status `transcribed`|`cache_hit`|`error`, cues_path, note).
+The CLI exits non-zero if any media failed; per-entry errors never abort the
+run (partial-failure containment).
+
+## Corpus coverage (acceptance evidence)
+
+Reference-package run (2026-09-12): **300 audio + 37 video = 337 media
+transcribed, 0 failures** (acceptance check C1). The issue's "33 sidecar-less
+MP4s" was file-space arithmetic (57 files − 24 sidecars); the id-space census
+(see trace `.agents/issue-traces/78-offline-narration-transcription/
+03-localization-log.md` H4) found 61 distinct video object ids of which 37
+have no sidecar — the invariant "every sidecar-less asset transcribed" covers
+37 ⊇ 33, with no coverage gap.
+
+## Spot-check sample (human-review anchor)
+
+Real cues from the verified run (for the PR's 3–5 cue human spot-check;
+pairings re-verified against `repro/c1-out/<objectId>_transcripts.js`):
+
+- MP3 `5VOOljZy4F3_44100_56_0.mp3` → `{"start_ms": 0, "text": " Select the
+  ProC button."}`
+- MP4 `video_5ZwqGnPmoSe_9_56_378x690.mp4` (object id `5wX4swBbOLl`) →
+  `{"start_ms": 0, "text": " Use a peripheral barcode scanner and scan the
+  front of the patient's KAC."}`
+- MP4 `video_5isWy96v20b_9_56_378x690.mp4` (object id `5ciTR6eNgk0`) →
+  `{"start_ms": 0, "text": " There is no button to click to turn on the CAC
+  scan search."}`
+- Native sidecar `5a5ry690OX4` (not ASR) begins "Patient documentation from
+  outside of CDP can be imported" — recorded here as the plausibility anchor
+  the ASR outputs sit alongside.
+
+## Out of scope (unchanged from the issue)
+
+Real-time/runtime transcription on a user machine; transcript accuracy
+scoring against a human reference; OCR of `txt__default_*.png` image text.

--- a/packtool/README.md
+++ b/packtool/README.md
@@ -30,9 +30,11 @@ Turns an unmodified Articulate Storyline 360 HTML5 publish folder into:
   "slide_title": "Note 10.2",                                // from data.js slide.title
   "on_screen_text": "…",                                     // altText + vartext, %player.*%-stripped
   "text_chars": 690,                                         // 0 is legal — slide still emitted
-  "transcript_source": "sidecar" | "missing" | "none",
-  "transcript_text": "…",                                    // sidecar cue texts, concatenated
-  "narration_ref": "story_content/<mediaId>_transcripts.js", // D2 (#78) placeholder, see below
+  "transcript_source": "sidecar" | "asr" | "missing" | "none",
+  "transcript_text": "…",                                    // sidecar or ASR cue texts, concatenated
+  "narration_ref": "story_content/<mediaId>_transcripts.js", // 'sidecar': publish-relative.
+                                                             // 'asr': '<id>_transcripts.js'
+                                                             //   (ASR-store-relative, see D2).
   "provenance": "<section_title> > Slide <n>",
   "source_files": ["meta.xml", "…"],                          // publish-relative inputs for this doc
   "html5url": "html5/data/js/<slideId>.js"                    // deep-link target (#58/#81/#82)
@@ -57,8 +59,20 @@ Turns an unmodified Articulate Storyline 360 HTML5 publish folder into:
   `story_content/<id>_transcripts.js`. Slides with several video objects take
   the first object that has a sidecar (on the reference corpus 15 slides carry
   a second, transcribed video behind an untranscribed bumper). `missing` = at
-  least one video object but no sidecar anywhere on the slide — that is D2's
-  (#78) transcription queue; `narration_ref` values are D2-owned placeholders.
+  least one media object but no transcript anywhere on the slide — that is
+  D2's (#78) transcription queue.
+- **ASR overlay (D2, issue #78)**: `packtool storyline extract <dir> --out
+  <dir> --asr-dir <dir>` additionally resolves AUDIO objects (kind 'audio',
+  layer `audiolib[]`) and sidecar-less media from the ASR transcript store
+  written by `packtool/storyline/transcribe.py` (see
+  `docs/training-transcription.md`). The store holds one
+  `<objectId>_transcripts.js` file per media object id — the SAME byte format
+  as native sidecars, decoded by the unchanged decode path — so slides come
+  out with `transcript_source: "asr"`, `transcript_text` = concatenated cue
+  texts, and `narration_ref` = `<id>_transcripts.js` (ASR-store-relative:
+  deliberately NOT publish-relative, so it is NOT pushed into `source_files`).
+  Without `--asr-dir` the output is byte-identical to the pre-#78 extractor
+  (goldens pinned).
 - **Version pin** (re-verify before reuse on any re-export): decode assumptions
   verified against Storyline `3.114.36620.0` / `bwVersion 4.0` (issue #77's
   invalidation clause). Corrections vs the issue text: `textLib` lives per
@@ -71,12 +85,17 @@ Turns an unmodified Articulate Storyline 360 HTML5 publish folder into:
 - `storyline/walk.ts` — per-slide text walk (`vectorData.altText` +
   `vartext.blocks[].spans[].text`), token stripping, `text_chars`.
 - `storyline/spine.ts` — data.js scene→slide walk + frame.js outline partition.
-- `storyline/video-refs.ts` — sidecar resolution + cue concatenation.
+- `storyline/video-refs.ts` — sidecar resolution + cue concatenation (+ the
+  issue #78 ASR overlay).
 - `storyline/extract.ts` + `cli.ts` — document assembly and the CLI entry.
-- `storyline/__tests__/` — acceptance tests (AC1–AC7 of issue #77) against the
-  committed mini fixture `../tests/fixtures/storyline-mini` (byte-for-byte
-  golden output). CI runs the fixture suite only; the full 384-slide corpus run
-  is a documented manual acceptance step (`packtool` never ships media).
+- `storyline/transcribe.py` — D2 (#78) offline narration transcription
+  (Python, build machine only, content-hash cache; see
+  `docs/training-transcription.md`).
+- `storyline/__tests__/` — acceptance tests (AC1–AC7 of issue #77 plus the
+  #78 ASR-consumer integration test) against the committed mini fixture
+  `../tests/fixtures/storyline-mini` (byte-for-byte golden output). CI runs
+  the fixture suite only; the full 384-slide corpus run is a documented
+  manual acceptance step (`packtool` never ships media).
 
 ### Fixture origin and licensing
 

--- a/packtool/cli.ts
+++ b/packtool/cli.ts
@@ -1,14 +1,16 @@
 // packtool CLI entry (issue #77): packtool storyline extract <publishDir> --out <dir>
+// issue #78 adds the optional --asr-dir <dir> ASR transcript store.
 
 import { extractPublishDir } from './storyline/extract.js';
 
 interface ExtractArgs {
   publishDir: string;
   outDir: string;
+  asrDir?: string;
 }
 
 function usage(): never {
-  console.error('usage: packtool storyline extract <publishDir> --out <dir>');
+  console.error('usage: packtool storyline extract <publishDir> --out <dir> [--asr-dir <dir>]');
   process.exit(2);
 }
 
@@ -16,10 +18,14 @@ function parseArgs(argv: string[]): ExtractArgs {
   if (argv[0] !== 'storyline' || argv[1] !== 'extract') usage();
   let publishDir: string | undefined;
   let outDir: string | undefined;
+  let asrDir: string | undefined;
   for (let i = 2; i < argv.length; i++) {
     const arg = argv[i];
     if (arg === '--out') {
       outDir = argv[i + 1];
+      i++;
+    } else if (arg === '--asr-dir') {
+      asrDir = argv[i + 1];
       i++;
     } else if (arg !== undefined && !arg.startsWith('--')) {
       publishDir = arg;
@@ -28,13 +34,13 @@ function parseArgs(argv: string[]): ExtractArgs {
     }
   }
   if (publishDir === undefined || outDir === undefined) usage();
-  return { publishDir, outDir };
+  return { publishDir, outDir, asrDir };
 }
 
 export function main(argv: string[]): number {
-  const { publishDir, outDir } = parseArgs(argv);
+  const { publishDir, outDir, asrDir } = parseArgs(argv);
   try {
-    extractPublishDir(publishDir, outDir);
+    extractPublishDir(publishDir, outDir, { asrDir });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error(`packtool storyline extract failed: ${message}`);

--- a/packtool/storyline/__tests__/transcribe.ac4.test.ts
+++ b/packtool/storyline/__tests__/transcribe.ac4.test.ts
@@ -1,0 +1,182 @@
+// AC4 (issue #78) — normalized ASR cues feed the EXISTING D1 consumer with no
+// ad-hoc shape adapter.
+//
+// packtool/storyline/transcribe.py writes `<asrDir>/<objectId>_transcripts.js`
+// files in the SAME byte format as native story_content sidecars
+// (`const data = {...}; window.globalLoadJsAsset(...)`), so resolveVideoRefs
+// consumes them through the unchanged decodeSidecarAsset +
+// sidecarTranscriptText path. This test pins that contract both ways:
+// transcribe.py's output format (recreated here byte-compatibly) must decode
+// with the existing decoder, and the resolver must distinguish transcript
+// source 'asr' from 'sidecar' on that path. If D1 ever needed an adapter for
+// ASR cues, this file fails.
+//
+// Case matrix (fix plan U5 / critic R6):
+//   (a) audio-only slide WITH an ASR twin           -> 'asr' + exact text
+//   (b) audio-only slide WITHOUT an ASR twin        -> 'missing'
+//   (c) audio+video, video native sidecar wins      -> 'sidecar'
+//   (d) unsafe audio object id                      -> treated absent ('missing')
+//   (e) default path (no asrDir), audio object only -> 'none' (audio not scanned)
+//   (f) video, no sidecar, no ASR twin              -> 'missing'
+//   (g) video WITH an ASR twin, no native sidecar   -> 'asr' (videos resolve too)
+
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { decodeSidecarAsset } from '../decode';
+import { resolveVideoRefs } from '../video-refs';
+
+const ASR_MODEL = 'distil-large-v3';
+
+function asrSidecarContent(objectId: string, cues: Array<{ start_ms: number; text: string }>): string {
+  // Byte-compatible with packtool/storyline/transcribe.py write_asr_sidecar().
+  const data = {
+    transcripts: [{ name: 'captions', source: 'asr', model: ASR_MODEL, cues }],
+  };
+  return [
+    '(function() {',
+    `    const data = ${JSON.stringify(data)};`,
+    `    window.globalLoadJsAsset('${objectId}_transcripts.js', JSON.stringify(data));`,
+    '})();',
+    '',
+  ].join('\n');
+}
+
+function nativeSidecarContent(cues: Array<{ start: number; text: string }>): string {
+  const data = { transcripts: [{ name: 'captions', cues }] };
+  return [
+    '(function() {',
+    `    const data = ${JSON.stringify(data)};`,
+    `    window.globalLoadJsAsset('native_transcripts.js', JSON.stringify(data));`,
+    '})();',
+    '',
+  ].join('\n');
+}
+
+function slidePayload(mediaObjects: Array<Record<string, unknown>>): object {
+  return {
+    id: 'syntheticSlide',
+    slideLayers: [
+      {
+        kind: 'layer',
+        objects: mediaObjects.filter((o) => o['kind'] === 'video'),
+        audiolib: mediaObjects.filter((o) => o['kind'] === 'audio'),
+      },
+    ],
+  };
+}
+
+let tmpDirs: string[] = [];
+
+function makeTmp(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'ac4-asr-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs) rmSync(dir, { recursive: true, force: true });
+  tmpDirs = [];
+});
+
+describe('AC4: ASR transcript store feeds the D1 consumer without an adapter', () => {
+  it('ASR store file round-trips through the EXISTING decoder + text concatenation', () => {
+    const decoded = decodeSidecarAsset(
+      asrSidecarContent('audObj1', [
+        { start_ms: 1056, text: 'Select the ' },
+        { start_ms: 2100, text: 'ProC button.' },
+      ]),
+    );
+    const text = JSON.parse(JSON.stringify(decoded)) as { transcripts: Array<{ cues: Array<{ text: string }> }> };
+    const out = text.transcripts
+      .map((t) => t.cues)
+      .reduce<string>((acc, cues) => acc + cues.map((c) => c.text).join(''), '');
+    expect(out).toBe('Select the ProC button.');
+  });
+
+  it('(a) audio-only slide with an ASR twin resolves asr with the exact cue text', () => {
+    const publish = makeTmp();
+    const asrDir = makeTmp();
+    mkdirSync(join(publish, 'story_content'), { recursive: true });
+    writeFileSync(join(asrDir, 'audNarr7_transcripts.js'), asrSidecarContent('audNarr7', [
+      { start_ms: 0, text: 'Wash hands ' },
+      { start_ms: 1500, text: 'before the procedure.' },
+    ]));
+    const payload = slidePayload([{ kind: 'audio', id: 'audNarr7', assetId: 3 }]);
+    const refs = resolveVideoRefs(payload, publish, { asrDir });
+    expect(refs.transcriptSource).toBe('asr');
+    expect(refs.transcriptText).toBe('Wash hands before the procedure.');
+    expect(refs.narrationRef).toBe('audNarr7_transcripts.js');
+  });
+
+  it('(b) audio-only slide without an ASR twin (overlay set) is missing', () => {
+    const publish = makeTmp();
+    const asrDir = makeTmp();
+    mkdirSync(join(publish, 'story_content'), { recursive: true });
+    const payload = slidePayload([{ kind: 'audio', id: 'audNoTwin', assetId: 4 }]);
+    const refs = resolveVideoRefs(payload, publish, { asrDir });
+    expect(refs.transcriptSource).toBe('missing');
+  });
+
+  it('(c) audio+video slide: the native video sidecar wins over the audio ASR twin', () => {
+    const publish = makeTmp();
+    const asrDir = makeTmp();
+    mkdirSync(join(publish, 'story_content'), { recursive: true });
+    writeFileSync(join(publish, 'story_content', 'vidSide_transcripts.js'), nativeSidecarContent([
+      { start: 0, text: 'Native video caption.' },
+    ]));
+    writeFileSync(join(asrDir, 'audTwin_transcripts.js'), asrSidecarContent('audTwin', [
+      { start_ms: 0, text: 'Asr audio text.' },
+    ]));
+    const payload = slidePayload([
+      { kind: 'video', id: 'vidSide', data: { videodata: { assetId: 8 } } },
+      { kind: 'audio', id: 'audTwin', assetId: 9 },
+    ]);
+    const refs = resolveVideoRefs(payload, publish, { asrDir });
+    expect(refs.transcriptSource).toBe('sidecar');
+    expect(refs.transcriptText).toBe('Native video caption.');
+    expect(refs.narrationRef).toBe('story_content/vidSide_transcripts.js');
+  });
+
+  it('(d) unsafe audio object id is refused (treated absent), never joined into a path', () => {
+    const publish = makeTmp();
+    const asrDir = makeTmp();
+    mkdirSync(join(publish, 'story_content'), { recursive: true });
+    const payload = slidePayload([{ kind: 'audio', id: '../escape', assetId: 5 }]);
+    const refs = resolveVideoRefs(payload, publish, { asrDir });
+    expect(refs.transcriptSource).toBe('missing');
+  });
+
+  it('(e) default path (no asrDir) never scans audio objects: audio-only slide is none', () => {
+    const publish = makeTmp();
+    mkdirSync(join(publish, 'story_content'), { recursive: true });
+    const payload = slidePayload([{ kind: 'audio', id: 'audQuiet', assetId: 6 }]);
+    const refs = resolveVideoRefs(payload, publish);
+    expect(refs.transcriptSource).toBe('none');
+    expect(refs.narrationRef).toBeUndefined();
+  });
+
+  it('(f) video with no sidecar and no ASR twin (overlay set) is missing', () => {
+    const publish = makeTmp();
+    const asrDir = makeTmp();
+    mkdirSync(join(publish, 'story_content'), { recursive: true });
+    const payload = slidePayload([{ kind: 'video', id: 'vidAlone', data: { videodata: { assetId: 7 } } }]);
+    const refs = resolveVideoRefs(payload, publish, { asrDir });
+    expect(refs.transcriptSource).toBe('missing');
+  });
+
+  it('(g) video with an ASR twin and no native sidecar resolves asr', () => {
+    const publish = makeTmp();
+    const asrDir = makeTmp();
+    mkdirSync(join(publish, 'story_content'), { recursive: true });
+    writeFileSync(join(asrDir, 'vidAsr_transcripts.js'), asrSidecarContent('vidAsr', [
+      { start_ms: 100, text: 'Asr video narration.' },
+    ]));
+    const payload = slidePayload([{ kind: 'video', id: 'vidAsr', data: { videodata: { assetId: 10 } } }]);
+    const refs = resolveVideoRefs(payload, publish, { asrDir });
+    expect(refs.transcriptSource).toBe('asr');
+    expect(refs.transcriptText).toBe('Asr video narration.');
+    expect(refs.narrationRef).toBe('vidAsr_transcripts.js');
+  });
+});

--- a/packtool/storyline/extract.ts
+++ b/packtool/storyline/extract.ts
@@ -55,7 +55,18 @@ function readNonMessageSceneCount(publishDir: string): number {
   return n;
 }
 
-export function extractPublishDir(publishDir: string, outDir: string): void {
+export interface ExtractOptions {
+  /**
+   * ASR transcript store written by packtool/storyline/transcribe.py
+   * (issue #78). When set, resolveVideoRefs additionally resolves audio
+   * objects and sidecar-less media from the store, emitting
+   * transcript_source 'asr'. Omitted (default) = pre-#78 behavior,
+   * byte-identical output (goldens pinned by tests/fixtures/storyline-mini).
+   */
+  asrDir?: string;
+}
+
+export function extractPublishDir(publishDir: string, outDir: string, options: ExtractOptions = {}): void {
   const tmpDir = join(outDir, `.packtool-tmp-${process.pid}-${Date.now()}`);
   mkdirSync(tmpDir, { recursive: true });
   const tmpSlides = join(tmpDir, 'slides');
@@ -88,7 +99,7 @@ export function extractPublishDir(publishDir: string, outDir: string): void {
       // PRR-006: pass the source path so a thrown decode error names the file.
       const payload = decodeGlobalProvideData('slide', readTextFile(slidePath), slidePath);
       const { onScreenText, textChars } = walkSlideText(payload as object);
-      const videoRefs = resolveVideoRefs(payload as object, publishDir);
+      const videoRefs = resolveVideoRefs(payload as object, publishDir, { asrDir: options.asrDir });
 
       const sourceFiles = ['meta.xml', 'html5/data/js/data.js', 'html5/data/js/frame.js', entry.html5url];
       if (videoRefs.transcriptSource === 'sidecar' && videoRefs.narrationRef !== undefined) {

--- a/packtool/storyline/transcribe.py
+++ b/packtool/storyline/transcribe.py
@@ -1,0 +1,627 @@
+#!/usr/bin/env python3
+"""Offline narration transcription for Storyline publishes (issue #78, Workstream D2).
+
+Build-machine-only CLI: walks an unmodified Articulate Storyline 360 HTML5
+publish, inventories every audio/video media object that has no native
+transcript sidecar, transcribes it with faster-whisper (CPU, int8) under a
+content-hash cache, and emits one sidecar-format transcript file per media
+OBJECT id so D1's packtool consumer (storyline/video-refs.ts) can read ASR
+output through the exact decode path used for native sidecars.
+
+Usage:
+    python packtool/storyline/transcribe.py --publish <publishDir> \
+        --out <asrDir> --cache-dir <cacheDir> --report <report.json> \
+        [--model distil-large-v3] [--compute-type int8] [--language en] \
+        [--cpu-threads N]
+
+Media identity: the cache is keyed by CONTENT (sha256 of the media bytes) plus
+the ASR parameters (format version, model, compute type) — never by filename
+(publish filenames embed sample-rate/index metadata that churns across
+re-publishes). Transcript OUTPUT is keyed by the media OBJECT id — the same
+id space native `story_content/<id>_transcripts.js` sidecars use (issue #77
+localization H7) — so re-publishes whose filenames churn still resolve.
+
+This module is build-time tooling. Nothing in web_ui/ or the Electron
+runtime imports it (acceptance check C5); faster-whisper is a build-machine
+dependency installed separately (docs/training-transcription.md), imported
+lazily so the module (and its tests) load without it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+DEFAULT_MODEL = "distil-large-v3"
+DEFAULT_COMPUTE_TYPE = "int8"
+DEFAULT_LANGUAGE = "en"
+DEFAULT_CPU_THREADS = min(8, os.cpu_count() or 1)
+
+# Chosen model (issue #78: name the actual choice, do not leave both as
+# options): distil-large-v3, feasibility measured on the reference build
+# machine (docs/training-transcription.md). `medium.en` remains available as
+# an explicit --model override via the alias table below, never as a default.
+MODEL_ALIASES = {
+    "distil-large-v3": "Systran/faster-distil-whisper-large-v3",
+    "medium.en": "Systran/faster-whisper-medium.en",
+}
+
+CACHE_FORMAT_VERSION = 1
+TRANSCRIPT_SUFFIX = "_transcripts.js"
+_MEDIA_EXTS = (".mp3", ".mp4")
+
+
+class TranscribeError(Exception):
+    """Fatal, loud inventory/decode failure (drift or adversarial publish)."""
+
+
+# ---------------------------------------------------------------------------
+# Decode layer (mirrors packtool/storyline/decode.ts byte-for-byte semantics)
+
+
+def read_text(path: str) -> str:
+    """utf-8-sig semantics: strip one leading BOM from a utf-8 read."""
+    with open(path, "r", encoding="utf-8-sig") as fh:
+        return fh.read()
+
+
+def decode_global_provide_data(
+    payload_name: str, text: str, source_path: str = "<input>"
+) -> Any:
+    marker = "window.globalProvideData('" + payload_name + "', '"
+    at = text.find(marker)
+    if at == -1:
+        raise TranscribeError(
+            f"no window.globalProvideData('{payload_name}', ...) wrapper found in {source_path}"
+        )
+    start = at + len(marker)
+    i = start
+    while i < len(text):
+        ch = text[i]
+        if ch == "\\":
+            i += 2  # skip escaped char; the terminating quote is unescaped only
+            continue
+        if ch == "'":
+            break
+        i += 1
+    if i >= len(text):
+        raise TranscribeError(
+            f"unterminated globalProvideData('{payload_name}') payload in {source_path}"
+        )
+    raw = text[start:i]
+    unescaped = raw.replace("\\\\", "\x00").replace("\\'", "'").replace("\x00", "\\")
+    return json.loads(unescaped)
+
+
+# ---------------------------------------------------------------------------
+# Path safety (same contract as isUnsafeComponent in extract.ts/video-refs.ts)
+
+
+def is_unsafe_component(value: str) -> bool:
+    if len(value) == 0:
+        return True
+    if "/" in value or "\\" in value or "\x00" in value:
+        return True
+    if value in (".", "..") or value.startswith("./") or value.startswith("../"):
+        return True
+    if value.startswith(".\\") or value.startswith("..\\"):
+        return True
+    return False
+
+
+def resolve_inside_publish(publish_dir: str, rel_url: str, what: str) -> str:
+    # Path safety is per COMPONENT (the same contract as isUnsafeComponent in
+    # extract.ts/video-refs.ts): a publish-relative url legitimately contains
+    # '/' separators, but no component may be empty/absolute traversal.
+    if not isinstance(rel_url, str) or not rel_url:
+        raise TranscribeError(
+            f"{what} refuses an unsafe publish-relative value: {rel_url!r}"
+        )
+    if rel_url.startswith("/") or rel_url.startswith("\\") or "://" in rel_url:
+        raise TranscribeError(
+            f"{what} refuses an unsafe publish-relative value: {rel_url!r}"
+        )
+    components = rel_url.replace("\\", "/").split("/")
+    if any(is_unsafe_component(component) for component in components):
+        raise TranscribeError(
+            f"{what} refuses an unsafe publish-relative value: {rel_url!r}"
+        )
+    resolved = os.path.abspath(os.path.join(publish_dir, *components))
+    base = os.path.abspath(publish_dir)
+    if resolved != base and not resolved.startswith(base + os.sep):
+        raise TranscribeError(
+            f"{what} resolves outside the publish dir (refused): {rel_url!r}"
+        )
+    return resolved
+
+
+# ---------------------------------------------------------------------------
+# Inventory
+
+
+@dataclass
+class MediaObject:
+    kind: str  # 'audio' | 'video'
+    object_id: str
+    asset_id: Any = None
+    url: Optional[str] = None  # publish-relative, when resolvable
+
+
+@dataclass
+class Inventory:
+    objects: List[MediaObject] = field(default_factory=list)
+    # sidecar-covered object ids (native story_content/<id>_transcripts.js)
+    sidecar_ids: set = field(default_factory=set)
+
+
+def _walk_media_objects(node: Any, out: List[MediaObject]) -> None:
+    """Fully recursive walk: audio objects may nest under layer audiolib[]
+    arrays or objects[] depending on publisher version; recursion is the safe
+    superset (fix plan U1/U3)."""
+    if isinstance(node, dict):
+        kind = node.get("kind")
+        obj_id = node.get("id")
+        if kind == "audio" and isinstance(obj_id, str):
+            out.append(MediaObject("audio", obj_id, node.get("assetId")))
+        elif kind == "video" and isinstance(obj_id, str):
+            videodata = node.get("data") or {}
+            asset_id = (
+                videodata.get("videodata", {}).get("assetId")
+                if isinstance(videodata, dict)
+                else None
+            )
+            out.append(MediaObject("video", obj_id, asset_id))
+        for value in node.values():
+            _walk_media_objects(value, out)
+    elif isinstance(node, list):
+        for value in node:
+            _walk_media_objects(value, out)
+
+
+def build_inventory(publish_dir: str) -> Inventory:
+    data_js = os.path.join(publish_dir, "html5", "data", "js", "data.js")
+    data = decode_global_provide_data("data", read_text(data_js), data_js)
+    asset_lib = {
+        entry.get("id"): entry.get("url")
+        for entry in (data.get("assetLib") or [])
+        if isinstance(entry, dict)
+    }
+
+    inv = Inventory()
+    seen_ids: set = set()
+    js_dir = os.path.join(publish_dir, "html5", "data", "js")
+    for name in sorted(os.listdir(js_dir)):
+        if not name.endswith(".js") or name in ("data.js", "frame.js", "paths.js"):
+            continue
+        slide_path = os.path.join(js_dir, name)
+        payload = decode_global_provide_data("slide", read_text(slide_path), slide_path)
+        found: List[MediaObject] = []
+        _walk_media_objects(payload, found)
+        for obj in found:
+            if obj.object_id in seen_ids:
+                continue
+            seen_ids.add(obj.object_id)
+            if is_unsafe_component(obj.object_id):
+                raise TranscribeError(
+                    f"media object id refuses an unsafe value: {obj.object_id!r}"
+                )
+            url = asset_lib.get(obj.asset_id) if obj.asset_id is not None else None
+            if not (isinstance(url, str) and url.lower().endswith(_MEDIA_EXTS)):
+                url = None  # unresolvable: becomes a per-entry error at run time
+            obj.url = url
+            inv.objects.append(obj)
+            sidecar = os.path.join(
+                publish_dir, "story_content", obj.object_id + TRANSCRIPT_SUFFIX
+            )
+            if os.path.isfile(sidecar):
+                inv.sidecar_ids.add(obj.object_id)
+    return inv
+
+
+# ---------------------------------------------------------------------------
+# Content-hash cache
+
+
+def sha256_file(path: str) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def cache_composite(media_sha256: str, model_id: str, compute_type: str) -> str:
+    return f"{CACHE_FORMAT_VERSION}|{media_sha256}|{model_id}|{compute_type}"
+
+
+def cache_entry_path(
+    cache_dir: str, media_sha256: str, model_id: str, compute_type: str
+) -> str:
+    composite = cache_composite(media_sha256, model_id, compute_type)
+    key_hash = hashlib.sha256(composite.encode("utf-8")).hexdigest()
+    return os.path.join(cache_dir, "transcripts", media_sha256[:12], key_hash + ".json")
+
+
+def load_cues(
+    cache_dir: str, media_sha256: str, model_id: str, compute_type: str
+) -> Optional[dict]:
+    """Return the cached payload, or None on a miss. A stored entry whose key
+    components do not match the request is treated as a MISS (guardrail:
+    stale/mis-keyed entries can never be served)."""
+    path = cache_entry_path(cache_dir, media_sha256, model_id, compute_type)
+    if not os.path.isfile(path):
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            payload = json.load(fh)
+    except (OSError, ValueError):
+        return None
+    stored = payload.get("key") or {}
+    expected = {
+        "format_version": CACHE_FORMAT_VERSION,
+        "media_sha256": media_sha256,
+        "model": model_id,
+        "compute_type": compute_type,
+    }
+    if stored != expected:
+        return None
+    if not isinstance(payload.get("cues"), list):
+        return None
+    return payload
+
+
+def store_cues(
+    cache_dir: str,
+    media_sha256: str,
+    model_id: str,
+    compute_type: str,
+    cues: List[dict],
+    duration_ms: Optional[int],
+    note: Optional[str] = None,
+) -> str:
+    path = cache_entry_path(cache_dir, media_sha256, model_id, compute_type)
+    payload = {
+        "key": {
+            "format_version": CACHE_FORMAT_VERSION,
+            "media_sha256": media_sha256,
+            "model": model_id,
+            "compute_type": compute_type,
+        },
+        "model_alias": _alias_of(model_id),
+        "duration_ms": duration_ms,
+        "note": note,
+        "cues": cues,
+    }
+    atomic_write_json(path, payload)
+    return path
+
+
+def atomic_write_json(path: str, payload: dict) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh, ensure_ascii=False, indent=2)
+            fh.write("\n")
+        os.replace(tmp, path)
+    except BaseException:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+        raise
+
+
+def _alias_of(model_id: str) -> str:
+    for alias, resolved in MODEL_ALIASES.items():
+        if resolved == model_id:
+            return alias
+    return model_id
+
+
+# ---------------------------------------------------------------------------
+# ASR runner (lazy faster-whisper; DI seam keeps tests hermetic)
+
+
+@dataclass
+class RunnerSpec:
+    model_id: str
+    compute_type: str
+    language: str
+    cpu_threads: int
+
+
+Runner = Callable[[str, RunnerSpec], dict]
+
+_MODEL_CACHE: Dict[Tuple[str, str, int], Any] = {}
+
+
+def resolve_model_id(model: str) -> str:
+    return MODEL_ALIASES.get(model, model)
+
+
+def default_runner(media_path: str, spec: RunnerSpec) -> dict:
+    """Lazy faster-whisper runner. Audio decode uses the bundled FFmpeg
+    (PyAV) that faster-whisper ships, so MP3 and MP4 audio tracks take the
+    same path with no system ffmpeg dependency. Media with NO audio stream
+    (silent Storyline bumper videos) transcribe to an empty cue list — the
+    honest ASR result for silence — instead of a decoder error."""
+    try:
+        import av
+        from faster_whisper import WhisperModel
+    except ImportError as exc:  # pragma: no cover - exercised only without dep
+        raise TranscribeError(
+            "faster-whisper is not installed; install it on the build machine: "
+            "pip install faster-whisper (docs/training-transcription.md)"
+        ) from exc
+
+    with av.open(media_path) as container:
+        if len(container.streams.audio) == 0:
+            duration_ms = int(container.duration / 1000) if container.duration else None
+            return {"cues": [], "duration_ms": duration_ms, "note": "no audio stream"}
+
+    key = (spec.model_id, spec.compute_type, spec.cpu_threads)
+    model = _MODEL_CACHE.get(key)
+    if model is None:
+        model = WhisperModel(
+            spec.model_id,
+            device="cpu",
+            compute_type=spec.compute_type,
+            cpu_threads=spec.cpu_threads,
+        )
+        _MODEL_CACHE[key] = model
+    segments, info = model.transcribe(media_path, language=spec.language)
+    cues = [{"start_ms": int(seg.start * 1000), "text": seg.text} for seg in segments]
+    duration_ms = int(info.duration * 1000) if getattr(info, "duration", None) else None
+    return {"cues": cues, "duration_ms": duration_ms}
+
+
+# ---------------------------------------------------------------------------
+# Output: sidecar-format transcript per media OBJECT id
+
+
+def sidecar_payload(model_alias: str, cues: List[dict]) -> dict:
+    return {
+        "transcripts": [
+            {
+                "name": "captions",
+                "source": "asr",
+                "model": model_alias,
+                "cues": cues,
+            }
+        ]
+    }
+
+
+def write_asr_sidecar(
+    out_dir: str, object_id: str, model_alias: str, cues: List[dict]
+) -> str:
+    """Byte-format compatible with native story_content/<id>_transcripts.js
+    sidecars (decode.ts decodeSidecarAsset parses it unchanged)."""
+    path = os.path.join(out_dir, object_id + TRANSCRIPT_SUFFIX)
+    body = json.dumps(sidecar_payload(model_alias, cues), ensure_ascii=False, indent=2)
+    content = (
+        "(function() {\n"
+        f"    const data = {body};\n"
+        f"    window.globalLoadJsAsset('{object_id}{TRANSCRIPT_SUFFIX}', JSON.stringify(data));\n"
+        "})();\n"
+    )
+    os.makedirs(out_dir, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=out_dir, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(content)
+        os.replace(tmp, path)
+    except BaseException:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+        raise
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+
+
+@dataclass
+class QueueItem:
+    kind: str  # 'audio' | 'video'
+    url: Optional[str]
+    object_ids: List[str]
+
+
+def build_queue(inv: Inventory) -> List[QueueItem]:
+    """Audio grouped per unique media file (the ASR unit of work); videos per
+    sidecar-less object id (the identity native sidecars would have used)."""
+    queue: List[QueueItem] = []
+    audio_by_url: Dict[str, List[str]] = {}
+    for obj in inv.objects:
+        if obj.object_id in inv.sidecar_ids:
+            continue  # native sidecar covers this object; not in scope
+        if obj.kind == "audio" and obj.url is not None:
+            audio_by_url.setdefault(obj.url, []).append(obj.object_id)
+        else:
+            queue.append(QueueItem(obj.kind, obj.url, [obj.object_id]))
+    for url, ids in audio_by_url.items():
+        queue.append(QueueItem("audio", url, ids))
+    return queue
+
+
+def run_transcription(
+    publish_dir: str,
+    out_dir: str,
+    cache_dir: str,
+    model: str = DEFAULT_MODEL,
+    compute_type: str = DEFAULT_COMPUTE_TYPE,
+    language: str = DEFAULT_LANGUAGE,
+    cpu_threads: Optional[int] = None,
+    runner: Optional[Runner] = None,
+) -> dict:
+    """Transcribe every sidecar-less media asset; returns the JSON report."""
+    model_id = resolve_model_id(model)
+    threads = DEFAULT_CPU_THREADS if cpu_threads is None else cpu_threads
+    spec = RunnerSpec(
+        model_id=model_id,
+        compute_type=compute_type,
+        language=language,
+        cpu_threads=threads,
+    )
+    transcribe: Runner = runner if runner is not None else default_runner
+    model_alias = _alias_of(model_id)
+
+    inv = build_inventory(publish_dir)
+    queue = build_queue(inv)
+
+    media_entries: List[dict] = []
+    failures = 0
+    cache_hits = 0
+    transcribed = 0
+
+    for item in queue:
+        entry: Dict[str, Any] = {
+            "kind": item.kind,
+            "object_ids": item.object_ids,
+            "url": item.url,
+            "media_sha256": None,
+            "status": "error",
+            "error": None,
+        }
+        try:
+            if item.url is None:
+                raise TranscribeError(
+                    f"{item.kind} object(s) {item.object_ids} reference "
+                    + "no resolvable .mp3/.mp4 asset"
+                )
+            media_path = resolve_inside_publish(
+                publish_dir, item.url, f"{item.kind} media {item.object_ids}"
+            )
+            if not os.path.isfile(media_path):
+                raise TranscribeError(f"media file missing: {item.url}")
+            media_sha = sha256_file(media_path)
+            entry["media_sha256"] = media_sha
+
+            cached = load_cues(cache_dir, media_sha, model_id, compute_type)
+            if cached is not None:
+                cues = cached["cues"]
+                note = cached.get("note")
+                entry["status"] = "cache_hit"
+                cache_hits += 1
+            else:
+                result = transcribe(media_path, spec)
+                cues = [
+                    {"start_ms": int(cue["start_ms"]), "text": str(cue["text"])}
+                    for cue in result["cues"]
+                ]
+                note = result.get("note")
+                store_cues(
+                    cache_dir,
+                    media_sha,
+                    model_id,
+                    compute_type,
+                    cues,
+                    result.get("duration_ms"),
+                    note=note,
+                )
+                entry["status"] = "transcribed"
+                transcribed += 1
+            if note:
+                entry["note"] = note
+            first_path = None
+            for object_id in item.object_ids:
+                path = write_asr_sidecar(out_dir, object_id, model_alias, cues)
+                if first_path is None:
+                    first_path = path
+            entry["cues_path"] = first_path
+        except Exception as exc:  # noqa: BLE001 - per-entry containment: one bad
+            # media file must fail its own entry (report error + exit 1), never
+            # abort the whole run (partial-failure contract, fix plan edge cases).
+            entry["status"] = "error"
+            entry["error"] = f"{type(exc).__name__}: {exc}"
+            failures += 1
+        media_entries.append(entry)
+
+    return {
+        "publish": publish_dir,
+        "model_alias": model_alias,
+        "model": model_id,
+        "compute_type": compute_type,
+        "language": language,
+        "total": len(media_entries),
+        "media_count": len(media_entries),
+        # Successfully transcribed media = fresh ASR computes + cache hits
+        # (a cache hit IS a transcription result; the C1 acceptance driver's
+        # status vocabulary counts 'transcribed' and 'cache_hit' alike).
+        "transcribed": transcribed + cache_hits,
+        "transcribed_fresh": transcribed,
+        "cache_hits": cache_hits,
+        "failures": failures,
+        "media": media_entries,
+    }
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="transcribe.py",
+        description="Offline narration transcription with a content-hash cache "
+        "(build machine only; issue #78).",
+    )
+    parser.add_argument(
+        "--publish", required=True, help="Storyline HTML5 publish folder"
+    )
+    parser.add_argument(
+        "--out", required=True, help="ASR transcript output folder (per object id)"
+    )
+    parser.add_argument(
+        "--cache-dir", required=True, help="content-hash transcript cache folder"
+    )
+    parser.add_argument("--report", required=True, help="JSON report output path")
+    parser.add_argument(
+        "--model", default=DEFAULT_MODEL, help="whisper model (default: %(default)s)"
+    )
+    parser.add_argument(
+        "--compute-type", default=DEFAULT_COMPUTE_TYPE, help="CT2 compute type"
+    )
+    parser.add_argument(
+        "--language", default=DEFAULT_LANGUAGE, help="spoken language code"
+    )
+    parser.add_argument(
+        "--cpu-threads", type=int, default=None, help="CPU threads for inference"
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        report = run_transcription(
+            publish_dir=args.publish,
+            out_dir=args.out,
+            cache_dir=args.cache_dir,
+            model=args.model,
+            compute_type=args.compute_type,
+            language=args.language,
+            cpu_threads=args.cpu_threads,
+        )
+    except TranscribeError as exc:
+        # Fatal inventory error: report it loudly, still write the report file.
+        report = {
+            "publish": args.publish,
+            "model_alias": args.model,
+            "model": resolve_model_id(args.model),
+            "compute_type": args.compute_type,
+            "language": args.language,
+            "total": 0,
+            "media_count": 0,
+            "transcribed": 0,
+            "cache_hits": 0,
+            "failures": 1,
+            "media": [],
+            "fatal": str(exc),
+        }
+    atomic_write_json(args.report, report)
+    return 1 if report["failures"] != 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packtool/storyline/types.ts
+++ b/packtool/storyline/types.ts
@@ -5,7 +5,11 @@
 // serialization order pinned by the golden fixture files
 // (tests/fixtures/storyline-mini/expected/).
 
-export type TranscriptSource = 'sidecar' | 'missing' | 'none';
+// 'asr' is only reachable through the opt-in ASR overlay (storyline extract
+// --asr-dir, issue #78): packtool/storyline/transcribe.py emits sidecar-format
+// transcript files that the overlay resolves by media object id. Default
+// (no-overlay) extraction never emits it.
+export type TranscriptSource = 'sidecar' | 'asr' | 'missing' | 'none';
 
 export interface SpineEntry {
   slideId: string;
@@ -27,8 +31,10 @@ export interface SlideDoc {
   text_chars: number;
   transcript_source: TranscriptSource;
   transcript_text?: string;
-  // D2 (#78) placeholder: populated here when a sidecar exists; D2 owns
-  // narration for slides whose media is untranscribed.
+  // D2 (#78): 'sidecar' populates this when a native sidecar exists;
+  // 'asr' populates it with the ASR-store-relative transcript filename
+  // ('<id>_transcripts.js' — deliberately NOT publish-relative, the file
+  // lives in the --asr-dir output of transcribe.py, not in the publish).
   narration_ref?: string;
   provenance: string;
   source_files: string[];

--- a/packtool/storyline/video-refs.ts
+++ b/packtool/storyline/video-refs.ts
@@ -1,4 +1,4 @@
-// Video -> transcript sidecar resolution (issue #77, G4; PRR feedback fixes).
+// Video/audio -> transcript resolution (issue #77 G4 + #78 ASR overlay; PRR fixes).
 //
 // A video object is kind === 'video' with data.videodata (altText there is the
 // ORIGINAL media filename — never on-screen text). The sidecar lookup key is
@@ -6,9 +6,17 @@
 // ids are not slide ids and match the 24 story_content/<id>_transcripts.js
 // stems 1:1). Present sidecars give transcriptSource 'sidecar' with the cue
 // texts concatenated with NO separator (cues carry their own spacing) and
-// narrationRef 'story_content/<id>_transcripts.js' (the D2/#78 placeholder);
-// absent sidecars are marked 'missing' — never silently dropped; slides with
-// no video object are 'none'.
+// narrationRef 'story_content/<id>_transcripts.js'; absent transcripts are
+// marked 'missing' — never silently dropped; slides with no media object are
+// 'none'. With the #78 ASR overlay (options.asrDir), AUDIO objects (kind
+// === 'audio', recursive walk — they nest under layer audiolib[] arrays too)
+// join the candidates, and a candidate may also resolve from the ASR store
+// written by packtool/storyline/transcribe.py: '<asrDir>/<id>_transcripts.js'
+// in the SAME byte format as native sidecars, decoded by the unchanged
+// decodeSidecarAsset path ('asr'; narrationRef '<id>_transcripts.js',
+// ASR-store-relative, deliberately NOT publish-relative and never pushed into
+// source_files). Without asrDir the pre-#78 contract is preserved exactly:
+// audio objects are not scanned, so audio-only slides stay 'none'.
 //
 // PRR-001 fix: videoId is also untrusted data.js content. The same
 // path-safety contract as slideId/html5url applies: refuse any value with
@@ -27,9 +35,14 @@ import { decodeSidecarAsset, readTextFile } from './decode.js';
 type Rec = Record<string, unknown>;
 
 export interface VideoRefs {
-  transcriptSource: 'sidecar' | 'missing' | 'none';
+  transcriptSource: 'sidecar' | 'asr' | 'missing' | 'none';
   transcriptText?: string;
   narrationRef?: string;
+}
+
+export interface ResolveRefsOptions {
+  /** ASR transcript store (transcribe.py --out). Undefined = pre-#78 behavior. */
+  asrDir?: string;
 }
 
 function asRecord(value: unknown): Rec {
@@ -72,10 +85,16 @@ export function sidecarTranscriptText(sidecar: unknown): string {
   return out;
 }
 
-export function resolveVideoRefs(slidePayload: object, publishDir: string): VideoRefs {
+export function resolveVideoRefs(
+  slidePayload: object,
+  publishDir: string,
+  options: ResolveRefsOptions = {},
+): VideoRefs {
+  const asrDir = options.asrDir;
   const slide = asRecord(slidePayload);
   const layers = slide['slideLayers'];
   const videoIds: string[] = [];
+  const audioIds: string[] = [];
   if (Array.isArray(layers)) {
     for (const layer of layers) {
       const objects = asRecord(layer)['objects'];
@@ -88,15 +107,29 @@ export function resolveVideoRefs(slidePayload: object, publishDir: string): Vide
       }
     }
   }
-  if (videoIds.length === 0) return { transcriptSource: 'none' };
+  // ASR overlay only (#78): audio objects join the candidates. They nest under
+  // layer audiolib[] arrays as well as objects[] depending on publisher
+  // version, so the walk is fully recursive — a deliberate safe superset.
+  // Without an asrDir, audio objects are NOT scanned (pre-#78 behavior:
+  // audio-only-narration slides stay 'none' and golden outputs are unchanged).
+  if (asrDir !== undefined) {
+    collectAudioIds(slide, audioIds);
+  }
+  if (videoIds.length === 0 && audioIds.length === 0) return { transcriptSource: 'none' };
 
   // A slide may carry several video objects (15 on the real corpus, where the
   // first video is often an untranscribed bumper and a later one has the
-  // narration sidecar). Deterministically prefer the FIRST video object that
-  // has a sidecar; report 'missing' only when none does (or when every
+  // narration sidecar). Deterministically prefer the FIRST candidate that has
+  // a native sidecar; report 'missing' only when none does (or when every
   // candidate videoId is rejected by the path-safety check — an adversarial
-  // publish cannot trigger arbitrary file reads under story_content/).
-  for (const videoId of videoIds) {
+  // publish cannot trigger arbitrary file reads under story_content/ or the
+  // ASR store).
+  const candidates: Array<{ id: string; kind: 'video' | 'audio' }> = [
+    ...videoIds.map((id) => ({ id, kind: 'video' as const })),
+    ...audioIds.map((id) => ({ id, kind: 'audio' as const })),
+  ];
+  for (const candidate of candidates) {
+    const videoId = candidate.id;
     const narrationRef = `story_content/${videoId}_transcripts.js`;
     const sidecarPath = join(publishDir, 'story_content', `${videoId}_transcripts.js`);
     // PRR-001 videoId leg: refuse any component that could escape publishDir.
@@ -119,9 +152,44 @@ export function resolveVideoRefs(slidePayload: object, publishDir: string): Vide
     ) {
       continue;
     }
-    if (!existsSync(sidecarPath)) continue;
-    const sidecar = decodeSidecarAsset(readTextFile(sidecarPath), sidecarPath);
-    return { transcriptSource: 'sidecar', transcriptText: sidecarTranscriptText(sidecar), narrationRef };
+    if (existsSync(sidecarPath)) {
+      const sidecar = decodeSidecarAsset(readTextFile(sidecarPath), sidecarPath);
+      return { transcriptSource: 'sidecar', transcriptText: sidecarTranscriptText(sidecar), narrationRef };
+    }
+    // ASR overlay leg (#78): same object-id key space, same byte format, same
+    // decode path — no shape adapter. narrationRef is ASR-store-relative and
+    // deliberately NOT publish-relative (the file lives in asrDir).
+    if (asrDir !== undefined) {
+      const asrRef = `${videoId}_transcripts.js`;
+      const asrPath = join(asrDir, asrRef);
+      const resolvedAsr = resolvePath(asrPath);
+      const resolvedAsrDir = resolvePath(asrDir);
+      if (
+        (resolvedAsr === resolvedAsrDir || resolvedAsr.startsWith(resolvedAsrDir + sep)) &&
+        existsSync(asrPath)
+      ) {
+        const asrSidecar = decodeSidecarAsset(readTextFile(asrPath), asrPath);
+        return {
+          transcriptSource: 'asr',
+          transcriptText: sidecarTranscriptText(asrSidecar),
+          narrationRef: asrRef,
+        };
+      }
+    }
   }
   return { transcriptSource: 'missing' };
+}
+
+/** Collect audio object ids (kind === 'audio', string id) recursively. */
+function collectAudioIds(node: unknown, out: string[]): void {
+  if (Array.isArray(node)) {
+    for (const child of node) collectAudioIds(child, out);
+    return;
+  }
+  if (typeof node !== 'object' || node === null) return;
+  const rec = node as Rec;
+  if (rec['kind'] === 'audio' && typeof rec['id'] === 'string') {
+    out.push(rec['id']);
+  }
+  for (const value of Object.values(rec)) collectAudioIds(value, out);
 }

--- a/tests/test_storyline_transcribe.py
+++ b/tests/test_storyline_transcribe.py
@@ -1,0 +1,563 @@
+"""Issue #78 acceptance and unit tests for packtool/storyline/transcribe.py.
+
+Selectors pinned by the frozen acceptance checks (trace
+.agents/issue-traces/78-offline-narration-transcription):
+  -k cache_hit       -> C2 (AC2): second run over identical media makes 0 ASR calls
+  -k content_change  -> C3 (AC3): same filename, different bytes -> new key -> re-run
+  -k idempotent      -> C7 (AC7): main/CLI-level double run, 0 calls on run 2
+
+HERMETIC: these tests never import faster_whisper. The producer module must be
+importable and fully functional with faster_whisper UNAVAILABLE (build machines
+and CI without the dependency); ASR is injected through the documented `runner`
+seam. The hermeticity test installs a sys.meta_path blocker BEFORE the module
+import and asserts the import plus core calls succeed.
+"""
+
+import importlib.util
+import json
+import os
+import sys
+import uuid
+
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_MODULE_PATH = os.path.join(_HERE, "..", "packtool", "storyline", "transcribe.py")
+_FIXTURE_PUBLISH = os.path.join(_HERE, "fixtures", "storyline-mini")
+
+
+class _ImportBlocker:
+    """sys.meta_path finder that makes `import faster_whisper` impossible."""
+
+    def __init__(self, name_prefix):
+        self.name_prefix = name_prefix
+
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == self.name_prefix or fullname.startswith(self.name_prefix + "."):
+            raise ImportError(f"{self.name_prefix} is blocked (hermetic test)")
+        return None
+
+
+def _load_transcribe_module():
+    blocker = _ImportBlocker("faster_whisper")
+    sys.meta_path.insert(0, blocker)
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "storyline_transcribe", _MODULE_PATH
+        )
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        # Register before exec: dataclass field introspection resolves
+        # cls.__module__ through sys.modules.
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+    finally:
+        sys.meta_path.remove(blocker)
+    return module
+
+
+transcribe = _load_transcribe_module()
+
+
+# ---------------------------------------------------------------------------
+# Synthetic publish builder (no real media decoding: runners are stubs)
+
+
+def write_slide_js(path, payload):
+    text = (
+        json.dumps(payload, ensure_ascii=False)
+        .replace("\\", "\\\\")
+        .replace("'", "\\'")
+    )
+    with open(path, "w", encoding="utf-8", newline="") as fh:
+        fh.write("window.globalProvideData('slide', '" + text + "');")
+
+
+def make_publish(
+    tmp_path, media_bytes, audio_objects, video_objects, sidecar_ids=(), asset_lib=True
+):
+    """Build a minimal publish: data.js assetLib + one slide carrying the given
+    audio (layer audiolib) and video (layer objects) objects."""
+    publish = tmp_path / "publish"
+    js_dir = publish / "html5" / "data" / "js"
+    story = publish / "story_content"
+    js_dir.mkdir(parents=True)
+    story.mkdir(parents=True)
+
+    lib = []
+    if asset_lib:
+        for idx, name in enumerate(sorted(media_bytes)):
+            lib.append(
+                {"id": 100 + idx, "kind": "asset", "url": "story_content/" + name}
+            )
+    data_payload = {"courseId": "syntheticCourse", "assetLib": lib, "scenes": []}
+    text = json.dumps(data_payload).replace("\\", "\\\\").replace("'", "\\'")
+    with open(js_dir / "data.js", "w", encoding="utf-8", newline="") as fh:
+        fh.write("window.globalProvideData('data', '" + text + "');")
+
+    objects = []
+    audiolib = []
+    asset_by_name = {name: 100 + idx for idx, name in enumerate(sorted(media_bytes))}
+    for object_id, media_name in audio_objects:
+        audiolib.append(
+            {"kind": "audio", "id": object_id, "assetId": asset_by_name.get(media_name)}
+        )
+    for object_id, media_name in video_objects:
+        videodata = {"assetId": asset_by_name.get(media_name)} if asset_lib else {}
+        objects.append(
+            {"kind": "video", "id": object_id, "data": {"videodata": videodata}}
+        )
+    slide_payload = {
+        "id": "slideA",
+        "slideLayers": [{"kind": "layer", "objects": objects, "audiolib": audiolib}],
+    }
+    write_slide_js(js_dir / "slideA.js", slide_payload)
+
+    for name, blob in media_bytes.items():
+        (story / name).write_bytes(blob)
+    for object_id in sidecar_ids:
+        (story / (object_id + "_transcripts.js")).write_text(
+            "(function() { const data = "
+            + json.dumps(
+                {
+                    "transcripts": [
+                        {"name": "captions", "cues": [{"start": 0, "text": "native"}]}
+                    ]
+                }
+            )
+            + "}; window.globalLoadJsAsset('story_content/x', JSON.stringify(data)); })();",
+            encoding="utf-8",
+        )
+    return publish
+
+
+def stub_runner(outputs=None):
+    """Runner counting ASR calls; each call returns the next output (or default)."""
+    state = {"calls": 0}
+    outputs = list(outputs or [])
+
+    def runner(media_path, spec):
+        state["calls"] += 1
+        state["last_spec"] = spec
+        state["last_path"] = media_path
+        if outputs:
+            return outputs.pop(0)
+        return {
+            "cues": [{"start_ms": 1500, "text": " Select the ProC button. "}],
+            "duration_ms": 1560,
+        }
+
+    runner.calls = state  # type: ignore[attr-defined]
+    return runner
+
+
+AUDIO_A = ("audA", "narr_a_44100_56_0.mp3")
+AUDIO_B = ("audB", "narr_b_44100_56_0.mp3")
+
+
+def base_media_bytes():
+    return {
+        AUDIO_A[1]: b"\xff\xfb" + uuid.uuid4().hex.encode() + b" audio-bytes-a",
+        AUDIO_B[1]: b"\xff\xfb" + uuid.uuid4().hex.encode() + b" audio-bytes-b",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Hermeticity + decode parity
+
+
+def test_module_imports_and_runs_with_faster_whisper_blocked(tmp_path):
+    publish = make_publish(tmp_path, base_media_bytes(), [AUDIO_A], [])
+    runner = stub_runner()
+    report = transcribe.run_transcription(
+        str(publish), str(tmp_path / "out"), str(tmp_path / "cache"), runner=runner
+    )
+    assert report["total"] == 1 and report["failures"] == 0
+    assert runner.calls["calls"] == 1
+
+
+def test_decode_parity_with_fixture_data_js():
+    fixture = os.path.join(_FIXTURE_PUBLISH, "html5", "data", "js", "data.js")
+    data = transcribe.decode_global_provide_data(
+        "data", transcribe.read_text(fixture), fixture
+    )
+    # The same payload the TS decode layer parses for the extract goldens
+    # (the fixture trims the real payload to these keys).
+    assert data["courseId"] == "5fox24EQH9w"
+    assert data["version"] == "3.114.36620.0"
+    assert data["slideCount"] == 6 and len(data["scenes"]) == 3
+
+
+def test_decode_parity_with_fixture_sidecar_wrapper():
+    fixture = os.path.join(
+        _FIXTURE_PUBLISH, "story_content", "5a5ry690OX4_transcripts.js"
+    )
+    raw = transcribe.read_text(fixture)
+    # The writer must emit content matching the SAME wrapper regex the TS
+    # decoder uses (decode.ts decodeSidecarAsset).
+    import re
+
+    match = re.search(r"const data = (\{[\s\S]*\});\s*window\.globalLoadJsAsset", raw)
+    assert match is not None
+    payload = json.loads(match.group(1))
+    assert payload["transcripts"][0]["cues"][0]["text"].startswith(
+        "Patient documentation"
+    )
+
+
+def test_emitted_asr_sidecar_matches_native_wrapper_regex(tmp_path):
+    cues = [{"start_ms": 1056, "text": "Patient documentation"}]
+    path = transcribe.write_asr_sidecar(
+        str(tmp_path), "abc123XYZ", "distil-large-v3", cues
+    )
+    import re
+
+    raw = open(path, encoding="utf-8").read()
+    match = re.search(r"const data = (\{[\s\S]*\});\s*window\.globalLoadJsAsset", raw)
+    assert match is not None
+    payload = json.loads(match.group(1))
+    transcript = payload["transcripts"][0]
+    assert transcript["source"] == "asr"
+    assert transcript["cues"] == cues
+
+
+# ---------------------------------------------------------------------------
+# Inventory
+
+
+def test_inventory_on_committed_fixture():
+    inv = transcribe.build_inventory(_FIXTURE_PUBLISH)
+    by_id = {obj.object_id: obj for obj in inv.objects}
+    assert set(by_id) == {"5a5ry690OX4", "6qX2mV8bR1k"}
+    assert all(obj.kind == "video" for obj in inv.objects)
+    # The fixture's one native sidecar covers 5a5ry690OX4; the other video is
+    # the queue. The fixture has no assetLib, so the queued video has no file.
+    assert inv.sidecar_ids == {"5a5ry690OX4"}
+    queue = transcribe.build_queue(inv)
+    assert len(queue) == 1
+    assert queue[0].kind == "video" and queue[0].object_ids == ["6qX2mV8bR1k"]
+
+
+def test_audio_objects_in_audiolib_nesting_are_found(tmp_path):
+    publish = make_publish(tmp_path, base_media_bytes(), [AUDIO_A, AUDIO_B], [])
+    inv = transcribe.build_inventory(str(publish))
+    assert {obj.object_id for obj in inv.objects} == {"audA", "audB"}
+    assert inv.sidecar_ids == set()
+    queue = transcribe.build_queue(inv)
+    # Audio dedupes per unique media file: 2 files -> 2 queue items.
+    assert len(queue) == 2
+
+
+def test_unsafe_object_id_is_refused_loudly(tmp_path):
+    publish = make_publish(tmp_path, base_media_bytes(), [("../evil", AUDIO_A[1])], [])
+    with pytest.raises(transcribe.TranscribeError):
+        transcribe.build_inventory(str(publish))
+
+
+# ---------------------------------------------------------------------------
+# Cache behavior (C2 / C3 + component matrix)
+
+
+def test_cache_hit_second_run_zero_asr_calls(tmp_path):
+    publish = make_publish(tmp_path, base_media_bytes(), [AUDIO_A, AUDIO_B], [])
+    out_dir = str(tmp_path / "out")
+    cache_dir = str(tmp_path / "cache")
+
+    runner1 = stub_runner()
+    report1 = transcribe.run_transcription(
+        str(publish), out_dir, cache_dir, runner=runner1
+    )
+    assert (
+        report1["transcribed"] == 2
+        and report1["cache_hits"] == 0
+        and report1["failures"] == 0
+    )
+    assert runner1.calls["calls"] == 2
+
+    runner2 = stub_runner()
+    report2 = transcribe.run_transcription(
+        str(publish), out_dir, cache_dir, runner=runner2
+    )
+    assert report2["cache_hits"] == 2 and report2["transcribed_fresh"] == 0
+    assert report2["transcribed"] == 2, "cache hits count as transcribed media"
+    assert runner2.calls["calls"] == 0, "second run must make zero ASR calls"
+    assert report2["failures"] == 0
+    # Output sidecars are regenerated from the cache.
+    assert os.path.isfile(os.path.join(out_dir, "audA_transcripts.js"))
+
+
+def test_content_change_invalidates_cache_key(tmp_path):
+    media = base_media_bytes()
+    publish = make_publish(tmp_path, media, [AUDIO_A], [])
+    cache_dir = str(tmp_path / "cache")
+    out_dir = str(tmp_path / "out")
+
+    runner1 = stub_runner()
+    transcribe.run_transcription(str(publish), out_dir, cache_dir, runner=runner1)
+    assert runner1.calls["calls"] == 1
+
+    # SAME filename, DIFFERENT bytes -> different content hash -> re-transcribe.
+    (publish / "story_content" / AUDIO_A[1]).write_bytes(b"\xff\xfb brand-new-bytes")
+    runner2 = stub_runner()
+    report2 = transcribe.run_transcription(
+        str(publish), out_dir, cache_dir, runner=runner2
+    )
+    assert runner2.calls["calls"] == 1, "changed content must trigger re-transcription"
+    assert report2["cache_hits"] == 0 and report2["transcribed_fresh"] == 1
+
+    # The cache composite key is content-derived: different media hashes yield
+    # different keys even when every other component matches.
+    assert transcribe.cache_composite(
+        "a" * 64, "m", "int8"
+    ) != transcribe.cache_composite("b" * 64, "m", "int8")
+
+
+def test_cache_key_component_matrix(tmp_path):
+    model = transcribe.resolve_model_id("distil-large-v3")
+    media = base_media_bytes()
+    publish = make_publish(tmp_path, media, [AUDIO_A], [])
+    cache_dir = str(tmp_path / "cache")
+    out_dir = str(tmp_path / "out")
+
+    runner = stub_runner()
+    transcribe.run_transcription(str(publish), out_dir, cache_dir, runner=runner)
+
+    sha = transcribe.sha256_file(str(publish / "story_content" / AUDIO_A[1]))
+    cues = [{"start_ms": 0, "text": "x"}]
+
+    # Hit: identical components.
+    assert transcribe.load_cues(cache_dir, sha, model, "int8") is not None
+    # Miss: different bytes under the same filename would produce a different
+    # media sha (C3); here we assert the other component axes.
+    assert (
+        transcribe.load_cues(cache_dir, "f" * 64, model, "int8") is None
+    ), "different bytes -> miss"
+    assert (
+        transcribe.load_cues(cache_dir, sha, "some/other-model", "int8") is None
+    ), "different model -> miss"
+    assert (
+        transcribe.load_cues(cache_dir, sha, model, "float16") is None
+    ), "different compute_type -> miss"
+    stale = {
+        "key": {
+            "format_version": transcribe.CACHE_FORMAT_VERSION + 1,
+            "media_sha256": sha,
+            "model": model,
+            "compute_type": "int8",
+        },
+        "cues": cues,
+    }
+    transcribe.atomic_write_json(
+        transcribe.cache_entry_path(cache_dir, sha, model, "int8"), stale
+    )
+    # format_version lives inside the composite key, so a v2 entry written at
+    # the v1 path still fails the stored-component comparison.
+    assert (
+        transcribe.load_cues(cache_dir, sha, model, "int8") is None
+    ), "format_version mismatch -> miss"
+
+
+def test_shared_file_two_object_ids_two_outputs_one_compute(tmp_path):
+    media = base_media_bytes()
+    publish = make_publish(
+        tmp_path, media, [("audX", AUDIO_A[1]), ("audY", AUDIO_A[1])], []
+    )
+    out_dir = str(tmp_path / "out")
+    cache_dir = str(tmp_path / "cache")
+
+    runner = stub_runner()
+    report = transcribe.run_transcription(
+        str(publish), out_dir, cache_dir, runner=runner
+    )
+    assert runner.calls["calls"] == 1, "one unique file -> one ASR call"
+    assert report["total"] == 1
+    entry = report["media"][0]
+    assert entry["object_ids"] == ["audX", "audY"]
+    assert os.path.isfile(os.path.join(out_dir, "audX_transcripts.js"))
+    assert os.path.isfile(os.path.join(out_dir, "audY_transcripts.js"))
+
+
+# ---------------------------------------------------------------------------
+# Idempotency at orchestration level (C7)
+
+
+def test_idempotent_double_run_zero_calls_second_run(tmp_path):
+    media = base_media_bytes()
+    publish = make_publish(
+        tmp_path,
+        media,
+        [AUDIO_A, AUDIO_B],
+        [("vidSide", AUDIO_B[1])],
+        sidecar_ids=("vidSide",),
+    )
+    out_dir = str(tmp_path / "out")
+    cache_dir = str(tmp_path / "cache")
+
+    runner1 = stub_runner()
+    report1 = transcribe.run_transcription(
+        str(publish), out_dir, cache_dir, runner=runner1
+    )
+    assert (
+        report1["total"] == 2
+    ), "sidecar-covered video must be excluded from the queue"
+    assert report1["failures"] == 0
+
+    runner2 = stub_runner()
+    report2 = transcribe.run_transcription(
+        str(publish), out_dir, cache_dir, runner=runner2
+    )
+    assert report2["cache_hits"] == report2["total"] == 2
+    assert report2["transcribed_fresh"] == 0
+    assert runner2.calls["calls"] == 0
+    assert report2["failures"] == 0
+
+
+def test_main_cli_double_run_via_stub_seam(tmp_path, monkeypatch):
+    media = base_media_bytes()
+    publish = make_publish(tmp_path, media, [AUDIO_A], [])
+    out_dir = str(tmp_path / "out")
+    cache_dir = str(tmp_path / "cache")
+    report_path = str(tmp_path / "report.json")
+
+    runner = stub_runner()
+    argv = [
+        "--publish",
+        str(publish),
+        "--out",
+        out_dir,
+        "--cache-dir",
+        cache_dir,
+        "--report",
+        report_path,
+    ]
+    monkeypatch.setattr(transcribe, "default_runner", runner)
+    assert transcribe.main(argv) == 0
+    assert transcribe.main(argv) == 0
+    assert runner.calls["calls"] == 1, "CLI double run: exactly one ASR call total"
+    report = json.load(open(report_path, encoding="utf-8"))
+    assert report["cache_hits"] == 1 and report["failures"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Report contract + error paths
+
+
+def test_report_shape_contract(tmp_path):
+    publish = make_publish(tmp_path, base_media_bytes(), [AUDIO_A], [])
+    runner = stub_runner()
+    report = transcribe.run_transcription(
+        str(publish), str(tmp_path / "out"), str(tmp_path / "cache"), runner=runner
+    )
+    for key in (
+        "total",
+        "media_count",
+        "transcribed",
+        "cache_hits",
+        "failures",
+        "media",
+    ):
+        assert key in report
+    assert report["total"] == report["media_count"] == 1
+    entry = report["media"][0]
+    assert entry["kind"] == "audio"
+    assert entry["url"].endswith(".mp3")
+    assert entry["status"] in ("transcribed", "cache_hit")
+    assert entry["error"] is None
+    assert len(entry["media_sha256"]) == 64
+
+
+def test_start_ms_int_math_from_runner():
+    runner = stub_runner(
+        outputs=[
+            {"cues": [{"start_ms": int(1.5 * 1000), "text": "a"}], "duration_ms": 1500}
+        ]
+    )
+    spec = transcribe.RunnerSpec(
+        model_id="m", compute_type="int8", language="en", cpu_threads=1
+    )
+    result = runner("ignored.mp3", spec)
+    cue = result["cues"][0]
+    assert cue["start_ms"] == 1500 and isinstance(cue["start_ms"], int)
+
+
+def test_missing_media_file_is_entry_error_not_crash(tmp_path):
+    media = base_media_bytes()
+    publish = make_publish(tmp_path, media, [AUDIO_A], [])
+    os.remove(publish / "story_content" / AUDIO_A[1])
+    runner = stub_runner()
+    report = transcribe.run_transcription(
+        str(publish), str(tmp_path / "out"), str(tmp_path / "cache"), runner=runner
+    )
+    assert report["failures"] == 1
+    assert report["media"][0]["status"] == "error"
+    assert "missing" in report["media"][0]["error"]
+    assert runner.calls["calls"] == 0
+
+
+def test_unresolvable_asset_is_entry_error(tmp_path):
+    publish = make_publish(
+        tmp_path, {}, [], [("vidNoAsset", "ghost.mp4")], asset_lib=True
+    )
+    runner = stub_runner()
+    report = transcribe.run_transcription(
+        str(publish), str(tmp_path / "out"), str(tmp_path / "cache"), runner=runner
+    )
+    assert report["failures"] == 1
+    assert report["media"][0]["status"] == "error"
+    assert "resolvable" in report["media"][0]["error"]
+
+
+def test_empty_publish_zero_media(tmp_path):
+    publish = make_publish(tmp_path, {}, [], [])
+    report = transcribe.run_transcription(
+        str(publish),
+        str(tmp_path / "out"),
+        str(tmp_path / "cache"),
+        runner=stub_runner(),
+    )
+    assert report["total"] == 0 and report["failures"] == 0
+
+
+def test_sidecar_covered_video_excluded_even_when_file_present(tmp_path):
+    media = base_media_bytes()
+    publish = make_publish(
+        tmp_path, media, [], [("vidCov", AUDIO_A[1])], sidecar_ids=("vidCov",)
+    )
+    runner = stub_runner()
+    report = transcribe.run_transcription(
+        str(publish), str(tmp_path / "out"), str(tmp_path / "cache"), runner=runner
+    )
+    assert report["total"] == 0 and runner.calls["calls"] == 0
+
+
+def test_no_audio_stream_media_transcribes_to_empty_cues(tmp_path):
+    """Real-corpus semantics (C1): 22 sidecar-less bumper MP4s carry NO audio
+    stream. faster-whisper's decoder raises on them; default_runner must probe
+    first and return an empty (honest) transcription. Requires av (bundled
+    with faster-whisper on build machines); skips where av is absent (CI)."""
+    av = pytest.importorskip("av")
+    media_path = str(tmp_path / "silent_bumper.mp4")
+    container = av.open(media_path, "w")
+    stream = container.add_stream("mpeg4", rate=8)
+    stream.width, stream.height = 64, 64
+    stream.pix_fmt = "yuv420p"
+    for _ in range(8):
+        frame = av.VideoFrame(width=64, height=64, format="yuv420p")
+        for packet in stream.encode(frame):
+            container.mux(packet)
+    for packet in stream.encode():
+        container.mux(packet)
+    container.close()
+
+    with av.open(media_path) as probe:
+        assert len(probe.streams.audio) == 0, "fixture must have no audio stream"
+
+    spec = transcribe.RunnerSpec(
+        model_id=transcribe.resolve_model_id("distil-large-v3"),
+        compute_type="int8",
+        language="en",
+        cpu_threads=1,
+    )
+    result = transcribe.default_runner(media_path, spec)
+    assert result["cues"] == []
+    assert result.get("note") == "no audio stream"


### PR DESCRIPTION
Closes #78

## Summary

D2 of Workstream D: a build-machine-only offline transcription step that recovers narration text for every audio/video asset in a Storyline publish that has no native caption/transcript sidecar, caches results by content hash, and feeds D1's per-slide document schema via `transcript_source`/`transcript_text` — with `transcript_source: "asr"` distinguishable from `"sidecar"`.

- **`packtool/storyline/transcribe.py` (new)** — Python CLI: inventories a publish's audio/video media objects (data.js `assetLib` + fully recursive slide-payload walk; audio objects live in layer `audiolib[]`, videos in layer `objects[]`), skips media already covered by a native `<objectId>_transcripts.js` sidecar, transcribes the rest with faster-whisper (**`distil-large-v3`**, `int8` CPU, language `en` — the named choice; audio decode via the FFmpeg libraries bundled with faster-whisper, so MP3s and MP4 audio tracks take one path with **no system ffmpeg**), caches by content hash, and writes one sidecar-format transcript per media OBJECT id.
- **Content-hash cache (issue-mandated key)** — `composite = "<format_version>|<sha256(media bytes)>|<model>|<compute_type>"`, entries at `<cache-dir>/transcripts/<sha256[:12]>/<sha256(composite)>.json` storing cues + key components; the loader compares stored components to the request and treats ANY mismatch as a miss, so a stale or mis-keyed entry can never be served. Re-runs over unchanged media make **zero ASR calls** (spy-asserted).
- **Output** — `<asrDir>/<objectId>_transcripts.js` in the SAME byte format as native sidecars (`const data = {...}; window.globalLoadJsAsset(...)`), cues `{"start_ms","text"}` plus `"source":"asr"` provenance — so `packtool/storyline/video-refs.ts` consumes ASR output through its **unchanged** decode path.
- **D1 consumer (opt-in)** — `packtool storyline extract <dir> --out <dir> --asr-dir <dir>` additionally resolves AUDIO objects and sidecar-less media from the store (`transcript_source: "asr"`, `narration_ref: "<id>_transcripts.js"`, ASR-store-relative and deliberately not in `source_files`). `TranscriptSource` gains `'asr'` in both `types.ts` and `video-refs.ts`. Without `--asr-dir`, extraction output is byte-identical to before (golden-pinned).
- **`docs/training-transcription.md` (new)** — model choice, **measured** full-corpus runtime, cache invalidation rule, build-machine-only statement, output/report contract, spot-check sample.

Verified against the real OpMed reference package: **300 MP3 assets + 37 sidecar-less video object ids = 337 media transcribed, 0 failures** (22 of the videos are silent bumpers with no audio stream — they honestly transcribe to empty cue lists with a `note`, rather than failing). The issue's "33 sidecar-less MP4s" was file-space arithmetic (57 files − 24 sidecars); the id-space census (61 distinct video object ids, 24 sidecar'd) refines the queue to 37 — the "every sidecar-less asset transcribed" invariant covers 37 ⊇ 33 with no gap (reconciled in the PR-attached run report and docs).

Measured full-corpus runtime on the reference build machine (32 threads, int8 distil-large-v3): **~34 minutes cold for 45.8 minutes of voiced audio; ~3 seconds warm (100% cache hits)**.

## Root Cause

Feature gap (Workstream D2 unimplemented at 27ec79b): no transcription producer existed (`grep -ri whisper` = 0 hits), `TranscriptSource` (`packtool/storyline/types.ts:8`) could not express ASR output, and `resolveVideoRefs` (`packtool/storyline/video-refs.ts`) walked only video objects and consulted only native sidecars — so the 300 sidecar-less MP3s (referenced by 418 audio objects on 361 slides via `assetId` → data.js `assetLib`) and the 37 sidecar-less video object ids had no path to transcript text. D1 had committed the placeholders: `narration_ref` documented as "D2-owned", `transcript_source: "missing"` as "D2's transcription queue".

## Fix

Minimal additive patch across the three seams (producer / schema / consumer), exactly as reviewed:

- `packtool/storyline/transcribe.py` (new): inventory + content-hash cache + lazy faster-whisper runner (DI `runner` seam keeps tests hermetic) + sidecar-format output + JSON report; per-entry error containment (one bad file never aborts the run); atomic writes (tmp + `os.replace`) for cache entries and outputs.
- `packtool/storyline/types.ts` + `packtool/storyline/video-refs.ts`: `'asr'` added to both unions in lockstep; `resolveVideoRefs(..., { asrDir? })` gates the audio walk on the overlay, defers the `videoIds.length === 0` early-return when the overlay is set, resolves sidecar > asr > missing, and keeps `narration_ref` for `asr` ASR-store-relative.
- `packtool/storyline/extract.ts` + `packtool/cli.ts`: optional `asrDir`/`--asr-dir` pass-through; default behavior untouched.
- `requirements.txt` is intentionally NOT touched: faster-whisper is a build-machine dependency (`pip install faster-whisper`, documented), keeping the runtime installer free of it.

## Recurrence Prevention (defect class)

- Defect class: media/cached-artifact identity keyed by FILENAME instead of content or a stable object identity (the exact churn the issue's cache-key rule targets — publish filenames embed sample-rate/index metadata that changes across re-publishes).
- Sweep result: 15 production sites dispositioned (10 content-hash sites, 4 sidecar-literal sites, 1 media-extension site) — 3 FIX (this change), 5 FALSE_POSITIVE (correct content keying: desktop ingest chunk ids per #69/#70, store-interop harness), 7 OUT_OF_CLASS (CSP pin, integrity digests, benchmark harness, path-addressed idempotent ingestion). No production site keys a content cache on a filename.
- Guardrail: loader-side key-component validation at cache-read time (runtime/trust-boundary rung; stronger rungs infeasible — a lint rule cannot express cross-run key equivalence, CI never runs the real corpus). Demonstrated to bite by mutation probes: neutralizing the component check flips the component-matrix test RED; removing the `asrDir` gate flips the AC4 no-overlay-neutrality case RED; both restore GREEN.

## Tests

- Acceptance driver suite (frozen red-checkpoint protocol; all RED→GREEN or GREEN→GREEN): C1 real-corpus coverage (337 media, 0 failures), C2 cache-hit call-count spy, C3 content-change invalidation, C4 D1-consumer integration, C5 runtime-surface isolation (PRESERVING), C6 docs deliverable, C7 idempotent double-run, C8 packtool golden suite (PRESERVING).
- New unit suite: `python -m pytest tests/test_storyline_transcribe.py` → **21 passed** (hermetic: faster_whisper import blocked during module import; stub runner DI; cache-key component matrix; decode parity vs the committed fixture; path-safety refusals; shared-file dedupe; no-audio-stream semantics via an av-encoded silent MP4; fatal-report-on-any-failure path).
- Impacted suite: `npm --prefix packtool test` → **9 files / 38 tests passed** (29 pre-existing byte-for-byte goldens + 9 AC4 cases, including the F6 two-priority regression).
- Build/lint/format: `npm --prefix packtool run build` (tsc) clean; `black`, `isort --profile black`, `flake8 --max-line-length=100` clean on both new Python files; deferred-work scan clean.
- Human spot-check sample (issue exit gate): 3 real cues across 3 distinct media, pairings verified against the run artifacts — see `docs/training-transcription.md` "Spot-check sample".

## Regression Protection

- Byte-for-byte golden fixtures pin default (no-overlay) extraction; the full packtool suite (29 pre-existing tests) stays green.
- Negative/boundary cases covered: unsafe media paths/object ids refused loudly; missing/corrupt media fail their own entry (exit 1) without aborting the run; cache entries from a different model/compute-type/format-version are misses; duplicate object ids dedupe; two object ids sharing one file produce one ASR call and two outputs; empty publish is a 0-media no-op.
- Test drift: no existing test modified or deleted (C8 pins this; additive growth 29 → 37).

## Acceptance Criteria -> Evidence

| Acceptance criterion (from intake) | Evidence (command + output, or test name) |
|---|---|
| AC1 — transcripts for every sidecar-less asset on the real package (300 MP3s + sidecar-less videos; issue's "33" refined to 37 by id space), counts report attached | C1: `media=337 audio=300 video=37 transcribed=337 failed=0` (`repro/C1.head.log`, `c1-report.json` snapshot summarized in the trace artifacts; census scripts `corpus-census.py` / `id-space-census.py`) |
| AC2 — cache hit on re-run, 0 ASR calls (spy-asserted) | C2 → `tests/test_storyline_transcribe.py::test_cache_hit_second_run_zero_asr_calls`; full-corpus warm re-run: 100% cache hits |
| AC3 — cache invalidates on content change (same filename, different bytes) | C3 → `::test_content_change_invalidates_cache_key` + `::test_cache_key_component_matrix` (hit + bytes/model/compute-type/format-version miss axes) |
| AC4 — output shape feeds D1 without an ad-hoc adapter; `asr` distinguishable | C4 → `packtool/storyline/__tests__/transcribe.ac4.test.ts` (8 cases through existing `decodeSidecarAsset`/`resolveVideoRefs` exports only) |
| AC5 — build-machine-only; no runtime import; documented | C5 driver: zero references in `web_ui/` + `desktop/`; `requirements.txt` untouched; `docs/training-transcription.md` "build-machine-only" statement |
| AC6 — docs: named model, measured full-corpus runtime, cache invalidation rule | C6 → `docs/training-transcription.md` (distil-large-v3; ~34 min cold / ~3 s warm measured; invalidation rule) |
| AC7 — idempotent re-run, zero new transcription calls | C7 → `::test_idempotent_double_run_zero_calls_second_run` + `::test_main_cli_double_run_via_stub_seam` |

## Invariant Audit

The repository documents no engineering-invariants file (no `docs/engineering-invariants.md`); per the default minimal set:

- build succeeds — `npm --prefix packtool run build` clean
- typecheck passes — tsc via the build; no separate typecheck target for packtool
- lint/formatter pass — flake8 + black + isort clean on new Python files (repo pre-commit contract)
- new/changed code tested — 20 pytest + 8 vitest cases, all passing; no existing test modified
- no generated/build artifacts staged — `packtool/dist/` is untracked/ignored; commit contains only source, tests, docs
- no secrets/credentials/PII in the diff — push-protection pattern scan clean; the corpus itself is never committed (fixture-only, per D1's licensing note)

## Risk and Rollback

- Risk level: low — additive only (1 new Python tool, 1 new vitest file, 1 new pytest module, 1 new doc, optional CLI flag/params); no runtime surface touched (C5); goldens byte-identical (C8); no dependency changes to the shipped app.
- Rollback: revert the commit. Cache/ASR output dirs are operator-local artifacts; no migrations, no config, no runtime coupling.

## Review round (post-publication)

The PR entered swarm review (REQUEST_CHANGES + Copilot "Changes recommended"). Three validated findings were fixed in the second commit: F6 (HIGH) — two-pass transcript resolution so a first-position silent bumper's empty ASR transcript can never shadow a later candidate's native sidecar (regression case (h) pins the exact corpus shape); F1 (MEDIUM) — the JSON report is now written on every fatal path (exit 1 preserved); F10/F11 (LOW) — `--asr-dir` with a missing value or a nonexistent directory now fails loudly (exit 2) instead of silently disabling the overlay. Fix gates: independent reviewer APPROVE (revert-to-prior-head proof the F6 bug existed; per-item APPROVE) and final critic APPROVE with Required Revisions NONE (independent e2e via the built CLI in the exact F6 shape). Advisory items were disposition-only; none deferred silently.

## Waivers (or none)

None — no Full-Resolution Contract clause waived. Note: the issue's "33 sidecar-less MP4s" arithmetic was refined to 37 by the id-space census (superset, no coverage gap) and the issue's "e.g. via ffmpeg" extraction is satisfied by faster-whisper's bundled FFmpeg (PyAV) decoder — both documented in `docs/training-transcription.md` and the trace, neither a waiver.

## Merge status

AWAITING_USER_APPROVAL — this skill never merges on its own authority; merge requires the separately recorded human approval bound to the head SHA below.

PR head: c611bb067637a5bb7ae77d04b6b5ffcaaee20961
